### PR TITLE
UADIGITAL-2203: Updated Drupal core to version 8.8.1 (security update).

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=7.0",
         "composer/installers": "1.7.0",
         "cweagans/composer-patches": "1.6.7",
-        "drupal/core-recommended": "8.8.0",
+        "drupal/core-recommended": "8.8.1",
         "drush/drush": "9.7.1",
         "drupal/bootstrap_barrio": "4.22"
     },


### PR DESCRIPTION
(For SA-CORE-2019-11 & SA-CORE-2019-12)