### PR TITLE
Closes #24 Update Drupal core-recommended version to 8.8.2 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=7.0",
         "composer/installers": "1.7.0",
         "cweagans/composer-patches": "1.6.7",
-        "drupal/core-recommended": "8.8.1",
+        "drupal/core-recommended": "8.8.2",
         "drush/drush": "9.7.1",
         "drupal/bootstrap_barrio": "4.22"
     },


### PR DESCRIPTION
Closes #24 by updating drupal/core-recommended to 8.8.2 in composer.json.