### PR TITLE
closes #28 - use !== instead of !=

### DIFF
--- a/modules/custom/az_core/src/Form/QuickstartCoreSettingsForm.php
+++ b/modules/custom/az_core/src/Form/QuickstartCoreSettingsForm.php
@@ -145,7 +145,7 @@ class QuickstartCoreSettingsForm extends ConfigFormBase {
       }
 
       $path = strtolower(trim(trim($submitted_value), " \\/"));
-      if (!empty($path) && $submitted_value != $element['#default_value']) {
+      if (!empty($path) && $submitted_value !== $element['#default_value']) {
         if ($this->routeProvider->getRoutesByPattern($path)->count()) {
           $form_state->setError($element, t('The path is already in use.'));
         }


### PR DESCRIPTION
Don't use operators that convert type unless absolutely needed

## Description
PHP likes to do some weird type conversions with `==`, `!=`, and `<>`. These can be dangerous so we shouldn't use these operators unless there's a good justification and some additional verification going on. See the example below:
```
php > var_dump('0 cats' != 0);
bool(false)
php > var_dump('0 cats' !== 0);
bool(true)
```

## Related Issue
https://www.netsparker.com/blog/web-security/type-juggling-authentication-bypass-cms-made-simple/
https://github.com/FloeDesignTechnologies/phpcs-security-audit/pull/53