### PR TITLE
#45: Workaround for Display Suite deprecation notices.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "drush/drush": "9.7.1",
         "drupal/background_image_formatter": "1.4",
         "drupal/bootstrap_barrio": "4.22",
-        "drupal/ds": "3.5",
+        "drupal/ds": "3.x-dev#f73614254bb7baa311b99886b0393e2ab738d5f7",
         "drupal/field_group": "3.0",
         "drupal/layout_builder_restrictions": "2.5",
         "drupal/layout_builder_styles": "1.0-beta1"
@@ -38,7 +38,8 @@
               "missing theme config schema": "https://www.drupal.org/files/issues/2019-11-15/improve-theme-settings-remove-deprecated-code-3037780-22.patch"
           },
           "drupal/ds": {
-              "D9 deprecation fixes": "https://www.drupal.org/files/issues/2020-02-07/ds-deprecated-code-3110306-2.patch"
+              "D9 deprecation fixes": "https://www.drupal.org/files/issues/2020-02-07/ds-deprecated-code-3110306-2.patch",
+              "Remove drush plugin": "https://git.drupalcode.org/project/ds/commit/c8db6ed6f5f2a543f9fe50d440a5dd94a1f13fae.diff"
           },
           "drupal/layout_builder_styles": {
               "D9 deprecation fixes": "https://www.drupal.org/files/issues/2019-11-06/deprecated-3092650-2.patch",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This should resolve the remaining deprecation notices generated by the Display Suite module.  This pins Display Suite to the dev revision associated with the most recent recommended release (8.x-3.5) because the composer patches plugin was only able to apply the existing patch using `git apply` (because the patch includes binary file changes) and, at least using the latest release of composer-patches, the only way to enforce that `git apply` is used was to change Display Suite to  use a dev version.

## Related Issue
#39, #45 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
