### PR TITLE
Closes #67 by updating barrio to 8.x-4.23 & remove patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "drupal/core-recommended": "8.8.4",
         "drush/drush": "9.7.1",
         "drupal/background_image_formatter": "1.4",
-        "drupal/bootstrap_barrio": "^4.23",
+        "drupal/bootstrap_barrio": "4.23",
         "drupal/ds": "3.x-dev#f73614254bb7baa311b99886b0393e2ab738d5f7",
         "drupal/field_group": "3.0",
         "drupal/layout_builder_restrictions": "2.5",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "drupal/core-recommended": "8.8.4",
         "drush/drush": "9.7.1",
         "drupal/background_image_formatter": "1.4",
-        "drupal/bootstrap_barrio": "4.22",
+        "drupal/bootstrap_barrio": "^4.23",
         "drupal/ds": "3.x-dev#f73614254bb7baa311b99886b0393e2ab738d5f7",
         "drupal/field_group": "3.0",
         "drupal/layout_builder_restrictions": "2.5",
@@ -34,9 +34,6 @@
     },
     "extra": {
       "patches": {
-          "drupal/bootstrap_barrio": {
-              "missing theme config schema": "https://www.drupal.org/files/issues/2019-11-15/improve-theme-settings-remove-deprecated-code-3037780-22.patch"
-          },
           "drupal/ds": {
               "D9 deprecation fixes": "https://www.drupal.org/files/issues/2020-02-07/ds-deprecated-code-3110306-2.patch",
               "Remove drush plugin": "https://git.drupalcode.org/project/ds/commit/c8db6ed6f5f2a543f9fe50d440a5dd94a1f13fae.diff"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
updates composer.json to "drupal/bootstrap_barrio": "4.23" and removes `missing theme config schema` patch.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Steps I took:

- lando composer require 'drupal/bootstrap_barrio:^4.23'
- manually deleted the patch from composer.json
- lando rebuild, install, start
- ensured all looked as expected (including under admin/appearance)
- confirmed the contents from [the patch](https://www.drupal.org/files/issues/2018-12-16/missing-config-schema-3017668-6.patch) are included in [this new version](https://git.drupalcode.org/project/bootstrap_barrio/-/blob/8.x-4.x/config/schema/bootstrap_barrio.schema.yml)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
