### PR TITLE
Fixes #160: Added custom az_cas setting for disabling password reset form.

### DIFF
--- a/modules/custom/az_cas/az_cas.links.task.yml
+++ b/modules/custom/az_cas/az_cas.links.task.yml
@@ -1,0 +1,5 @@
+az_cas.az_cas_settings_tab:
+  route_name: az_cas.settings
+  title: 'AZ CAS'
+  base_route: az_core.az_settings
+  weight: 0

--- a/modules/custom/az_cas/az_cas.routing.yml
+++ b/modules/custom/az_cas/az_cas.routing.yml
@@ -1,0 +1,7 @@
+az_cas.settings:
+  path: '/admin/config/az-quickstart/settings/az-cas'
+  defaults:
+    _form: '\Drupal\az_cas\Form\AzCasSettingsForm'
+    _title: 'AZ CAS Settings'
+  requirements:
+    _permission: 'administer account settings'

--- a/modules/custom/az_cas/az_cas.services.yml
+++ b/modules/custom/az_cas/az_cas.services.yml
@@ -1,0 +1,6 @@
+services:
+  az_cas.prevent_password_reset_subscriber:
+    class: Drupal\az_cas\Subscriber\PreventPasswordResetSubscriber
+    arguments: ['@config.factory']
+    tags:
+      - { name: 'event_subscriber' }

--- a/modules/custom/az_cas/config/install/az_cas.settings.yml
+++ b/modules/custom/az_cas/config/install/az_cas.settings.yml
@@ -1,0 +1,1 @@
+disable_password_recovery_link: true

--- a/modules/custom/az_cas/config/schema/az_cas.schema.yml
+++ b/modules/custom/az_cas/config/schema/az_cas.schema.yml
@@ -1,0 +1,7 @@
+az_cas.settings:
+  type: config_object
+  label: 'AZ CAS settings'
+  mapping:
+    disable_password_recovery_link:
+      type: boolean
+      label: 'Disable password recovery link'

--- a/modules/custom/az_cas/src/Form/AzCasSettingsForm.php
+++ b/modules/custom/az_cas/src/Form/AzCasSettingsForm.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\az_cas\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteBuilderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class AzCasSettingsForm.
+ */
+class AzCasSettingsForm extends ConfigFormBase {
+
+  /**
+   * The route builder.
+   *
+   * @var \Drupal\Core\Routing\RouteBuilderInterface
+   */
+  protected $routeBuilder;
+
+  /**
+   * Constructs a AzCasSettingsForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Routing\RouteBuilderInterface $route_builder
+   *   The route builder.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, RouteBuilderInterface $route_builder) {
+    parent::__construct($config_factory);
+
+    $this->routeBuilder = $route_builder;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('router.builder')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'az_cas_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['az_cas.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $az_cas_config = $this->config('az_cas.settings');
+
+    $form['disable_password_recovery_link'] = [
+      '#title' => t("Disable 'request new password' form"),
+      '#type' => 'checkbox',
+      '#description' => t("Disables the default password recovery functionality provided by Drupal core."),
+      '#default_value' => $az_cas_config->get('disable_password_recovery_link'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('az_cas.settings')
+      ->set('disable_password_recovery_link', $form_state->getValue('disable_password_recovery_link'))
+      ->save();
+
+    $this->routeBuilder->setRebuildNeeded();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/custom/az_cas/src/Subscriber/PreventPasswordResetSubscriber.php
+++ b/modules/custom/az_cas/src/Subscriber/PreventPasswordResetSubscriber.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\az_cas\Subscriber;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Routing\RouteBuildEvent;
+use Drupal\Core\Routing\RoutingEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Provides a PreventPasswordResetSubscriber.
+ */
+class PreventPasswordResetSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs the object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[RoutingEvents::ALTER][] = ['alter', 0];
+    return $events;
+  }
+
+  /**
+   * Alter the user password reset route to prevent access.
+   *
+   * @param \Drupal\Core\Routing\RouteBuildEvent $event
+   *   The routing event.
+   */
+  public function alter(RouteBuildEvent $event) {
+    if ($this->configFactory->get('az_cas.settings')->get('disable_password_recovery_link')) {
+      $route_collection = $event->getRouteCollection();
+      $route_collection->get('user.pass')->setRequirement('_access', 'FALSE');
+    }
+  }
+
+}

--- a/modules/custom/az_cas/tests/src/Functional/AzCasAdminSettingsTest.php
+++ b/modules/custom/az_cas/tests/src/Functional/AzCasAdminSettingsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\Tests\az_cas\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests AZ CAS admin settings form.
+ *
+ * @group az_cas
+ */
+class AzCasAdminSettingsTest extends BrowserTestBase {
+
+  /**
+   * The profile to install as a basis for testing.
+   *
+   * @var string
+   */
+  protected $profile = 'az_quickstart';
+
+  /**
+   * Disable strict schema cheking.
+   *
+   * @var bool
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * The default theme to use for testing.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'seven';
+
+  /**
+   * The admin user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->adminUser = $this->drupalCreateUser(['administer account settings']);
+    $this->drupalLogin($this->adminUser);
+  }
+
+  /**
+   * Tests that access to the password reset form is disabled.
+   *
+   * @dataProvider disablePasswordRecoveryLinkProvider
+   */
+  public function testPasswordResetBehavior($disable_password_recovery_link) {
+    $edit = [
+      'disable_password_recovery_link' => $disable_password_recovery_link,
+    ];
+    $this->drupalPostForm('/admin/config/az-quickstart/settings/az-cas', $edit, 'Save configuration');
+
+    // The menu router info needs to be rebuilt after saving this form so the
+    // CAS menu alter runs again.
+    $this->container->get('router.builder')->rebuild();
+
+    $this->drupalLogout();
+    $this->drupalGet('user/password');
+    if ($disable_password_recovery_link) {
+      $this->assertSession()->pageTextContains(t('Access denied'));
+      $this->assertSession()->pageTextNotContains(t('Reset your password'));
+    }
+    else {
+      $this->assertSession()->pageTextNotContains(t('Access denied'));
+      $this->assertSession()->pageTextContains(t('Reset your password'));
+    }
+  }
+
+  /**
+   * Data provider for testPasswordResetBehavior.
+   */
+  public function disablePasswordRecoveryLinkProvider() {
+    return [[FALSE], [TRUE]];
+  }
+
+}

--- a/modules/custom/az_core/az_core.links.task.yml
+++ b/modules/custom/az_core/az_core.links.task.yml
@@ -1,5 +1,5 @@
 az_core.az_settings_az_tab:
-  route_name: az_core.az_quickstart
+  route_name: az_core.az_settings
   title: 'Quickstart Core'
-  base_route: az_core.az_quickstart
+  base_route: az_core.az_settings
   weight: -10


### PR DESCRIPTION
## Description

- Adds custom az_cas module setting for disabling user password reset link/form/route provided by core
- Adds AZ CAS settings form (attached to AZ Core settings form as local task/tab)
- Adds RouteSubscriber class/service to alter core `user.pass` route when custom setting is enabled
- Adds AzCasAdminSettings functional test for testing custom setting
- Fixes existing `Quickstart Core` local task (tab) to be displayed in the correct location

## Related Issue
#160 

## How Has This Been Tested?
Tested locally using lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
