### PR TITLE
Fixes #162, Fixes #159: Added permission for administering Quickstart settings & added additional test users to ProboCI sites.

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -41,11 +41,11 @@ steps:
   - name: Add Test User Accounts
     plugin: Script
     script:
-      - drush user:create azcontenteditor --password="probo"
-      - drush user:role:add az_content_editor azcontenteditor
-      - drush user:create azcontentadmin --password="probo"
-      - drush user:role:add az_content_editor azcontentadmin
-      - drush user:role:add az_content_admin azcontentadmin
+      - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush user:create azcontenteditor --password="probo"
+      - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush user:role:add az_content_editor azcontenteditor
+      - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush user:create azcontentadmin --password="probo"
+      - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush user:role:add az_content_editor azcontentadmin
+      - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush user:role:add az_content_admin azcontentadmin
   - name: Run PHPUnit Tests
     plugin: Script
     script:

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -38,6 +38,14 @@ steps:
     runInstall: true
     profileName: az_quickstart
     installArgs: "--site-name='Quickstart Review' --account-name=azadmin --account-pass=probo --verbose"
+  - name: Add Test User Accounts
+    plugin: Script
+    script:
+      - drush user:create azcontenteditor --password="probo"
+      - drush user:role:add az_content_editor azcontenteditor
+      - drush user:create azcontentadmin --password="probo"
+      - drush user:role:add az_content_editor azcontentadmin
+      - drush user:role:add az_content_admin azcontentadmin
   - name: Run PHPUnit Tests
     plugin: Script
     script:

--- a/config/install/user.role.az_content_admin.yml
+++ b/config/install/user.role.az_content_admin.yml
@@ -10,6 +10,7 @@ permissions:
   - 'access taxonomy overview'
   - 'administer book outlines'
   - 'administer nodes'
+  - 'administer quickstart configuration'
   - 'administer taxonomy'
   - 'bypass node access'
   - 'create content translations'

--- a/modules/custom/az_core/az_core.permissions.yml
+++ b/modules/custom/az_core/az_core.permissions.yml
@@ -1,0 +1,4 @@
+administer quickstart configuration:
+  title: 'Administer Quickstart configuration'
+  description: 'Administer Quickstart settings for AZQS modules.'
+  restrict access: FALSE

--- a/modules/custom/az_core/az_core.routing.yml
+++ b/modules/custom/az_core/az_core.routing.yml
@@ -4,7 +4,7 @@ az_core.az_quickstart:
     _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
     _title: 'Arizona Quickstart'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'administer quickstart configuration'
 
 az_core.az_settings:
   path: '/admin/config/az-quickstart/settings'
@@ -12,7 +12,7 @@ az_core.az_settings:
     _form: '\Drupal\az_core\Form\QuickstartCoreSettingsForm'
     _title: 'Arizona Quickstart Settings'
   requirements:
-    _permission: 'access administration pages'
+    _permission: 'administer quickstart configuration'
 
 route_callbacks:
   - '\Drupal\az_core\Routing\Routes::routes'

--- a/modules/custom/az_core/tests/src/Functional/ClearCacheTest.php
+++ b/modules/custom/az_core/tests/src/Functional/ClearCacheTest.php
@@ -33,7 +33,7 @@ class ClearCacheTest extends BrowserTestBase {
    * Tests the clear cache button on the Quickstart settings page.
    */
   public function testClearCache() {
-    $user = $this->drupalCreateUser(['access administration pages']);
+    $user = $this->drupalCreateUser(['administer quickstart configuration']);
     $this->drupalLogin($user);
     $assert = $this->assertSession();
     $this->drupalGet(Url::fromRoute('az_core.az_settings'));

--- a/modules/custom/az_core/tests/src/Functional/MonitoringPageTest.php
+++ b/modules/custom/az_core/tests/src/Functional/MonitoringPageTest.php
@@ -33,7 +33,7 @@ class MonitoringPageTest extends BrowserTestBase {
    * Tests the monitoring page functionality.
    */
   public function testMonitoringPage() {
-    $user = $this->drupalCreateUser(['administer site configuration', 'access administration pages']);
+    $user = $this->drupalCreateUser(['administer site configuration', 'administer quickstart configuration']);
     $this->drupalLogin($user);
     $assert = $this->assertSession();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
- Adds `administer quickstart configuration` permission to az_core
- Adds `administer quickstart configuration` to default permissions for `az_content_admin` role
- Updates existing az_core routes to use new permission
- Updates existing az_core tests to use new permission
- Adds ProboCI step to create test users with custom roles

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#162 #159 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with lando:
- composer install
- phpcs
- drupal-check
- phpunit
- manual functional testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have ~added~updated tests to cover my changes.
- [x] All new and existing tests passed.
