### PR TITLE
Fixes #167 Add default configuration for main menu block

### DIFF
--- a/config/install/block.block.az_barrio_main_menu.yml
+++ b/config/install/block.block.az_barrio_main_menu.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.main
+  module:
+    - system
+  theme:
+    - az_barrio
+id: az_barrio_main_menu
+theme: az_barrio
+region: navigation
+weight: 0
+provider: null
+plugin: 'system_menu_block:main'
+settings:
+  id: 'system_menu_block:main'
+  label: 'Main navigation'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 2
+  expand_all_items: false
+visibility: {  }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pull request adds a configuration entity for the placement of the main menu block in the barrio theme. The present default depth values for the block do not allow for dropdowns to be rendered, as they are of a depth that is trimmed from the markup by the default depth value.

## Description
This adds YAML configuration for the main menu block that contains the default values with the exception of updating **Number of levels to display** from 1 to 2. This allows dropdowns for the main menu nav to actually appear in the markup.

## Related Issue
#167 

## How Has This Been Tested?
Tested locally by visiting `/admin/structure/block/manage/az_barrio_main_menu` after installation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
