### PR TITLE
Fixes #170 Provide appropriate value for Navbar width container configuration.

### DIFF
--- a/themes/custom/az_barrio/config/install/az_barrio.settings.yml
+++ b/themes/custom/az_barrio/config/install/az_barrio.settings.yml
@@ -34,7 +34,7 @@ bootstrap_barrio_button_outline: 0
 # Navbar
 # --------------
 bootstrap_barrio_navbar_toggle: 1
-bootstrap_barrio_navbar_container: 'navbar-toggleable-md'
+bootstrap_barrio_navbar_container: true
 bootstrap_barrio_navbar_top_position: ''
 bootstrap_barrio_navbar_top_color: 'navbar-light'
 bootstrap_barrio_navbar_position: ''


### PR DESCRIPTION
A variable in the `az_barrio` settings that is intended for boolean usage was currently set to a string value, causing some Form API issues.

## Description
A configuration setting for `bootstrap_barrio_navbar_container` is intended for boolean usage as the value of a checkbox, but is currently set to a default value of `'navbar-toggleable-md'`. This gets evaluated as true, but causes the Form API to discard that value the first time the theme settings form is saved, which breaks the site menu.

## Related Issue
#170 

## How Has This Been Tested?
Ensure that after site installation, the theme setting for `Components > Navbar > Navbar width container` is checked.

## Types of changes
Configuration updates.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
