### PR TITLE
Fixes #179 Update DS commit hash

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "drupal/cas": "1.6.0",
         "drupal/core-recommended": "8.8.5",
         "drush/drush": "9.7.1",
-        "drupal/ds": "3.x-dev#f73614254bb7baa311b99886b0393e2ab738d5f7",
+        "drupal/ds": "3.x-dev#170540060a644102ab3524cd1d31de408d492186",
         "drupal/externalauth": "1.2.0",
         "drupal/field_group": "3.0",
         "drupal/layout_builder_restrictions": "2.5",
@@ -46,7 +46,6 @@
                 "ajax css load order issue": "https://www.drupal.org/files/issues/2020-02-12/1461322-20.patch"
             },
             "drupal/ds": {
-                "D9 deprecation fixes": "https://www.drupal.org/files/issues/2020-02-07/ds-deprecated-code-3110306-2.patch",
                 "Remove drush plugin": "https://git.drupalcode.org/project/ds/commit/c8db6ed6f5f2a543f9fe50d440a5dd94a1f13fae.diff"
             },
             "drupal/layout_builder_styles": {


### PR DESCRIPTION


## Description
This morning the composer build process of the profile broke due to the dev version of display suite having been updated to a version that includes a patch we were previously using and the patch consequently failing. Due to the commit referencing feature of composer being fairly bug prone, it's no longer requesting our specified commit hash. I've attempted to fix this by removing the patch in question and updating to a commit hash that included it.

## Related Issue
#179 

## How Has This Been Tested?
Locally. Review of display suite components is needed as this brings in several new display suite commits.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
