### PR TITLE
Fixes #171 Resolve Duplicate Drupal Messages

### DIFF
--- a/themes/custom/az_barrio/config/install/az_barrio.settings.yml
+++ b/themes/custom/az_barrio/config/install/az_barrio.settings.yml
@@ -40,6 +40,10 @@ bootstrap_barrio_navbar_top_color: 'navbar-light'
 bootstrap_barrio_navbar_position: ''
 bootstrap_barrio_navbar_color: 'navbar-light'
 
+# Messages.
+# ----------------------------
+bootstrap_barrio_messages_widget: 'default'
+
 # Colors
 # --------------
 bootstrap_barrio_table_hover: 1

--- a/themes/custom/az_barrio/templates/page.html.twig
+++ b/themes/custom/az_barrio/templates/page.html.twig
@@ -153,15 +153,6 @@
             {{ page.content_featured }}
           </section>
           {% endif %}
-          {% if page.highlighted %}
-          <div class="{{ container }}">
-            <div class="row">
-              <div class="col">
-              {{ page.highlighted }}
-              </div>
-            </div>
-          </div>
-          {% endif %}
           {% if page.breadcrumb or page.content_top %}
           <div class="{{ container }}">
             <div class="row">


### PR DESCRIPTION
This pull request resolves the duplicate messages that are presently being rendered by `az_barrio`.

## Description
The twig template that az_barrio renders its blocks from has apparently always been double rendering the messages, but due to the functionality where messages were displayed via JS in the screen corner as toasts, this issue was being masked. It's not necessary to print the messages in the subtheme as they're rendered in the surrounding markup of the parent theme: 

```
    {% if page.highlighted %}
      <div class="highlighted">
        <aside class="{{ container }} section clearfix" role="complementary">
          {{ page.highlighted }}
        </aside>
      </div>
    {% endif %}
```
This isn't readily overridden in the subtheme as this takes place 'between' the blocks that the subtheme is responsible for rendering due to barrio's twig inheritance design. As such, it's not necessary to render these in the subtheme.

I have also added a default setting for the barrio message style, to reflect the new alert style configuration that was added to barrio in a recent version, [8.x-4.23](https://www.drupal.org/project/bootstrap_barrio/releases/8.x-4.23)

The chosen alert style (alerts classic) is the setting form default, but I am setting it in the configuration for purposes of documentation and being explicit. Alerts classic causes the messages to be rendered on the page above the content rather than the screen corner, and is the option that most resembles `ua_zen`'s messages. 

## Related Issue
#171 

## How Has This Been Tested?
Verify locally or via probo to determine that messages are only being rendered once.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
