### PR TITLE
Fixes #183 Update CDN Link to Github-based CDN

### DIFF
--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -179,7 +179,7 @@ function az_barrio_az_bootstrap_assets_path($type) {
     if ($az_bootstrap_cdn_version == 'stable') {
       $az_bootstrap_cdn_version = AZ_BOOTSTRAP_STABLE_VERSION;
     }
-    $az_bootstrap_path = 'https://cdn.uadigital.arizona.edu/lib/arizona-bootstrap/' . $az_bootstrap_cdn_version;
+    $az_bootstrap_path = 'https://cdn.digital.arizona.edu/lib/arizona-bootstrap/' . $az_bootstrap_cdn_version;
   }
   else {
     $az_bootstrap_path = 'libraries/arizona-bootstrap';

--- a/themes/custom/az_barrio/includes/common.inc
+++ b/themes/custom/az_barrio/includes/common.inc
@@ -7,7 +7,7 @@
  * Contains common functionality for the entire theme.
  */
 
-define('AZ_BOOTSTRAP_STABLE_VERSION', 'latest');
+define('AZ_BOOTSTRAP_STABLE_VERSION', 'master');
 define('AZ_BRAND_ICONS_STABLE_VERSION', 'v1.1.0');
 
 

--- a/themes/custom/az_barrio/includes/common.inc
+++ b/themes/custom/az_barrio/includes/common.inc
@@ -7,7 +7,7 @@
  * Contains common functionality for the entire theme.
  */
 
-define('AZ_BOOTSTRAP_STABLE_VERSION', 'master');
+define('AZ_BOOTSTRAP_STABLE_VERSION', 'latest');
 define('AZ_BRAND_ICONS_STABLE_VERSION', 'v1.1.0');
 
 


### PR DESCRIPTION
The following PR updates the URL being used for fetching the CDN resources for az barrio.

## Description
The helper function `az_barrio_az_bootstrap_assets_path` has been updated to point to the correct link. 

References to loaded css assets from the previous cdn will still be seen in browser network activity, but this appears to be due to loading of milo from the old cdn. Bootstrap itself should be coming from the new cdn.

## Related Issue
#183

## How Has This Been Tested?
locally. Turn off CSS aggregation, and then verify that the CSS files being loaded are coming from [https://cdn.digital.arizona.edu/lib/arizona-bootstrap/](https://cdn.digital.arizona.edu/lib/arizona-bootstrap/)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
