### PR TITLE
Build assets and publish to github release

### DIFF
--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -23,7 +23,7 @@ jobs:
           composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
           composer config use-github-api false
           composer require --no-update az-digital/az_quickstart:${AZ_TRIMMED_REF}
-          composer install -o
+          composer install --no-dev -o
       - name: Zip Assets
         run: |
           zip -r -x\*.git* az_quickstart.zip az-quickstart-scaffolding

--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -15,7 +15,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Build project # This would actually build your project, using zip for an example artifact
         run: |
-          composer self-update
           composer global require hirak/prestissimo
           git clone https://github.com/az-digital/az-quickstart-scaffolding.git
           cd az-quickstart-scaffolding

--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -1,0 +1,57 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+name: Upload Release Asset
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build project # This would actually build your project, using zip for an example artifact
+        run: |
+          composer self-update
+          composer global require hirak/prestissimo
+          git clone https://github.com/az-digital/az-quickstart-scaffolding.git
+          cd az-quickstart-scaffolding
+          composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
+          composer config use-github-api false
+          composer require --no-update az-digital/az_quickstart:${{ github.ref }}
+          composer install -o
+          zip azqs.zip *
+          tar zcf azqs.tar.gz *
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Zip Assets
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./azqs.zip
+          asset_name: azqs.zip
+          asset_content_type: application/zip
+      - name: Upload Tar Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./azqs.tar.gz
+          asset_name: azqs.tar.gz
+          asset_content_type: application/x-gzip

--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -36,7 +36,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Upload Zip Assets
-        id: upload-release-asset
+        id: upload-zip-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
           asset_name: azqs.zip
           asset_content_type: application/zip
       - name: Upload Tar Asset
-        id: upload-release-asset
+        id: upload-tar-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -24,7 +24,7 @@ jobs:
           composer config use-github-api false
           composer require --no-update az-digital/az_quickstart:${AZ_TRIMMED_REF}
           composer install -o
-          zip azqs.zip *
+          zip -r azqs.zip *
           tar zcf azqs.tar.gz *
       - name: Create Release
         id: create_release

--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -26,7 +26,7 @@ jobs:
           composer install --no-dev -o
       - name: Zip Assets
         run: |
-          zip -r -x '*.git*' az_quickstart.zip az_quickstart
+          zip -r -x\*.git* az_quickstart.zip az_quickstart
       - name: Tar Assets
         run: |
           tar --exclude '*.git*' -c -z -f az_quickstart.tar.gz az_quickstart

--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -24,8 +24,12 @@ jobs:
           composer config use-github-api false
           composer require --no-update az-digital/az_quickstart:${AZ_TRIMMED_REF}
           composer install -o
-          zip -r -x\*.git* "az_quickstart-${AZ_TRIMMED_REF}.zip" *
-          tar --exclude .gitignore --exclude .git -c -z -f "az_quickstart-${AZ_TRIMMED_REF}.tar.gz" *
+      - name: Zip Assets
+        run: |
+          zip -r -x\*.git* az_quickstart.zip az-quickstart-scaffolding
+      - name: Tar Assets
+        run: |
+          tar --exclude .gitignore --exclude .git -c -z -f az_quickstart.tar.gz az-quickstart-scaffolding
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -43,8 +47,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./az_quickstart-${AZ_TRIMMED_REF}.zip
-          asset_name: az_quickstart-${AZ_TRIMMED_REF}.zip
+          asset_path: ./az_quickstart.zip
+          asset_name: az_quickstart.zip
           asset_content_type: application/zip
       - name: Upload Tar Asset
         id: upload-tar-asset
@@ -53,6 +57,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./az_quickstart-${AZ_TRIMMED_REF}.tar.gz
-          asset_name: az_quickstart-${AZ_TRIMMED_REF}.tar.gz
+          asset_path: ./az_quickstart.tar.gz
+          asset_name: az_quickstart.tar.gz
           asset_content_type: application/x-gzip

--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -18,18 +18,18 @@ jobs:
       - name: Build project # This would actually build your project, using zip for an example artifact
         run: |
           composer global require hirak/prestissimo
-          git clone https://github.com/az-digital/az-quickstart-scaffolding.git
-          cd az-quickstart-scaffolding
+          git clone https://github.com/az-digital/az-quickstart-scaffolding.git az_quickstart
+          cd az_quickstart
           composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
           composer config use-github-api false
           composer require --no-update az-digital/az_quickstart:${AZ_TRIMMED_REF}
           composer install --no-dev -o
       - name: Zip Assets
         run: |
-          zip -r -x\*.git* az_quickstart.zip az-quickstart-scaffolding
+          zip -r -x\*.git* az_quickstart.zip az_quickstart
       - name: Tar Assets
         run: |
-          tar --exclude .gitignore --exclude .git -c -z -f az_quickstart.tar.gz az-quickstart-scaffolding
+          tar --exclude .gitignore --exclude .git -c -z -f az_quickstart.tar.gz az_quickstart
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -9,7 +9,7 @@ name: Upload Release Asset
 jobs:
   build:
     name: Upload Release Asset
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -26,10 +26,10 @@ jobs:
           composer install --no-dev -o
       - name: Zip Assets
         run: |
-          zip -r -x\*.git* az_quickstart.zip az_quickstart
+          zip -r -x '*.git*' az_quickstart.zip az_quickstart
       - name: Tar Assets
         run: |
-          tar --exclude .gitignore --exclude .git -c -z -f az_quickstart.tar.gz az_quickstart
+          tar --exclude '*.git*' -c -z -f az_quickstart.tar.gz az_quickstart
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -24,8 +24,8 @@ jobs:
           composer config use-github-api false
           composer require --no-update az-digital/az_quickstart:${AZ_TRIMMED_REF}
           composer install -o
-          zip -r azqs.zip *
-          tar zcf azqs.tar.gz *
+          zip -r -x\*.git* "az_quickstart-${AZ_TRIMMED_REF}.zip" *
+          tar --exclude .gitignore --exclude .git -c -z -f "az_quickstart-${AZ_TRIMMED_REF}.tar.gz" *
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -43,8 +43,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./azqs.zip
-          asset_name: azqs.zip
+          asset_path: ./az_quickstart-${AZ_TRIMMED_REF}.zip
+          asset_name: az_quickstart-${AZ_TRIMMED_REF}.zip
           asset_content_type: application/zip
       - name: Upload Tar Asset
         id: upload-tar-asset
@@ -53,6 +53,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./azqs.tar.gz
-          asset_name: azqs.tar.gz
+          asset_path: ./az_quickstart-${AZ_TRIMMED_REF}.tar.gz
+          asset_name: az_quickstart-${AZ_TRIMMED_REF}.tar.gz
           asset_content_type: application/x-gzip

--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Build Variables
+        run: echo "::set-env - name=AZ_TRIMMED_REF::${GITHUB_REF#refs/*/}"
       - name: Build project # This would actually build your project, using zip for an example artifact
         run: |
           composer global require hirak/prestissimo
@@ -20,7 +22,7 @@ jobs:
           cd az-quickstart-scaffolding
           composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
           composer config use-github-api false
-          composer require --no-update az-digital/az_quickstart:${{ github.ref }}
+          composer require --no-update az-digital/az_quickstart:${AZ_TRIMMED_REF}
           composer install -o
           zip azqs.zip *
           tar zcf azqs.tar.gz *

--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Build Variables
-        run: echo "::set-env - name=AZ_TRIMMED_REF::${GITHUB_REF#refs/*/}"
+        run: echo "::set-env name=AZ_TRIMMED_REF::${GITHUB_REF#refs/*/}"
       - name: Build project # This would actually build your project, using zip for an example artifact
         run: |
           composer global require hirak/prestissimo


### PR DESCRIPTION
## Description
This update will build az_quickstart using az-quickstart-scaffolding, create zip and tar archives, create a github release based on the incoming tag, then push the archives to the release.

## Related Issue
Closes #185

## How Has This Been Tested?
Tags have been created and assets get successfully built and pushed to github

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
