### PR TITLE
Update bootstrap barrio to 4.27

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "composer/installers": "1.7.0",
         "cweagans/composer-patches": "1.6.7",
         "drupal/background_image_formatter": "1.4",
-        "drupal/bootstrap_barrio": "4.23",
+        "drupal/bootstrap_barrio": "4.27",
         "drupal/cas": "1.6.0",
         "drupal/core-recommended": "8.8.5",
         "drush/drush": "9.7.1",


### PR DESCRIPTION

bootstrap_barrio 8.x-4.27
By hatuhay on 3 May 2020
Git tag 8.x-4.27
Bug fixes
Fix conflict with lazy_build on blocks

Read moreabout bootstrap_barrio 8.x-4.27 View usage statistics for this release
bootstrap_barrio 8.x-4.26
By hatuhay on 2 May 2020
Git tag 8.x-4.26
Bug fixes
Small fixes and patches

Read moreabout bootstrap_barrio 8.x-4.26 View usage statistics for this release
bootstrap_barrio 8.x-4.25
By hatuhay on 19 April 2020
Git tag 8.x-4.25
Bug fixesNew features
Adds classes to nav links
Adds icon options for default Drupal navigation links
Cleans code for account menu
Add icons to alerts
Improve fixed bottom alerts

Read moreabout bootstrap_barrio 8.x-4.25 View usage statistics for this release
bootstrap_barrio 8.x-4.24
By hatuhay on 5 April 2020
Git tag 8.x-4.24
Bug fixesNew features
Commerce templates and styles
Correct install script
Typos and spacing corrections