### PR TITLE
#172 Add Utility Links Menu and Block.

### DIFF
--- a/az_quickstart.info.yml
+++ b/az_quickstart.info.yml
@@ -11,6 +11,7 @@ install:
   - az_cas
   - az_core
   - az_flexible_page
+  - az_demo
   - node
   - history
   - block

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,9 @@
         "drupal/externalauth": "1.2.0",
         "drupal/field_group": "3.0",
         "drupal/layout_builder_restrictions": "2.5",
-        "drupal/layout_builder_styles": "1.0-beta1"
+        "drupal/layout_builder_styles": "1.0-beta1",
+        "drupal/migrate_plus": "5.1",
+        "drupal/migrate_tools": "5.0"
     },
     "extra": {
         "patches": {

--- a/config/install/block.block.az_utility_links.yml
+++ b/config/install/block.block.az_utility_links.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.az-utility-links
+  module:
+    - system
+  theme:
+    - az_barrio
+id: az_utility_links
+theme: az_barrio
+region: header
+weight: -6
+provider: null
+plugin: 'system_menu_block:az-utility-links'
+settings:
+  id: 'system_menu_block:az-utility-links'
+  label: 'Utility Links'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 1
+  expand_all_items: false
+visibility: {  }

--- a/config/install/system.menu.az-utility-links.yml
+++ b/config/install/system.menu.az-utility-links.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: az-utility-links
+label: 'Utility Links'
+description: 'The utility links menu contains secondary navigation links that are not part of the main menu.'
+locked: false

--- a/modules/custom/az_demo/az_demo.info.yml
+++ b/modules/custom/az_demo/az_demo.info.yml
@@ -1,0 +1,11 @@
+name: 'Quickstart Demo Content'
+type: module
+description: 'Provides sample content to demonstrate various features of the AZ Quickstart distribution.'
+core_version_requirement: ^8.8 || ^9
+package: 'The University of Arizona'
+dependencies:
+  - az_core
+  - az_flexible_page
+  - migrate
+  - migrate_plus
+  - migrate_tools

--- a/modules/custom/az_demo/az_demo.install
+++ b/modules/custom/az_demo/az_demo.install
@@ -12,7 +12,7 @@ use Drupal\migrate\MigrateMessage;
  * Implements hook_install().
  */
 function az_demo_install() {
-  $tag = 'az_demo_content';
+  $tag = 'Quickstart Demo Content';
 
   // Run the migrations that are tagged as demo content.
   $migrations = \Drupal::service('plugin.manager.migration')->createInstancesByTag($tag);
@@ -26,7 +26,7 @@ function az_demo_install() {
  * Implements hook_uninstall().
  */
 function az_demo_uninstall() {
-  $tag = 'az_demo_content';
+  $tag = 'Quickstart Demo Content';
 
   // Rollback the migrations that are tagged as demo content.
   $migrations = \Drupal::service('plugin.manager.migration')->createInstancesByTag($tag);

--- a/modules/custom/az_demo/az_demo.install
+++ b/modules/custom/az_demo/az_demo.install
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Contains az_demo.install.
+ */
+
+use Drupal\migrate\MigrateExecutable;
+use Drupal\migrate\MigrateMessage;
+
+/**
+ * Implements hook_install().
+ */
+function az_demo_install() {
+  $tag = 'az_demo_content';
+
+  // Run the migrations that are tagged as demo content.
+  $migrations = \Drupal::service('plugin.manager.migration')->createInstancesByTag($tag);
+  foreach ($migrations as $migration) {
+    $executable = new MigrateExecutable($migration, new MigrateMessage());
+    $executable->import();
+  }
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function az_demo_uninstall() {
+  $tag = 'az_demo_content';
+
+  // Rollback the migrations that are tagged as demo content.
+  $migrations = \Drupal::service('plugin.manager.migration')->createInstancesByTag($tag);
+  foreach ($migrations as $migration) {
+    $executable = new MigrateExecutable($migration, new MigrateMessage());
+    $executable->rollback();
+  }
+}

--- a/modules/custom/az_demo/az_demo.module
+++ b/modules/custom/az_demo/az_demo.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains az_demo.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function az_demo_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the az_demo module.
+    case 'help.page.az_demo':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Provides sample content to demonstrate various features of the AZ Quickstart distribution.') . '</p>';
+      return $output;
+
+    default:
+  }
+}

--- a/modules/custom/az_demo/data/az_demo_menu_links.json
+++ b/modules/custom/az_demo/data/az_demo_menu_links.json
@@ -1,0 +1,26 @@
+{
+  "menu_links": [
+    {
+      "link_id": "1",
+      "parent_link_id": "0",
+      "menu": "az-utility-links",
+      "title": "Utility 1",
+      "urlpath": "https://quickstart.arizona.edu/",
+      "external": true,
+      "expanded": false,
+      "enabled": true,
+      "weight": "1"
+    },
+    {
+      "link_id": "2",
+      "parent_link_id": "0",
+      "menu": "az-utility-links",
+      "title": "Utility 2",
+      "urlpath": "https://brand.arizona.edu/",
+      "external": true,
+      "expanded": false,
+      "enabled": true,
+      "weight": "2"
+    }
+  ]
+}

--- a/modules/custom/az_demo/migrations/az_demo_menu_links.yml
+++ b/modules/custom/az_demo/migrations/az_demo_menu_links.yml
@@ -72,7 +72,7 @@ process:
     source:
       - parent_link_id
       - '@menu_name'
-      - parent_name
+      - ''
 destination:
   plugin: entity:menu_link_content
   no_stub: true

--- a/modules/custom/az_demo/migrations/az_demo_menu_links.yml
+++ b/modules/custom/az_demo/migrations/az_demo_menu_links.yml
@@ -57,7 +57,7 @@ process:
   'link/uri':
     plugin: link_uri
     source:
-      - url
+      - urlpath
   route_name: '@route/route_name'
   route_parameters: '@route/route_parameters'
   url: '@route/url'

--- a/modules/custom/az_demo/migrations/az_demo_menu_links.yml
+++ b/modules/custom/az_demo/migrations/az_demo_menu_links.yml
@@ -1,0 +1,85 @@
+id: az_demo_menu_links
+label: AZ Quickstart Demo Menu Links
+migration_tags:
+  - az_demo_content
+source:
+  plugin: url
+  data_fetcher_plugin: file
+  data_parser_plugin: json
+  urls:
+    - profiles/custom/az_quickstart/modules/custom/az_demo/data/az_demo_menu_links.json
+  item_selector: menu_links
+  fields:
+    -
+      name: link_id
+      label: 'Menu Link ID'
+      selector: link_id
+    -
+      name: parent_link_id
+      label: 'Parent Menu Link ID (source)'
+      selector: parent_link_id
+    -
+      name: title
+      label: 'Link Title'
+      selector: title
+    -
+      name: menu
+      label: 'Parent Menu'
+      selector: menu
+    -
+      name: urlpath
+      label: 'URL or path'
+      selector: urlpath
+    -
+      name: external
+      label: 'External'
+      selector: external
+    -
+      name: expanded
+      label: 'Expanded'
+      selector: expanded
+    -
+      name: enabled
+      label: 'Enabled'
+      selector: enabled
+    -
+      name: weight
+      label: 'Weight'
+      selector: weight
+  ids:
+    link_id:
+      type: integer
+process:
+  bundle: menu_link_content
+  title: title
+  menu_name: menu
+  # Handle external urls or url aliases.
+  'link/uri':
+    plugin: link_uri
+    source:
+      - url
+  route_name: '@route/route_name'
+  route_parameters: '@route/route_parameters'
+  url: '@route/url'
+  options: '@route/options'
+  external: external
+  weight: weight
+  expanded: expanded
+  enabled: enabled
+  # Handle mapping of parent menu links. Refers to SOURCE id numbers.
+  parent:
+    plugin: menu_link_parent
+    source:
+      - parent_link_id
+      - '@menu_name'
+      - parent_name
+destination:
+  plugin: entity:menu_link_content
+  no_stub: true
+migration_dependencies: {  }
+dependencies:
+  enforced:
+    module:
+      - migrate
+      - migrate_plus
+      - migrate_tools

--- a/modules/custom/az_demo/migrations/az_demo_menu_links.yml
+++ b/modules/custom/az_demo/migrations/az_demo_menu_links.yml
@@ -1,7 +1,8 @@
 id: az_demo_menu_links
 label: AZ Quickstart Demo Menu Links
 migration_tags:
-  - az_demo_content
+  - Quickstart Demo Content
+  - Content
 source:
   plugin: url
   data_fetcher_plugin: file

--- a/modules/custom/az_demo/tests/src/Functional/AZDemoContentTest.php
+++ b/modules/custom/az_demo/tests/src/Functional/AZDemoContentTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\Tests\az_demo\Functional;
+
+use Drupal\Core\Url;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Verify successful importing of demo content.
+ *
+ * @group az_demo
+ */
+class AZDemoContentTest extends BrowserTestBase {
+
+  /**
+   * The profile to install as a basis for testing.
+   *
+   * @var string
+   */
+  protected $profile = 'az_quickstart';
+
+  /**
+   * @var bool
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'az_demo',
+  ];
+
+  /**
+   * A user with permission to administer site configuration.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $user;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->user = $this->drupalCreateUser(['administer site configuration']);
+    $this->drupalLogin($this->user);
+  }
+
+  /**
+   * Tests that imported utility links exist.
+   */
+  public function testUtilityLinks() {
+
+    // Go to the front page.
+    $this->drupalGet(Url::fromRoute('<front>'));
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(200);
+
+    // Check for utility links.
+    $assert->linkExists('Utility 1');
+    $assert->linkExists('Utility 2');
+  }
+
+}

--- a/themes/custom/az_barrio/templates/navigation/menu--az-utility-links.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--az-utility-links.html.twig
@@ -1,0 +1,64 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+      <ul{{ attributes.addClass('nav ml-auto justify-content-end') }}>
+    {% else %}
+      <ul class="menu">
+    {% endif %}
+    {% for item in items %}
+      {%
+        set classes = [
+          'nav-item',
+          item.is_expanded ? 'menu-item--expanded',
+          item.is_collapsed ? 'menu-item--collapsed',
+          item.in_active_trail ? 'menu-item--active-trail',
+        ]
+      %}
+      <li{{ item.attributes.addClass(classes) }}>
+        {%
+          set link_classes = [
+            'text-muted',
+            'nav-link',
+            item.in_active_trail ? 'active',
+            item.url.getOption('attributes').class ? item.url.getOption('attributes').class | join(''),
+            'nav-link-' ~ item.url.toString() | clean_class,
+          ]
+        %}
+        {{ link(item.title, item.url, {'class': link_classes}) }}
+        {% if item.below %}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
This pull request adds a utility links menu and block placement to the configuration for quickstart.

## Description
`az_utility_links` is added as a menu block, and the block is placed above the search box in the `Header 1` region. A template is added to handle the addition of necessary bootstrap 4 classes.

This PR also adds a basic `az_demo` module that imports demo content. This could be fleshed out further when we start in earnest on our demo content epic.

## Related Issue
#172 #195 

## How Has This Been Tested?
Locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
