### PR TITLE
Fixes #205: Apply patch for CAS module deprecation warning.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
                 "declare-default-theme-in-functional-tests": "https://www.drupal.org/files/issues/2020-04-06/3124254-v1-6%237-declare-default-theme-in-functional-test.patch",
                 "update-deprecated-setExpectedException-method-in-tests": "https://www.drupal.org/files/issues/2020-04-01/3124245-update-deprecated-setExpectedException-method-in-tests.patch",
                 "local-username-argument": "https://www.drupal.org/files/issues/2020-04-02/3124256-local-username-argument.patch",
-                "forward-compatibility-drupal-check": "https://www.drupal.org/files/issues/2020-04-02/3110204-6-forward-compatibility-drupal-check.patch"
+                "forward-compatibility-drupal-check": "https://www.drupal.org/files/issues/2020-04-02/3110204-6-forward-compatibility-drupal-check.patch",
+                "getstorage-deprecation": "https://www.drupal.org/files/issues/2020-05-20/3138426-2.patch"
             },
             "drupal/core": {
                 "ajax css load order issue": "https://www.drupal.org/files/issues/2020-02-12/1461322-20.patch",


### PR DESCRIPTION
## Description
Adds [drupal.org patch](https://www.drupal.org/project/cas/issues/3138426#comment-13626352) for CAS module deprecation warning that is currently breaking our Probo builds.

## Related Issue
#205 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with lando. Patch being used passed Drupal.org tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
