### PR TITLE
Integrate material design icons

### DIFF
--- a/themes/custom/az_barrio/az_barrio.libraries.yml
+++ b/themes/custom/az_barrio/az_barrio.libraries.yml
@@ -16,3 +16,8 @@ az-brand-icons:
   css:
     theme:
       libraries/ua-brand-icons/ua-brand-icons.min.css: {}
+material-design-icons-sharp:
+
+  css:
+    https://fonts.googleapis.com/css?family=Material+Icons+Sharp: {}
+

--- a/themes/custom/az_barrio/az_barrio.libraries.yml
+++ b/themes/custom/az_barrio/az_barrio.libraries.yml
@@ -17,7 +17,7 @@ az-brand-icons:
     theme:
       libraries/ua-brand-icons/ua-brand-icons.min.css: {}
 material-design-icons-sharp:
-
   css:
-    https://fonts.googleapis.com/css?family=Material+Icons+Sharp: {}
+    theme:
+      https://fonts.googleapis.com/css?family=Material+Icons+Sharp: {}
 

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -46,7 +46,6 @@ function az_barrio_preprocess_page(&$variables) {
 
   // Add Material Design Icons
   if (theme_get_setting('use_material_design_sharp_icons') === 1) {
-
     $variables['#attached']['library'][] = 'az_barrio/material-design-icons-sharp';
   }
 
@@ -176,10 +175,10 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
       $az_brand_icons_path => $az_brand_icons_css_info,
     ];
 
-    // Material Design Icons.
-    $libraries['material-design-icons-sharp']['css']['theme'] = [
-      $az_brand_icons_path => $az_brand_icons_css_info,
-    ];
+//    // Material Design Icons.
+//    $libraries['material-design-icons-sharp']['css']['theme'] = [
+//      $az_brand_icons_path => $az_brand_icons_css_info,
+//    ];
   }
 }
 

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -44,6 +44,12 @@ function az_barrio_preprocess_page(&$variables) {
     // $variables['title'] = FALSE;
   }
 
+  // Add Material Design Icons
+  if (theme_get_setting('use_material_design_sharp_icons') === 1) {
+
+    $variables['#attached']['library'][] = 'az_barrio/material-design-icons-sharp';
+  }
+
   // Check if information security policy should be displayed.
   $info_security_privacy = '';
   if (theme_get_setting('info_security_privacy')) {
@@ -167,6 +173,11 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
     }
 
     $libraries['az-brand-icons']['css']['theme'] = [
+      $az_brand_icons_path => $az_brand_icons_css_info,
+    ];
+
+    // Material Design Icons.
+    $libraries['material-design-icons-sharp']['css']['theme'] = [
       $az_brand_icons_path => $az_brand_icons_css_info,
     ];
   }

--- a/themes/custom/az_barrio/config/install/az_barrio.settings.yml
+++ b/themes/custom/az_barrio/config/install/az_barrio.settings.yml
@@ -65,6 +65,7 @@ az_brand_icons_source: 'cdn'
 az_brand_icons_class: true
 external_links: true
 sticky_footer: true
+material-icons-sharp: true
 
 logo:
   path: 'profiles/custom/az_quickstart/themes/custom/az_barrio/logo.png'

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -186,6 +186,19 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     '#default_value' => theme_get_setting('sticky_footer'),
   ];
 
+  // Material Design Icons
+  $form['material_design_icon_settings'] = [
+    '#type' => 'details',
+    '#title' => t('Material Design Icons'),
+    '#group' => 'bootstrap',
+    '#weight' => -8,
+  ];
+  $form['material_design_icon_settings']['settings']['material_design_icons']['use_material_design_sharp_icons'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Use Material Design Sharp Icons'),
+    '#default_value' => theme_get_setting('use_material_design_sharp_icons'),
+  ];
+
   // Components.
   $form['components']['navbar']['bootstrap_barrio_navbar_top_background']['#options'] = [
     'bg-primary' => t('Primary'),


### PR DESCRIPTION
## Description
Fixes #213 

Added material design icon font to az-bootstrap sharp variant as a library
Added checkbox in az_barrio to turn on or off
Set default for checkbox as TRUE
Made sure to check the theme setting before adding library.

## Related Issue
 #213 
 
## How Has This Been Tested?
Locally

## Types of changes
- [ x ] New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] I've added this Pull Request to the AZ Quickstart project in the right column.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
