### PR TITLE
removed some RFI and dynamic parameter warnings from PHPCS

### DIFF
--- a/modules/custom/az_core/src/QuickstartConfigInstaller.php
+++ b/modules/custom/az_core/src/QuickstartConfigInstaller.php
@@ -30,7 +30,7 @@ class QuickstartConfigInstaller extends ConfigInstaller {
     }
     $config_install_path = $this
       ->getDefaultConfigDirectory($type, $name);
-    if (!is_dir($config_install_path)) {
+    if (stream_resolve_include_path($config_install_path) === FALSE) {
       return;
     }
     $storage = new FileStorage($config_install_path, StorageInterface::DEFAULT_COLLECTION);
@@ -99,7 +99,7 @@ class QuickstartConfigInstaller extends ConfigInstaller {
     $app_root = \Drupal::root();
     $filename = $app_root . '/' . drupal_get_path($type, $name) . '/' . $name . '.az_config_overrides.yml';
 
-    if (file_exists($filename)) {
+    if (stream_resolve_include_path($filename)) {
       // If an override file exists, parse it for overrides.
       $yaml = Yaml::decode(file_get_contents($filename));
       if (!empty($yaml['overrides'])) {

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -5,7 +5,7 @@
  * Functions to support theming in the Arizona Barrio theme.
  */
 
-include_once dirname(__FILE__) . '/includes/common.inc';
+include_once drupal_get_path('theme', 'az_barrio') . '/includes/common.inc';
 
 use Drupal\Core\Link;
 use Drupal\Core\Render\Markup;

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -7,7 +7,7 @@
  * Provides theme settings for Arizona Barrio.
  */
 
-include_once dirname(__FILE__) . '/includes/common.inc';
+include_once drupal_get_path('theme', 'az_barrio') . '/includes/common.inc';
 
 use Drupal\Core\Form\FormStateInterface;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
The changes I made removed most but not all PHPCS warnings. The only warnings that were left over were 'possible RFI detected' by the use of `drupal_get_path()` in the az_barrio.theme file and the theme-settings file and 'filesystem function with dynamic parameter' on the use of `file_get_contents()` in the QuickstartConfigInstaller.php file. However I would argue that in keeping with the spirit of the security measures that PHPCS is helping us mitigate, these warnings should be acceptable. For one, the code sniffer tool is by its own admission a generator of 'false positives'. Please refer to their [README](https://github.com/FloeDesignTechnologies/phpcs-security-audit#annoyances) as well as this interesting issue [conversation](https://github.com/FloeDesignTechnologies/phpcs-security-audit/issues/69#issuecomment-599313528). Secondly, seeing as how a Remote File Inclusion attack relies on user input I would think that the simple `drupal_get_path() . '/includes/common.php';` would not be at a high risk. And with `file_get_contents()`, I simply could not figure out a way around it but to be fair it also relies on basically static input. The Drupal codebase itself is littered with this function also.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here:  #-->#174

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran lando phpcs and lando phpunit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added this Pull Request to the AZ Quickstart project in the right column. (not sure what this means)
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (I could write tests but I am not sure where to put them)
- [x] All new and existing tests passed.
