### PR TITLE
#33: Moved require-dev dependencies out of scaffolding repo (profile repo PR)

### DIFF
--- a/.ddev/commands/web/phpcs
+++ b/.ddev/commands/web/phpcs
@@ -4,4 +4,4 @@
 ## Usage: phpcs [flags] [args]
 ## Example: "ddev phpcs --version"
 
-vendor/bin/phpcs --colors web/profiles/custom/az_quickstart $@
+vendor/bin/phpcs --colors --standard=web/profiles/custom/az_quickstart/phpcs.xml.dist web/profiles/custom/az_quickstart $@

--- a/.ddev/commands/web/phpunit
+++ b/.ddev/commands/web/phpunit
@@ -4,4 +4,4 @@
 ## Usage: phpunit [flags] [args]
 ## Example: "ddev phpunit --version"
 
-vendor/bin/phpunit --bootstrap web/core/tests/bootstrap.php web/profiles/custom/az_quickstart $@
+vendor/bin/phpunit --configuration web/profiles/custom/az_quickstart/phpunit.xml.dist --bootstrap web/core/tests/bootstrap.php web/profiles/custom/az_quickstart $@

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,11 +16,16 @@ jobs:
       - name: Install dependencies
         run: |
           composer global require hirak/prestissimo
-          if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $AZ_TRIMMED_REF | wc -l) = 1 ]; then PROFILE_BRANCH="$AZ_TRIMMED_REF"; else PROFILE_BRANCH=master; fi
-          composer require --no-update az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+          if [ $(git ls-remote --heads https://github.com/az-digital/az-quickstart-scaffolding.git $AZ_TRIMMED_REF | wc -l) = 1 ]; then SCAFFOLD_BRANCH="$AZ_TRIMMED_REF"; else SCAFFOLD_BRANCH=master; fi
+          git clone --branch $SCAFFOLD_BRANCH https://github.com/az-digital/az-quickstart-scaffolding.git
+          cd az-quickstart-scaffolding
+          composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
+          composer config use-github-api false
+          composer require --no-update az-digital/az_quickstart:dev-${AZ_TRIMMED_REF}
           composer install -o
       - name: Check dependencies for vulnerabilities
         run: |
+          cd az-quickstart-scaffolding
           composer security-check
   code-check:
     name: Static Code Check
@@ -32,9 +37,14 @@ jobs:
       - name: Install dependencies
         run: |
           composer global require hirak/prestissimo
-          if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $AZ_TRIMMED_REF | wc -l) = 1 ]; then PROFILE_BRANCH="$AZ_TRIMMED_REF"; else PROFILE_BRANCH=master; fi
-          composer require --no-update az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+          if [ $(git ls-remote --heads https://github.com/az-digital/az-quickstart-scaffolding.git $AZ_TRIMMED_REF | wc -l) = 1 ]; then SCAFFOLD_BRANCH="$AZ_TRIMMED_REF"; else SCAFFOLD_BRANCH=master; fi
+          git clone --branch $SCAFFOLD_BRANCH https://github.com/az-digital/az-quickstart-scaffolding.git
+          cd az-quickstart-scaffolding
+          composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
+          composer config use-github-api false
+          composer require --no-update az-digital/az_quickstart:dev-${AZ_TRIMMED_REF}
           composer install -o
       - name: Run static code analysis
         run: |
+          cd az-quickstart-scaffolding
           composer phpcs

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,40 @@
+name: Security workflow
+
+on:
+  push:
+  schedule:
+    - cron:  '0 13 * * *'
+
+jobs:
+  dependency-audit:
+    name: Dependency Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - run: echo "::set-env name=AZ_TRIMMED_REF::${GITHUB_REF#refs/*/}"
+      - name: Install dependencies
+        run: |
+          composer global require hirak/prestissimo
+          if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $AZ_TRIMMED_REF | wc -l) = 1 ]; then PROFILE_BRANCH="$AZ_TRIMMED_REF"; else PROFILE_BRANCH=master; fi
+          composer require --no-update az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+          composer install -o
+      - name: Check dependencies for vulnerabilities
+        run: |
+          composer security-check
+  code-check:
+    name: Static Code Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - run: echo "::set-env name=AZ_TRIMMED_REF::${GITHUB_REF#refs/*/}"
+      - name: Install dependencies
+        run: |
+          composer global require hirak/prestissimo
+          if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $AZ_TRIMMED_REF | wc -l) = 1 ]; then PROFILE_BRANCH="$AZ_TRIMMED_REF"; else PROFILE_BRANCH=master; fi
+          composer require --no-update az-digital/az_quickstart:dev-${PROFILE_BRANCH}
+          composer install -o
+      - name: Run static code analysis
+        run: |
+          composer phpcs

--- a/.lando.yml
+++ b/.lando.yml
@@ -50,11 +50,11 @@ tooling:
   # Provide phpcs tooling to check coding standards.
   phpcs:
     service: appserver
-    cmd: /app/vendor/bin/phpcs --colors web/profiles/custom/az_quickstart
+    cmd: /app/vendor/bin/phpcs --colors --standard=web/profiles/custom/az_quickstart/phpcs.xml.dist web/profiles/custom/az_quickstart
   # Provide phpunit tooling to run unit tests.
   phpunit:
     service: appserver
-    cmd: /app/vendor/bin/phpunit --bootstrap web/core/tests/bootstrap.php web/profiles/custom/az_quickstart
+    cmd: /app/vendor/bin/phpunit --configuration web/profiles/custom/az_quickstart/phpunit.xml.dist --bootstrap web/core/tests/bootstrap.php web/profiles/custom/az_quickstart
   # Provide drupal-check tooling to check for deprecated code.
   drupal-check:
     service: appserver

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,6 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/joeparsons/az-quickstart-dev.git"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,10 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/joeparsons/az-quickstart-dev.git"
         }
     ],
     "require": {
@@ -38,11 +42,7 @@
         "drupal/token": "1.7"
     },
     "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
-        "drupal/core-dev-pinned": "*",
-        "mglaman/drupal-check": "1.1.1",
-        "pheromone/phpcs-security-audit": "dev-master#1b8a61d4ac8f4f1554bcbf67865f8e1c1b213bdd",
-        "sensiolabs/security-checker": "6.0.3"
+        "az-digital/az-quickstart-dev": "dev-master"
     },
     "extra": {
         "patches": {

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,13 @@
         "drupal/migrate_tools": "5.0",
         "drupal/token": "1.7"
     },
+    "require-dev": {
+        "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
+        "drupal/core-dev-pinned": "*",
+        "mglaman/drupal-check": "1.1.1",
+        "pheromone/phpcs-security-audit": "dev-master#1b8a61d4ac8f4f1554bcbf67865f8e1c1b213bdd",
+        "sensiolabs/security-checker": "6.0.3"
+    },
     "extra": {
         "patches": {
             "drupal/cas": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="az-quickstart">
+  <description>PHPCS configuration for AZ QuickStart</description>
+  <!-- Check all files within the AZ QuickStart installation profile. -->
+  <file>./web/profiles/custom/az_quickstart</file>
+  <arg name="extensions" value="php,install,module,profile,inc"/>
+
+  <arg name="cache" value=".phpcs-cache"/>
+  <arg name="parallel" value="10"/>
+
+  <exclude-pattern>*min.css</exclude-pattern>
+  <exclude-pattern>*min.js</exclude-pattern>
+  <exclude-pattern>*/arizona-bootstrap/*</exclude-pattern>
+  <exclude-pattern>*/ua-brand-icons/*</exclude-pattern>
+  <exclude-pattern>*/node_modules/*</exclude-pattern>
+
+  <!-- Code is to be tested as Drupal 8. -->
+  <config name="drupal_core_version" value="8"/>
+
+  <!-- Set configuration so that warnings should not cause error exit status. -->
+  <config name="ignore_warnings_on_exit" value="1"/>
+
+  <!-- Framework or CMS used. Must be a class under Security_Sniffs. -->
+  <!-- TODO: Investigate this missing class -->
+  <!-- <config name="CmsFramework" value="Drupal8"/> -->
+
+  <!-- Internal sniffs -->
+  <rule ref="Internal.NoCodeFound">
+    <!-- No PHP code in *.md *.txt *.yml -->
+    <exclude-pattern>*.md</exclude-pattern>
+    <exclude-pattern>*.txt</exclude-pattern>
+    <exclude-pattern>*.yml</exclude-pattern>
+  </rule>
+
+  <!-- Drupal sniffs. -->
+  <rule ref="Drupal">
+    <!-- Remove warnings in regard to Drupal.org .info file generation. -->
+    <exclude name="Drupal.InfoFiles.AutoAddedKeys"/>
+
+    <!-- TagsNotGrouped has false positives. See https://www.drupal.org/node/2502837  -->
+    <exclude name="Drupal.Commenting.DocComment.TagsNotGrouped"/>
+
+    <!-- MissingShort has false positives. See https://www.drupal.org/project/drupal/issues/2572635  -->
+    <exclude name="Drupal.Commenting.DocComment.MissingShort"/>
+  </rule>
+
+  <!-- Security Code Reviews Rules -->
+
+  <!-- Global properties -->
+  <!-- Please note that not every sniff uses them and they can be overwritten by rule -->
+  <!-- Paranoya mode: Will generate more alerts but will miss less vulnerabilites. Good for assisting manual code review. -->
+  <config name="ParanoiaMode" value="1"/>
+
+  <!-- BadFunctions -->
+  <!-- PHP functions that can lead to security issues -->
+  <rule ref="Security.BadFunctions.Asserts"/>
+  <rule ref="Security.BadFunctions.Backticks"/>
+  <rule ref="Security.BadFunctions.CallbackFunctions"/>
+  <rule ref="Security.BadFunctions.CryptoFunctions"/>
+  <rule ref="Security.BadFunctions.EasyRFI"/>
+  <rule ref="Security.BadFunctions.EasyXSS">
+    <properties>
+      <!-- Comment out to follow global ParanoiaMode -->
+      <property name="forceParanoia" value="1"/>
+    </properties>
+  </rule>
+  <rule ref="Security.BadFunctions.ErrorHandling"/>
+  <rule ref="Security.BadFunctions.FilesystemFunctions"/>
+  <rule ref="Security.BadFunctions.FringeFunctions"/>
+  <rule ref="Security.BadFunctions.FunctionHandlingFunctions"/>
+  <rule ref="Security.BadFunctions.Mysqli"/>
+  <rule ref="Security.BadFunctions.NoEvals"/>
+  <rule ref="Security.BadFunctions.Phpinfos"/>
+  <rule ref="Security.BadFunctions.PregReplace"/>
+  <rule ref="Security.BadFunctions.SQLFunctions"/>
+  <rule ref="Security.BadFunctions.SystemExecFunctions"/>
+
+  <!-- CVE -->
+  <!-- Entries from CVE database from vendor PHP and bugs.php.net -->
+  <rule ref="Security.CVE.CVE20132110"/>
+  <rule ref="Security.CVE.CVE20134113"/>
+
+  <!-- Misc -->
+  <rule ref="Security.Misc.BadCorsHeader"/>
+  <rule ref="Security.Misc.IncludeMismatch"/>
+  <rule ref="Security.Misc.TypeJuggle"/>
+
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,7 @@
 <ruleset name="az-quickstart">
   <description>PHPCS configuration for AZ QuickStart</description>
   <!-- Check all files within the AZ QuickStart installation profile. -->
-  <file>./web/profiles/custom/az_quickstart</file>
+  <file>.</file>
   <arg name="extensions" value="php,install,module,profile,inc"/>
 
   <arg name="cache" value=".phpcs-cache"/>


### PR DESCRIPTION
## Description
This moves various things related to our require-dev dependencies from the scaffolding repo to the profile repo:
- phpcs.xml.dist config
- Github actions security check workflow

It also adds a new repo, az-quickstart-dev as a require-dev dependency.

## Related Issue
#33 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally with lando
- On GitHub actions

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
