### PR TITLE
Closes #228 - Add .nav-utility class

### DIFF
--- a/themes/custom/az_barrio/templates/navigation/menu--az-utility-links.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--az-utility-links.html.twig
@@ -30,7 +30,7 @@
   {% import _self as menus %}
   {% if items %}
     {% if menu_level == 0 %}
-      <ul{{ attributes.addClass('nav ml-auto justify-content-end') }}>
+      <ul{{ attributes.addClass('nav nav-utility ml-auto justify-content-end') }}>
     {% else %}
       <ul class="menu">
     {% endif %}


### PR DESCRIPTION
Closes #228 by adding the `.nav-utility` class to the utility links menu. These styles are available in Bootstrap az-digital/arizona-bootstrap#81 (pending merge to master).