### PR TITLE
#230 Move .dropdown-item class from list element to anchor element

### DIFF
--- a/themes/custom/az_barrio/templates/navigation/menu--main.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main.html.twig
@@ -1,0 +1,66 @@
+{#
+/**
+ * @file
+ * Bootstrap Barrio's override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+      <ul{{ attributes.addClass('nav navbar-nav') }}>
+    {% else %}
+      <ul class="dropdown-menu">
+    {% endif %}
+    {% for item in items %}
+      {%
+        set classes = [
+          menu_level ? 'dropdown-item' : 'nav-item',
+          item.is_expanded ? 'menu-item--expanded',
+          item.is_collapsed ? 'menu-item--collapsed',
+          item.in_active_trail ? 'active',
+          item.below ? 'dropdown',
+        ]
+      %}
+      <li{{ item.attributes.addClass(classes) }}>
+        {%
+          set link_classes = [
+            not menu_level ? 'nav-link',
+            item.in_active_trail ? 'active',
+            item.below ? 'dropdown-toggle',
+            item.url.getOption('attributes').class ? item.url.getOption('attributes').class | join(' '),
+          ]
+        %}
+        {% if item.below %}
+          {{ link(item.title, item.url, {'class': link_classes, 'data-toggle': 'dropdown', 'aria-expanded': 'false', 'aria-haspopup': 'true' }) }}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+        {% else %}
+          {{ link(item.title, item.url, {'class': link_classes}) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endmacro %}

--- a/themes/custom/az_barrio/templates/navigation/menu--main.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main.html.twig
@@ -37,7 +37,7 @@
     {% for item in items %}
       {%
         set classes = [
-          menu_level ? 'dropdown-item' : 'nav-item',
+          not menu_level ? 'nav-item',
           item.is_expanded ? 'menu-item--expanded',
           item.is_collapsed ? 'menu-item--collapsed',
           item.in_active_trail ? 'active',
@@ -48,6 +48,7 @@
         {%
           set link_classes = [
             not menu_level ? 'nav-link',
+            menu_level ? 'dropdown-item',
             item.in_active_trail ? 'active',
             item.below ? 'dropdown-toggle',
             item.url.getOption('attributes').class ? item.url.getOption('attributes').class | join(' '),

--- a/themes/custom/az_barrio/templates/navigation/menu--main.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main.html.twig
@@ -47,8 +47,7 @@
       <li{{ item.attributes.addClass(classes) }}>
         {%
           set link_classes = [
-            not menu_level ? 'nav-link',
-            menu_level ? 'dropdown-item',
+            menu_level ? 'dropdown-item' : 'nav-link',
             item.in_active_trail ? 'active',
             item.below ? 'dropdown-toggle',
             item.url.getOption('attributes').class ? item.url.getOption('attributes').class | join(' '),


### PR DESCRIPTION
## Description
The current markup of the main navigation doesn't presently allow the proper Bootstrap classes to apply on the downdown menu items. @akslay found out that this is because the `.dropdown-item` class is currently present on the `li` element of the menu markup rather than on the link where bootstrap expects it to be.

This PR adds a twig template for the menu that moves the `.dropdown-item` class from the `li` element to the `a` element.

## Related Issue
#230

## How Has This Been Tested?
- Create a nested menu.
- Verify that links are white rather than red and underlined.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
