### PR TITLE
Fixes #241: Added media_library_theme_reset contrib module to fix Layout Builder Media Library display issues.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "drupal/field_group": "3.0",
         "drupal/layout_builder_restrictions": "2.5",
         "drupal/layout_builder_styles": "1.0-beta1",
+        "drupal/media_library_theme_reset": "1.0",
         "drupal/migrate_plus": "5.1",
         "drupal/migrate_tools": "5.0",
         "drupal/token": "1.7"

--- a/modules/custom/az_layouts/az_layouts.info.yml
+++ b/modules/custom/az_layouts/az_layouts.info.yml
@@ -6,4 +6,5 @@ package: The University of Arizona
 dependencies:
   - layout_builder_styles
   - layout_builder
+  - media_library_theme_reset
   - az_flexible_page


### PR DESCRIPTION
## Description
Adds media_library_theme_reset module as fix for #241 

## Related Issue
#241

## How Has This Been Tested?
Fix verified on ProboCI site.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
