### PR TITLE
Fixes #247: Improve compatibility with latest ddev release + backwards-compatible D9 ddev config changes.

### DIFF
--- a/.ddev/commands/web/install
+++ b/.ddev/commands/web/install
@@ -1,7 +1,13 @@
 #!/bin/sh
 
-## Description: Install Drupal using the Quickstart install profile.
+## Description: Create a new quickstart project and use the installation profile as a non-packagist repository using the matching scaffolding branch if available.
 ## Usage: install
 ## Example: "ddev install"
 
+rm -rf /var/www/html/*
+BRANCH_NAME=$(git -C /usr/local/quickstart-install-profile rev-parse --abbrev-ref HEAD); if [ $(git ls-remote --heads https://github.com/az-digital/az-quickstart-scaffolding.git $BRANCH_NAME | wc -l) = 1 ]; then SCAFFOLD_BRANCH="$BRANCH_NAME"; else SCAFFOLD_BRANCH="master"; fi; git clone --branch $SCAFFOLD_BRANCH https://github.com/az-digital/az-quickstart-scaffolding.git /var/www/html
+composer config repositories.localdev path /usr/local/quickstart-install-profile && composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:\*@dev
+composer install
 drush --root=/var/www/html/web site:install --account-mail=noreply@email.arizona.edu --account-name=azadmin --account-pass=azadmin --db-url=mysql://db:db@db:3306/db -y --verbose
+yarn --cwd /usr/local/quickstart-install-profile install
+npm install --no-progress --global eslint-config-drupal-bundle

--- a/.ddev/commands/web/install
+++ b/.ddev/commands/web/install
@@ -1,13 +1,7 @@
 #!/bin/sh
 
-## Description: Create a new quickstart project and use the installation profile as a non-packagist repository using the matching scaffolding branch if available.
+## Description: Install Drupal using the Quickstart install profile.
 ## Usage: install
 ## Example: "ddev install"
 
-rm -rf /var/www/html/docroot && rm /var/www/html/index.html
-BRANCH_NAME=$(git -C /usr/local/quickstart-install-profile rev-parse --abbrev-ref HEAD); if [ $(git ls-remote --heads https://github.com/az-digital/az-quickstart-scaffolding.git $BRANCH_NAME | wc -l) = 1 ]; then SCAFFOLD_BRANCH="$BRANCH_NAME"; else SCAFFOLD_BRANCH="master"; fi; git clone --branch $SCAFFOLD_BRANCH https://github.com/az-digital/az-quickstart-scaffolding.git /var/www/html
-composer config repositories.localdev path /usr/local/quickstart-install-profile && composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:\*@dev
-composer install
 drush --root=/var/www/html/web site:install --account-mail=noreply@email.arizona.edu --account-name=azadmin --account-pass=azadmin --db-url=mysql://db:db@db:3306/db -y --verbose
-yarn --cwd /usr/local/quickstart-install-profile install
-npm install --no-progress --global eslint-config-drupal-bundle

--- a/.ddev/config.quickstart.yaml
+++ b/.ddev/config.quickstart.yaml
@@ -1,8 +1,7 @@
 # Recipe for AZ Quickstart local development
-APIVersion: v1.13.0
 type: php
 docroot: web
-php_version: "7.2"
+php_version: "7.3"
 webserver_type: nginx-fpm
 
 # Default application ports
@@ -16,7 +15,17 @@ nfs_mount_enabled: false
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
-mariadb_version: "10.2"
+mariadb_version: "10.3"
 provider: default
 use_dns_when_possible: true
 timezone: ""
+
+# Create a new quickstart project and use the installation profile as a non-packagist repository using the matching scaffolding branch if available.
+hooks:
+  post-start:
+    - exec: rm -rf /var/www/html/docroot && rm /var/www/html/index.html
+    - exec: rm -rf .git && git init && BRANCH_NAME=$(git -C /usr/local/quickstart-install-profile rev-parse --abbrev-ref HEAD); if [ $(git ls-remote --heads https://github.com/az-digital/az-quickstart-scaffolding.git $BRANCH_NAME | wc -l) = 1 ]; then SCAFFOLD_BRANCH="$BRANCH_NAME"; else SCAFFOLD_BRANCH="master"; fi; git remote add origin https://github.com/az-digital/az-quickstart-scaffolding.git && git fetch && git checkout -t origin/$SCAFFOLD_BRANCH
+    - exec: composer config repositories.localdev path /usr/local/quickstart-install-profile && composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:\*@dev
+    - exec: composer install
+    - exec: yarn --cwd /usr/local/quickstart-install-profile install
+    - exec: npm install --no-progress --global eslint-config-drupal-bundle

--- a/.ddev/config.quickstart.yaml
+++ b/.ddev/config.quickstart.yaml
@@ -19,13 +19,3 @@ mariadb_version: "10.3"
 provider: default
 use_dns_when_possible: true
 timezone: ""
-
-# Create a new quickstart project and use the installation profile as a non-packagist repository using the matching scaffolding branch if available.
-hooks:
-  post-start:
-    - exec: rm -rf /var/www/html/docroot && rm /var/www/html/index.html
-    - exec: rm -rf .git && git init && BRANCH_NAME=$(git -C /usr/local/quickstart-install-profile rev-parse --abbrev-ref HEAD); if [ $(git ls-remote --heads https://github.com/az-digital/az-quickstart-scaffolding.git $BRANCH_NAME | wc -l) = 1 ]; then SCAFFOLD_BRANCH="$BRANCH_NAME"; else SCAFFOLD_BRANCH="master"; fi; git remote add origin https://github.com/az-digital/az-quickstart-scaffolding.git && git fetch && git checkout -t origin/$SCAFFOLD_BRANCH
-    - exec: composer config repositories.localdev path /usr/local/quickstart-install-profile && composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:\*@dev
-    - exec: composer install
-    - exec: yarn --cwd /usr/local/quickstart-install-profile install
-    - exec: npm install --no-progress --global eslint-config-drupal-bundle

--- a/.ddev/config.quickstart.yaml
+++ b/.ddev/config.quickstart.yaml
@@ -1,5 +1,5 @@
 # Recipe for AZ Quickstart local development
-type: php
+type: drupal8
 docroot: web
 php_version: "7.3"
 webserver_type: nginx-fpm


### PR DESCRIPTION
## Description
- ~Moves compser and yarn script steps out of custom ddev `install` command into ddev `post-start` hook~
- ~Replaces step that git clones scaffolding repo with git init, git fetch, and git checkout commands due to weirdness with `/var/www/html` directory already existing~
- Replaces existing command to remove files in the `/var/www/html` directory with `rm -rf /var/www/html/*` to fix problems with latest ddev release
- Bumps PHP + MariaDB versions in ddev config to improve D9 compatibility (while preserving backwards compatibility)

## Related Issue
#247 

## How Has This Been Tested?
Locally with ddev version 1.15.0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added this Pull Request to the AZ Quickstart project in the right column.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
