### PR TITLE
Fixes #249 Manage Layout Button Doesn't Work

### DIFF
--- a/modules/custom/az_layouts/src/Element/AZLayoutBuilder.php
+++ b/modules/custom/az_layouts/src/Element/AZLayoutBuilder.php
@@ -5,6 +5,7 @@ namespace Drupal\az_layouts\Element;
 use Drupal\layout_builder\Element\LayoutBuilder;
 use Drupal\Core\Url;
 use Drupal\layout_builder\SectionStorageInterface;
+use Drupal\Component\Plugin\Exception\ContextException;
 
 /**
  * Defines a render element for building the Layout Builder UI.
@@ -30,8 +31,16 @@ class AZLayoutBuilder extends LayoutBuilder {
     $section = $section_storage->getSection($delta);
     $layout = $section->getLayout();
     $layout_definition = $layout->getPluginDefinition();
-    $entity = $section_storage->getContextValue('entity');
-    $bundle = ($entity) ? $entity->bundle() : '';
+
+    // Try to find the entity context of where this section is being used.
+    try {
+      $entity = $section_storage->getContextValue('entity');
+      $bundle = ($entity) ? $entity->bundle() : '';
+    }
+    catch (ContextException $e) {
+      // There was no entity context, e.g. probably the default layout.
+      return $build;
+    }
 
     if ($bundle !== 'az_flexible_page') {
       return $build;


### PR DESCRIPTION
This pull request prevents a potential ContextException that could occur when editing the default layout for a content type.

## Description
There are some checks in place to verify that some customizations are only applied if the content type of the page is a flexible page. To do this, a check is made regarding the section's entity context. However, this could fail in cases where there was no entity context. (Typically when editing the default layout for a content type).

A potential `ContextException` is caught to resolve the issue.

## Related Issue
#249 

## How Has This Been Tested?
Visit: `/admin/structure/types/manage/az_flexible_page/display/default/layout` and verify no error is encountered.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
