### PR TITLE
Fixes #194 Add Breadcrumb Settings

### DIFF
--- a/az_quickstart.info.yml
+++ b/az_quickstart.info.yml
@@ -31,6 +31,7 @@ install:
   - options
   - path
   - pathauto
+  - easy_breadcrumb
   - page_cache
   - dynamic_page_cache
   - big_pipe

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "drupal/core-recommended": "8.9.2",
         "drush/drush": "9.7.1",
         "drupal/ds": "3.x-dev#170540060a644102ab3524cd1d31de408d492186",
+        "drupal/easy_breadcrumb": "1.13",
         "drupal/externalauth": "1.3",
         "drupal/field_group": "3.1",
         "drupal/layout_builder_restrictions": "2.7",

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,9 @@
             },
             "drupal/ds": {
                 "Remove drush plugin": "https://git.drupalcode.org/project/ds/commit/c8db6ed6f5f2a543f9fe50d440a5dd94a1f13fae.diff"
+            },
+            "drupal/easy_breadcrumb": {
+                "Easy_breadcrumb schema issue": "https://www.drupal.org/files/issues/2020-07-27/missing_schema_keys-3161765-4.patch"
             }
         }
     }

--- a/config/install/easy_breadcrumb.settings.yml
+++ b/config/install/easy_breadcrumb.settings.yml
@@ -12,7 +12,7 @@ absolute_paths: false
 hide_single_home_item: false
 title_from_page_when_available: false
 capitalizator_mode: ucwords
-capitalizator_ignored_words: ''
+capitalizator_ignored_words: 'of and or de del y o a'
 capitalizator_forced_words_first_letter: 0
 capitalizator_forced_words_case_sensitivity: 1
 add_structured_data_jsonld: false

--- a/config/install/easy_breadcrumb.settings.yml
+++ b/config/install/easy_breadcrumb.settings.yml
@@ -17,12 +17,6 @@ capitalizator_forced_words_first_letter: 0
 capitalizator_forced_words_case_sensitivity: 1
 add_structured_data_jsonld: false
 use_site_title: false
-dependencies:
-  module:
-    - easy_breadcrumb
-  enforced:
-    module:
-      - easy_breadcrumb
 include_invalid_paths: false
 add_structured_data_json_ld: 0
 excluded_paths: ''

--- a/config/install/easy_breadcrumb.settings.yml
+++ b/config/install/easy_breadcrumb.settings.yml
@@ -1,0 +1,32 @@
+applies_admin_routes: false
+include_home_segment: false
+home_segment_title: Home
+home_segment_keep: false
+include_title_segment: false
+language_path_prefix_as_segment: false
+use_menu_title_as_fallback: true
+use_page_title_as_menu_title_fallback: true
+remove_repeated_segments: true
+term_hierarchy: false
+absolute_paths: false
+hide_single_home_item: false
+title_from_page_when_available: false
+capitalizator_mode: ucwords
+capitalizator_ignored_words: ''
+capitalizator_forced_words_first_letter: 0
+capitalizator_forced_words_case_sensitivity: 1
+add_structured_data_jsonld: false
+use_site_title: false
+dependencies:
+  module:
+    - easy_breadcrumb
+  enforced:
+    module:
+      - easy_breadcrumb
+include_invalid_paths: false
+add_structured_data_json_ld: 0
+excluded_paths: ''
+replaced_titles: ''
+custom_paths: ''
+title_segment_as_link: false
+capitalizator_forced_words: ''

--- a/config/install/user.role.az_content_admin.yml
+++ b/config/install/user.role.az_content_admin.yml
@@ -9,6 +9,7 @@ permissions:
   - 'access news feeds'
   - 'access taxonomy overview'
   - 'administer book outlines'
+  - 'administer easy breadcrumb'
   - 'administer nodes'
   - 'administer quickstart configuration'
   - 'administer taxonomy'

--- a/themes/custom/az_barrio/templates/navigation/breadcrumb.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/breadcrumb.html.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * @file
+ * Theme override for a breadcrumb trail.
+ *
+ * Available variables:
+ * - breadcrumb: Breadcrumb trail items.
+ */
+#}
+
+{% if breadcrumb %}
+  <nav role="navigation" aria-label="breadcrumb">
+    <ol class="breadcrumb">
+    {% for item in breadcrumb %}
+      {% if item.url %}
+        <li class="breadcrumb-item">
+          <a href="{{ item.url }}">{{ item.text }}</a>
+        </li>
+      {% else %}
+        <li class="breadcrumb-item active" aria-current="page">
+          {{ item.text }}
+        </li>
+      {% endif %}
+    {% endfor %}
+    </ol>
+  </nav>
+{% endif %}


### PR DESCRIPTION
This pull request adds breadcrumb settings to `az_quickstart` that mimic the settings that were in place in `ua_zen` @joshuasosa suggested in the original ticket that this could be done using the contrib `easy_breadcrumb` module which is the approach taken in this PR.

## Description
This PR adds the `easy_breadcrumb` module, incorporates it into the install profile, provides default settings for it, and also provides a template override for the barrio breadcrumbs to apply the necessary aria labels, some of which weren't present in the original barrio theme.

By default, the **Home** breadcrumb entry isn't shown, and the "leaf" current breadcrumb showing the page isn't shown, as it's right next to the page title. If the leaf breadcrumb is enabled later, it has the proper aria property.

## Related Issue
#194 

## How Has This Been Tested?
Create nested menu pages and see if

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
