### PR TITLE
Fix [cas:username] token

### DIFF
--- a/modules/custom/az_cas/config/install/cas.settings.yml
+++ b/modules/custom/az_cas/config/install/cas.settings.yml
@@ -51,4 +51,4 @@ advanced:
   connection_timeout: 10
 login_link_enabled: false
 login_link_label: 'Log in using University of Arizona WebAuth'
-login_success_message: 'Logged in via University of Arizona WebAuth as %cas_username.'
+login_success_message: 'Logged in via University of Arizona WebAuth as [cas:username].'


### PR DESCRIPTION
## Description
This change corrects the format of the token that is replaced by the logged in user's account name.

## How Has This Been Tested?
Logged in with CAS, now I see my username

## Types of changes
change %cas_username to [cas:username]
