### PR TITLE
Add weekly dependabot checks for new packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds a config file for github dependabot.

## Description
Adding this dependabot config will generate a PR every Monday if there are available updates for our dependencies. We should still get the dependabot security update PRs as they become available.

For more info, see https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates