### PR TITLE
Fixes #336: Resolve new deprecation errors + various PHP code quality checks improvements

### DIFF
--- a/.ddev/commands/web/drupal-check
+++ b/.ddev/commands/web/drupal-check
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-## Description: Provide drupal-check tooling to check for deprecated custom code.
-## Usage: drupal-check [flags] [args]
-## Example: "ddev drupal-check --version"
-
-vendor/bin/drupal-check web/profiles web/modules web/themes $@

--- a/.ddev/commands/web/phpstan
+++ b/.ddev/commands/web/phpstan
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-## Description: Provide phpstan tooling to check for deprecated contrib module/theme code.
+## Description: Provide phpstan tooling to check for code quality and deprecated code.
 ## Usage: phpstan [flags] [args]
 ## Example: "ddev phpstan --version"
 
-vendor/bin/phpstan --configuration web/profiles/custom/az_quickstart/phpstan.neon web/modules web/themes $@
+vendor/bin/phpstan --configuration web/profiles/custom/az_quickstart/phpstan.neon web/profiles/custom/az_quickstart $@

--- a/.ddev/commands/web/phpstan-contrib
+++ b/.ddev/commands/web/phpstan-contrib
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+## Description: Provide phpstan tooling to check for deprecated contrib module/theme code.
+## Usage: phpstan-contrib [flags] [args]
+## Example: "ddev phpstan-contrib --version"
+
+vendor/bin/phpstan --configuration web/profiles/custom/az_quickstart/phpstan-contrib.neon web/modules web/themes $@

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,8 +14,8 @@ themes/custom/az_barrio/libraries/*.min.js linguist-generated=true
 # Set DDEV command files to lf
 .ddev/commands/web/install text eol=lf
 .ddev/commands/web/drupal text eol=lf
-.ddev/commands/web/drupal-check text eol=lf
 .ddev/commands/web/drush text eol=lf
 .ddev/commands/web/phpcs text eol=lf
 .ddev/commands/web/phpstan text eol=lf
+.ddev/commands/web/phpstan-contrib text eol=lf
 .ddev/commands/web/phpunit text eol=lf

--- a/.lando.yml
+++ b/.lando.yml
@@ -55,14 +55,14 @@ tooling:
   phpunit:
     service: appserver
     cmd: /app/vendor/bin/phpunit --configuration web/profiles/custom/az_quickstart/phpunit.xml.dist --bootstrap web/core/tests/bootstrap.php web/profiles/custom/az_quickstart
-  # Provide drupal-check tooling to check for deprecated custom code.
-  drupal-check:
-    service: appserver
-    cmd: /app/vendor/bin/drupal-check web/profiles
-  # Provide phpstan tooling to check for deprecated contrib module/theme code.
+  # Provide phpstan tooling to check for code quality and deprecated code.
   phpstan:
     service: appserver
-    cmd: /app/vendor/bin/phpstan analyse --configuration web/profiles/custom/az_quickstart/phpstan.neon web/modules web/themes
+    cmd: /app/vendor/bin/phpstan analyse --configuration web/profiles/custom/az_quickstart/phpstan.neon web/profiles/custom/az_quickstart
+  # Provide phpstan tooling to check for deprecated contrib module/theme code.
+  phpstan-contrib:
+    service: appserver
+    cmd: /app/vendor/bin/phpstan analyse --configuration web/profiles/custom/az_quickstart/phpstan-contrib.neon web/modules web/themes
   yarn:
     service: node
     cmd: yarn

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -14,9 +14,15 @@ steps:
       - composer config use-github-api false
       - composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${BRANCH_NAME}
       - composer install -o
-  - name: Drupal Coding Standards
+  - name: Run PHP_CodeSniffer coding standards checks
     plugin: Shell
     command: 'cd $SRC_DIR/az-quickstart-scaffolding ; ./vendor/bin/phpcs -p --colors web/profiles/custom/az_quickstart'
+  - name: Run PHPStan code quality checks
+    plugin: Script
+    script:
+      - cd $SRC_DIR/az-quickstart-scaffolding
+      - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/phpstan analyse --configuration web/profiles/custom/az_quickstart/phpstan.neon web/profiles/custom/az_quickstart
+      - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/phpstan analyse --configuration web/profiles/custom/az_quickstart/phpstan-contrib.neon web/modules web/themes
   - name: Run ESLint
     plugin: Script
     script:
@@ -25,12 +31,6 @@ steps:
       - sudo n 12.18.1
       - npm install --no-progress --global eslint-config-drupal-bundle
       - cd $SRC_DIR/az-quickstart-scaffolding/web/profiles/custom/az_quickstart && eslint --color .
-  - name: Check For Deprecated Code
-    plugin: Script
-    script:
-      - cd $SRC_DIR/az-quickstart-scaffolding
-      - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drupal-check web/profiles
-      - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/phpstan analyse --configuration web/profiles/custom/az_quickstart/phpstan.neon web/modules web/themes
   - name: Install Arizona Quickstart
     plugin: Drupal
     drupalVersion: 8

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -28,7 +28,7 @@ function az_core_help($route_name, RouteMatchInterface $route_match) {
  * Implements hook_pathauto_pattern_alter().
  *
  * Provide a fallback if the current node is not in a menu.
- * Reference: https://www.drupal.org/project/pathauto/issues/2904757#comment-13421490
+ * Reference: https://www.drupal.org/i/2904757#comment-13421490
  */
 function az_core_pathauto_pattern_alter(PathautoPatternInterface $pattern, array $context) {
   // Manually specify default AZQS pattern.

--- a/modules/custom/az_core/src/QuickstartConfigInstaller.php
+++ b/modules/custom/az_core/src/QuickstartConfigInstaller.php
@@ -30,6 +30,7 @@ class QuickstartConfigInstaller extends ConfigInstaller {
     }
     $config_install_path = $this
       ->getDefaultConfigDirectory($type, $name);
+    //phpcs:ignore Security.BadFunctions.FilesystemFunctions.WarnFilesystem
     if (!is_dir($config_install_path)) {
       return;
     }
@@ -96,11 +97,14 @@ class QuickstartConfigInstaller extends ConfigInstaller {
 
     $modified_configuration = [];
     $allowed_overrides = [];
+    // @phpstan-ignore-next-line
     $app_root = \Drupal::root();
     $filename = $app_root . '/' . drupal_get_path($type, $name) . '/' . $name . '.az_config_overrides.yml';
 
+    //phpcs:ignore Security.BadFunctions.FilesystemFunctions.WarnFilesystem
     if (file_exists($filename)) {
       // If an override file exists, parse it for overrides.
+      //phpcs:ignore Security.BadFunctions.FilesystemFunctions.WarnFilesystem
       $yaml = Yaml::decode(file_get_contents($filename));
       if (!empty($yaml['overrides'])) {
         foreach ($yaml['overrides'] as $override) {

--- a/phpstan-contrib.neon
+++ b/phpstan-contrib.neon
@@ -16,10 +16,13 @@ parameters:
 		- '#Call to deprecated method setMethods\(\) of class PHPUnit\\Framework\\MockObject\\MockBuilder.*#'
 		- '#Call to deprecated method expectExceptionMessageRegExp\(\) of class PHPUnit\\Framework\\TestCase.*#'
 		- '#Call to deprecated method readAttribute\(\) of class PHPUnit\\Framework\\Assert.*#'
-		# Ignore missing classes from optional module dependencies.
-		- '#Class Drupal\\(Tests\\)?(diff|entity_browser|feeds).*not found#'
 		# Ignore entitiy_embed cache tag warning (see https://www.drupal.org/project/entity_embed/issues/3087572#comment-13307163).
 		- '#config:entity_view_mode_list cache tag might be unclear and does not contain the cache key in it.#'
+	excludes_analyse:
+		# Exclude files with missing parent classes from optional module dependencies.
+		- */entity_reference_revisions/src/Plugin/diff/Field/EntityReferenceRevisionsFieldDiffBuilder.php
+		- */paragraphs/modules/paragraphs_library/tests/src/FunctionalJavascript/ParagraphsLibraryItemEntityBrowserTest.php
+		- */paragraphs/src/Feeds/*
 includes:
 	- %currentWorkingDirectory%/vendor/mglaman/phpstan-drupal/extension.neon
 	- %currentWorkingDirectory%/vendor/phpstan/phpstan-deprecation-rules/rules.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+	customRulesetUsed: true
+	reportUnmatchedIgnoredErrors: false
+includes:
+	- %currentWorkingDirectory%/vendor/mglaman/phpstan-drupal/extension.neon
+	- %currentWorkingDirectory%/vendor/phpstan/phpstan-deprecation-rules/rules.neon

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -311,6 +311,6 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
  * Submit handler for az_barrio_form_settings.
  */
 function az_barrio_form_system_theme_settings_submit($form, FormStateInterface &$form_state) {
-  // Clear cached library definitions so updated Bootstrap settings take effect immmediately.
+  // Clear cached libraries so any Bootsrap changes take effect immmediately.
   \Drupal::service('library.discovery')->clearCachedDefinitions();
 }


### PR DESCRIPTION
## Description
- Fixes #336 
- Removes drupal-check tooling
- Moves old `phpstan.neon` config to `phpstan-contrib.neon`
- Adds new `phpstan.neon` config for testing custom code
- Addresses various existing code quality check issues

## Related Issue
#336

## How Has This Been Tested?
Locally with lando

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Needed followup issue:
-  Replace `drupal-check` dependency in `az-quickstart-dev` metapackage with `phpstan-drupal`.