### PR TITLE
Closes #344: Update Drupal core to version 9.0.7 (bugfix release) and add akslay's core patch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "drupal/background_image_formatter": "1.7",
         "drupal/bootstrap_barrio": "4.30",
         "drupal/cas": "1.7",
-        "drupal/core-recommended": "9.0.6",
+        "drupal/core-recommended": "9.0.7",
         "drupal/ctools": "3.4",
         "drupal/easy_breadcrumb": "1.13",
         "drupal/externalauth": "1.3",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
             "drupal/core": {
                 "ajax css load order issue": "https://www.drupal.org/files/issues/2020-06-05/1461322-25.patch",
                 "Layout builder revisions issue": "https://www.drupal.org/files/issues/2019-06-17/3033516-17.patch",
-                "Quickedit attributes issue": "https://www.drupal.org/files/issues/2020-07-13/3072231-29-core-9-1-x.patch"
+                "Quickedit attributes issue": "https://www.drupal.org/files/issues/2020-07-13/3072231-29-core-9-1-x.patch",
+                "Document route:<button> in LinkWidget help text": "https://www.drupal.org/files/issues/2020-06-19/3153394-2.patch"
             },
             "drupal/ctools": {
                 "3128339 - d9 test failures": "https://gist.githubusercontent.com/joeparsons/38e27d7d424e5b17575d2987a4b670fb/raw/d55182041e8c87ad26372e06802335ad734fa28e/3128339-11-tests-only.patch"


### PR DESCRIPTION
## Description

- Updates Drupal core to version 9.0.7
- Adds @akslay's core patch which better documents core's accessible nolink menu option (https://www.drupal.org/project/drupal/issues/3153394)

## Related Issue
#344 

## How Has This Been Tested?
Locally with Lando

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
