### PR TITLE
Fixes 292: Add Views Paragraph

### DIFF
--- a/az_quickstart.info.yml
+++ b/az_quickstart.info.yml
@@ -11,6 +11,7 @@ install:
   - az_cas
   - az_paragraphs
   - az_paragraphs_text
+  - az_paragraphs_view
   - az_core
   - az_flexible_page
   - az_demo

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "drupal/token": "1.7",
         "drupal/paragraphs": "1.12",
         "drupal/entity_embed": "1.1",
-        "drupal/embed": "1.4"
+        "drupal/embed": "1.4",
+        "drupal/viewsreference": "2.0-beta2"
     },
     "require-dev": {
         "az-digital/az-quickstart-dev": "~1"

--- a/modules/custom/az_paragraphs/az_paragraphs_view/az_paragraphs_view.info.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/az_paragraphs_view.info.yml
@@ -1,0 +1,11 @@
+name: 'Quickstart Paragraphs - View'
+type: module
+description: 'Provides a view paragraph type.'
+core_version_requirement: ^8.8 || ^9
+dependencies:
+  - az_paragraphs
+  - field
+  - paragraphs
+  - views
+  - viewsreference
+package: 'The University of Arizona'

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/core.entity_form_display.paragraph.az_view_reference.default.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/core.entity_form_display.paragraph.az_view_reference.default.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.az_view_reference.field_az_view_reference
+    - paragraphs.paragraphs_type.az_view_reference
+  module:
+    - viewsreference
+id: paragraph.az_view_reference.default
+targetEntityType: paragraph
+bundle: az_view_reference
+mode: default
+content:
+  field_az_view_reference:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: viewsreference_select
+    region: content
+hidden:
+  created: true
+  status: true

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/core.entity_view_display.paragraph.az_view_reference.default.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/core.entity_view_display.paragraph.az_view_reference.default.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.az_view_reference.field_az_view_reference
+    - paragraphs.paragraphs_type.az_view_reference
+  module:
+    - viewsreference
+id: paragraph.az_view_reference.default
+targetEntityType: paragraph
+bundle: az_view_reference
+mode: default
+content:
+  field_az_view_reference:
+    weight: 0
+    label: hidden
+    settings:
+      plugin_types:
+        default: default
+        page: page
+        block: block
+        feed: 0
+    third_party_settings: {  }
+    type: viewsreference_formatter
+    region: content
+hidden: {  }

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_view_reference.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_view_reference.yml
@@ -26,19 +26,7 @@ settings:
     page: page
     block: block
     feed: 0
-  preselect_views:
-    block_content: 0
-    content: 0
-    content_recent: 0
-    files: 0
-    frontpage: 0
-    media: 0
-    media_library: 0
-    taxonomy_term: 0
-    user_admin_people: 0
-    watchdog: 0
-    who_s_new: 0
-    who_s_online: 0
+  preselect_views: {  }
   enabled_settings:
     limit: limit
     title: title

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_view_reference.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_view_reference.yml
@@ -1,0 +1,48 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_az_view_reference
+    - paragraphs.paragraphs_type.az_view_reference
+  module:
+    - viewsreference
+id: paragraph.az_view_reference.field_az_view_reference
+field_name: field_az_view_reference
+entity_type: paragraph
+bundle: az_view_reference
+label: View
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:view'
+  handler_settings:
+    target_bundles: null
+    auto_create: 0
+  plugin_types:
+    default: default
+    page: page
+    block: block
+    feed: 0
+  preselect_views:
+    block_content: 0
+    content: 0
+    content_recent: 0
+    files: 0
+    frontpage: 0
+    media: 0
+    media_library: 0
+    taxonomy_term: 0
+    user_admin_people: 0
+    watchdog: 0
+    who_s_new: 0
+    who_s_online: 0
+  enabled_settings:
+    limit: limit
+    title: title
+    argument: argument
+    pager: pager
+    offset: 0
+field_type: viewsreference

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.storage.paragraph.field_az_view_reference.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.storage.paragraph.field_az_view_reference.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - views
+    - viewsreference
+id: paragraph.field_az_view_reference
+field_name: field_az_view_reference
+entity_type: paragraph
+type: viewsreference
+settings:
+  target_type: view
+module: viewsreference
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/paragraphs.paragraphs_type.az_view_reference.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/paragraphs.paragraphs_type.az_view_reference.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - az_paragraphs
+id: az_view_reference
+label: View
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins:
+  az_default_paragraph_behavior:
+    enabled: true

--- a/themes/custom/az_barrio/templates/field/viewsreference--view-title.html.twig
+++ b/themes/custom/az_barrio/templates/field/viewsreference--view-title.html.twig
@@ -1,0 +1,3 @@
+<h2 class="viewsreference--view-title">
+    {{ title }}
+</h2>


### PR DESCRIPTION
This pull request adds the `viewsreference` module, and an associated paragraph bundle for creating views references.

## Description
This pull request adds the `viewsreference` module, and adds a related `az_paragraphs_view` module that is responsible for creating a View paragraph. A template is also added that causes the view title to be rendered as an h2, eg. as a block title. By default it was rendered as a div. The module is set to be enabled by default in the install profile.

## Related Issue
#292 

## How Has This Been Tested?

1. Verify that the Views paragraph exists (`az_view_reference`)
2. Create content.
3. Add a paragraph using the Add View button.
4. Select one of the default system views for testing purposes.
5. Save the content.
6. Verify that the view is rendered in the resultant page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
