### PR TITLE
Remove hirak/prestissimo from github actions

### DIFF
--- a/.github/workflows/create-upload-release.yml
+++ b/.github/workflows/create-upload-release.yml
@@ -17,7 +17,6 @@ jobs:
         run: echo "AZ_TRIMMED_REF=${GITHUB_REF#refs/*/}" >> ${GITHUB_ENV}
       - name: Build project # This would actually build your project, using zip for an example artifact
         run: |
-          composer global require hirak/prestissimo
           git clone https://github.com/az-digital/az-quickstart-scaffolding.git az_quickstart
           cd az_quickstart
           composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,6 @@ jobs:
           ref: ${{ env.SCAFFOLD_BRANCH }}
       - name: Install dependencies
         run: |
-          composer global require hirak/prestissimo
           cd az-quickstart-scaffolding
           composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
           composer config use-github-api false
@@ -49,7 +48,6 @@ jobs:
         run: echo "AZ_TRIMMED_REF=${GITHUB_REF#refs/*/}" >> ${GITHUB_ENV}
       - name: Install dependencies
         run: |
-          composer global require hirak/prestissimo
           if [ $(git ls-remote --heads https://github.com/az-digital/az-quickstart-scaffolding.git $AZ_TRIMMED_REF | wc -l) = 1 ]; then SCAFFOLD_BRANCH="$AZ_TRIMMED_REF"; else SCAFFOLD_BRANCH=main; fi
           git clone --branch $SCAFFOLD_BRANCH https://github.com/az-digital/az-quickstart-scaffolding.git
           cd az-quickstart-scaffolding


### PR DESCRIPTION
## Description
hirak/prestissimo is abandoned and not supported by Composer 2 according to the official documentation

> This is a composer 1.x plugin that downloads packages in parallel to speed up the installation process.
> 
> Announcement: Composer 2 is now available!
> This plugin is for Composer1; Composer2 is very fast on its own. Uninstall this plugin and update the Composer itself.

https://github.com/hirak/prestissimo
Closes #364 