### PR TITLE
Updated main branch alias to be 2.1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.x-dev"
+            "dev-main": "2.1.x-dev"
         },
         "patches": {
             "drupal/core": {


### PR DESCRIPTION
## Description
Change `dev-main` alias to reference 2.1.x instead of 2.x