### PR TITLE
Fixes #386: Update Paragraph Preview Styles

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
@@ -14,3 +14,11 @@ az_paragraphs.az_cards:
   dependencies:
     - az_barrio/global-styling
     - az_barrio/arizona-bootstrap
+az_paragraphs.preview:
+  version: VERSION
+  css:
+    theme:
+      css/az_paragraphs_preview.css: {}
+  dependencies:
+    - az_barrio/global-styling
+    - az_barrio/arizona-bootstrap

--- a/modules/custom/az_paragraphs/css/az_paragraphs_preview.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_preview.css
@@ -1,0 +1,27 @@
+/* Styles for quickstart paragraph previews.  */
+
+.js .paragraph-type-label::before {
+    content: "Type: ";
+    font-weight: bold;
+}
+
+.js .paragraph-top {
+    display: -ms-grid;
+    display: grid;
+    -ms-grid-columns: 100px auto 1fr auto;
+    grid-template-columns: 100px auto 1fr auto;
+    -ms-grid-rows: auto auto;
+    grid-template-rows: auto auto;
+    grid-gap: 0 5px;
+    -webkit-box-align: baseline;
+    -webkit-align-items: baseline;
+    -ms-flex-align: baseline;
+    align-items: baseline;
+    border-bottom: 1px solid #ccc;
+}
+
+.paragraph--view-mode--preview {
+    padding-right: 1em;
+    max-height: 200px;
+    overflow: hidden;
+}

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZDefaultParagraphsBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZDefaultParagraphsBehavior.php
@@ -148,6 +148,9 @@ class AZDefaultParagraphsBehavior extends ParagraphsBehaviorBase {
    */
   public function preprocess(&$variables) {
 
+    // Libraries to attach to this paragraph.
+    $libraries = [];
+
     /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
     $paragraph = $variables['paragraph'];
 
@@ -156,14 +159,25 @@ class AZDefaultParagraphsBehavior extends ParagraphsBehaviorBase {
 
     // Get the paragraph bundle name and compute name of potential library.
     $bundle = $paragraph->bundle();
-    $name = 'az_paragraphs.' . $bundle;
+    $libraries[] = 'az_paragraphs.' . $bundle;
 
-    // Check if az_paragraphs implements library for the  paragraph bundle.
-    $library = $this->libraryDiscovery->getLibraryByName('az_paragraphs', $name);
+    // Generate library names to check based on view mode.
+    if (!empty($variables['view_mode'])) {
+      // Potential library for paragraph view mode.
+      $libraries[] = 'az_paragraphs.' . $variables['view_mode'];
+      // Bundle-specific view mode libraries.
+      $libraries[] = 'az_paragraphs.' . $bundle . '_' . $variables['view_mode'];
+    }
 
-    // If we found a library, attach it to the paragraph.
-    if ($library) {
-      $variables['#attached']['library'][] = 'az_paragraphs/' . $name;
+    // Check if any of the potential library names actually exist.
+    foreach ($libraries as $name) {
+      // Check if library discovery service knows about the library.
+      $library = $this->libraryDiscovery->getLibraryByName('az_paragraphs', $name);
+
+      if ($library) {
+        // If we found a library, attach it to the paragraph.
+        $variables['#attached']['library'][] = 'az_paragraphs/' . $name;
+      }
     }
   }
 


### PR DESCRIPTION
This PR adds some preview-mode specific paragraph styles proposed by @danahertzberg  to make it easier to reorder collapsed paragraphs.

## Description
This PR adds some CSS for paragraph preview modes that enforces a height limit on paragraph previews proposed by @danahertzberg - the intent is that long previews are truncated in height so they can still be reordered easily.

To accomplish this, the PR also adds an extension to our existing library system. We previously had in place functionality that could load paragraph-specific libraries; that functionality has been expanded to allow for view-mode specific libraries and per-bundle-view-mode-specific libraries. The system is put into use to load a CSS library for paragraph previews.

This customization is to paragraph preview modes only, and does not apply to active long field edit forms.

## Related Issue
#386 

## How Has This Been Tested?
- Create paragraph content of significant length (eg. long text, long card deck)
- Verify that the preview mode of the paragraphs (collapsed, not the edit form) are truncated in height

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
