### PR TITLE
#391: Updated Drupal core to version 9.0.9 (critical security update for SA-CORE-2020-013).

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "drupal/background_image_formatter": "1.7",
         "drupal/bootstrap_barrio": "4.30",
         "drupal/cas": "1.7",
-        "drupal/core-recommended": "9.0.8",
+        "drupal/core-recommended": "9.0.9",
         "drupal/ctools": "3.4",
         "drupal/easy_breadcrumb": "1.13",
         "drupal/externalauth": "1.3",


### PR DESCRIPTION
## Description
https://www.drupal.org/sa-core-2020-013

## Related Issue
#391 
