### PR TITLE
remove hirak/prestissimo

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -8,8 +8,6 @@ config:
   xdebug: false
 services:
   appserver:
-    composer:
-      hirak/prestissimo: ^0.3.9
     overrides:
       environment:
         SIMPLETEST_DB: 'mysql://drupal8:drupal8@database/drupal8'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove hirak/prestissimo from .lando file since it is now outdated with composer2

According to the official documentation on this page
https://github.com/hirak/prestissimo
We should no longer be using it.

Closes #405 