### PR TITLE
Updating the PR template to add a configuration checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -19,6 +19,7 @@
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Configuration change (change that will need to be merged in to existing sites)
 
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->


### PR DESCRIPTION
This pull request adds a checkbox to track whether or not someones pull request is going to add configuration changes to Quickstart.

## Description
I added a line to the "Types of Changes" section: 
- [ ] Configuration change (change that will need to be merged in to existing sites)

## Related Issue
Closes Task/419


## Types of changes
Minor documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
