### PR TITLE
Remove all references to Milo font.

### DIFF
--- a/themes/custom/az_barrio/css/style.css
+++ b/themes/custom/az_barrio/css/style.css
@@ -391,7 +391,6 @@ a.nolink + ul .sf-clone-parent {
   color: #0c234b;
   font-size: 28px;
   font-size: 1.8rem;
-  font-family: MiloSerifWeb, TimesNewRoman, "Times New Roman", Times, Baskerville, Georgia, serif;
   text-transform: none;
   line-height: 1.4;
 }
@@ -664,6 +663,5 @@ fieldset.collapsed {
 
 .site-footer {
   padding-bottom: 0;
-  font-family: MiloWeb-Text, Verdana, Geneva, sans-serif;
   color: #49595e;
 }


### PR DESCRIPTION
## Description
Remove vestigial references to the Milo font family in az_barrio theme stylesheets

## Related Issue
Closes #422 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
