### PR TITLE
Make composer sort packages alphabetically.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "drupal/config_sync": "2.0-beta7",
         "drupal/config_update": "1.7",
         "drupal/core-recommended": "9.1.3",
+        "drupal/crop": "2.1",
         "drupal/ctools": "3.4",
         "drupal/date_ap_style": "^1.0",
         "drupal/draggableviews": "2.0.0",
@@ -45,6 +46,7 @@
         "drupal/externalauth": "1.3",
         "drupal/field_group": "3.1",
         "drupal/field_group_link": "^3.0@RC",
+        "drupal/image_widget_crop": "2.3",
         "drupal/media_library_form_element": "2.0",
         "drupal/media_library_theme_reset": "1.0",
         "drupal/metatag": "1.15",
@@ -58,9 +60,7 @@
         "drupal/token": "1.7",
         "drupal/views_bootstrap": "4.3",
         "drupal/viewsreference": "2.0-beta2",
-        "drupal/xmlsitemap": "1.0",
-        "drupal/crop": "2.1",
-        "drupal/image_widget_crop": "2.3"
+        "drupal/xmlsitemap": "1.0"
     },
     "require-dev": {
         "az-digital/az-quickstart-dev": "~1"
@@ -100,5 +100,8 @@
                 "Coffee test, support for Drupal 9 core_version_requirement": "https://www.drupal.org/files/issues/2020-10-27/3174680-5-make-test-module-d9-compatible.patch"
             }
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
Adds [`sort-package: true`](https://getcomposer.org/doc/06-config.md#sort-packages) to the composer config, and also sorts the existing packages so the next `composer require` will have a clean diff.

## Description
Closes #462 by adding sort-packages setting to composer config and sorting the existing packages.

## Related Issue
#462 

## How Has This Been Tested?
I tested that the new config is working by first adding it via `composer config sort-packages true`, then requiring an existing package via `composer require drupal/cas` to trigger the sort. I verified that the dependencies were all still there, just in alphabetical order.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
