### PR TITLE
Issue/473 Fix logo styling and update logo path to use relative url.

### DIFF
--- a/themes/custom/az_barrio/az_barrio.info.yml
+++ b/themes/custom/az_barrio/az_barrio.info.yml
@@ -3,8 +3,8 @@ type: theme
 description: 'Basic structure for a Bootstrap Barrio SubTheme.'
 core_version_requirement: ^8.8 || ^9
 base theme: bootstrap_barrio
-logo: az_barrio/logo.png
-footer_logo: az_barrio/footer_logo.png
+logo: az_barrio/images/logo.png
+footer_logo: az_barrio/images/logo.png
 block_default_region: 'content'
 
 libraries:

--- a/themes/custom/az_barrio/az_barrio.info.yml
+++ b/themes/custom/az_barrio/az_barrio.info.yml
@@ -3,8 +3,8 @@ type: theme
 description: 'Basic structure for a Bootstrap Barrio SubTheme.'
 core_version_requirement: ^8.8 || ^9
 base theme: bootstrap_barrio
-logo: az_barrio/images/logo.png
-footer_logo: az_barrio/images/logo.png
+logo: images/logo.png
+footer_logo: images/logo.png
 block_default_region: 'content'
 
 libraries:

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -388,7 +388,7 @@ function az_barrio_primary_logo() {
   $primary_logo_path_parts = pathinfo($primary_logo_path['path']);
   $primary_alt_text = Html::escape(theme_get_setting('primary_logo_alt_text'));
   $primary_title_text = Html::escape(theme_get_setting('primary_logo_title_text'));
-
+  $config = \Drupal::config('az_barrio.settings');
   if (\Drupal::moduleHandler()->moduleExists('token')) {
     $token_service = \Drupal::token();
     $primary_alt_text = $token_service->replace($primary_alt_text);
@@ -414,10 +414,18 @@ function az_barrio_primary_logo() {
       );
     }
     else {
-      $image = '<img src="' . file_url_transform_relative(file_create_url($primary_logo_path['path'])) . '" alt="' . $primary_alt_text . '" class="img-fluid" />';
-      $rendered_image = render($image);
-      $image_markup = Markup::create($rendered_image);
-      $return = Link::createFromRoute($image_markup, '<front>', [], [
+      $image_renderable = [
+        '#theme' => 'image',
+        '#uri' => $primary_logo_path['path'],
+        '#alt' => $primary_alt_text,
+        '#attributes' => [
+          'class' => ['img-fluid'],
+        ]
+      ];
+      $renderer = \Drupal::service('renderer');
+      $renderer->addCacheableDependency($image_renderable, $config);
+      $image_rendered = $renderer->render($image_renderable);
+      $return = Link::createFromRoute($image_rendered,'<front>', [], [
         'attributes' => [
           'title' => $primary_title_text,
           'class' => $primary_logo_link_classes,
@@ -443,6 +451,7 @@ function az_barrio_footer_logo() {
   $footer_link_destination = theme_get_setting('footer_logo_link_destination');
   $footer_alt_text = Html::escape(theme_get_setting('footer_logo_alt_text'));
   $footer_title_text = Html::escape(theme_get_setting('footer_logo_title_text'));
+  $config = \Drupal::config('az_barrio.settings');
   if (\Drupal::moduleHandler()->moduleExists('token')) {
     $token_service = \Drupal::token();
     $footer_alt_text = $token_service->replace($footer_alt_text);
@@ -467,11 +476,19 @@ function az_barrio_footer_logo() {
       ]);
     }
     else {
-      $image = '<img src="' . file_url_transform_relative(file_create_url($footer_logo_path)). '" alt="' . $footer_alt_text . '" class="img-fluid" />';
-      $rendered_image = render($image);
-      $image_markup = Markup::create($rendered_image);
+      $image_renderable = [
+        '#theme' => 'image',
+        '#uri' => $footer_logo_path,
+        '#alt' => $footer_alt_text,
+        '#attributes' => [
+          'class' => ['img-fluid'],
+        ]
+      ];
+      $renderer = \Drupal::service('renderer');
+      $renderer->addCacheableDependency($image_renderable, $config);
+      $image_rendered = $renderer->render($image_renderable);
       $footer_link_destination = (!empty($footer_link_destination)) ? $footer_link_destination : '<front>';
-      $return = Link::createFromRoute($image_markup, $footer_link_destination, [], [
+      $return = Link::createFromRoute($image_rendered, $footer_link_destination, [], [
         'attributes' => [
           'title' => $footer_title_text,
           'alt' => $footer_alt_text,

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -396,7 +396,6 @@ function az_barrio_primary_logo() {
 
   // Set primary logo.
   if (!empty($primary_logo_path)) {
-    $url = file_create_url($primary_logo_path['path']);
 
     // Inline SVG logo.
     if (theme_get_setting('az_barrio_logo_svg_inline') === TRUE && $primary_logo_path_parts['extension'] === 'svg') {
@@ -413,7 +412,7 @@ function az_barrio_primary_logo() {
       );
     }
     else {
-      $image = '<img src="' . $url . '" alt="' . $primary_alt_text . '" class="img-fluid" />';
+      $image = '<img src="/' . $primary_logo_path['path'] . '" alt="' . $primary_alt_text . '" class="img-fluid" />';
       $rendered_image = render($image);
       $image_markup = Markup::create($rendered_image);
       $return = Link::createFromRoute($image_markup, '<front>', [], [
@@ -465,8 +464,7 @@ function az_barrio_footer_logo() {
       ]);
     }
     else {
-      $url = file_create_url($footer_logo_path);
-      $image = '<img src="' . $url . '" alt="' . $footer_alt_text . '" class="img-fluid pb-4" />';
+      $image = '<img src=/"' . $footer_logo_path . '" alt="' . $footer_alt_text . '" class="img-fluid pb-4" />';
       $rendered_image = render($image);
       $image_markup = Markup::create($rendered_image);
       $footer_link_destination = (!empty($footer_link_destination)) ? $footer_link_destination : '<front>';

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -383,6 +383,7 @@ function az_barrio_brand_icons_assets_path($type) {
  */
 function az_barrio_primary_logo() {
   $return = '';
+  $primary_logo_link_classes = ['qs-site-logo', 'd-block'];
   $primary_logo_path = theme_get_setting('logo');
   $primary_logo_path_parts = pathinfo($primary_logo_path['path']);
   $primary_alt_text = Html::escape(theme_get_setting('primary_logo_alt_text'));
@@ -402,10 +403,11 @@ function az_barrio_primary_logo() {
       $svg = file_get_contents(DRUPAL_ROOT . '/' . $primary_logo_path['url']);
       $rendered_image = render($svg);
       $image_markup = Markup::create($rendered_image);
+      $primary_logo_link_classes[] = 'qs-logo-svg-inline';
       $return = Link::createFromRoute($image_markup, '<front>', [], [
         'attributes' => [
           'title' => $primary_title_text,
-          'class' => ['header_logo_svg'],
+          'class' => $primary_logo_link_classes,
           'rel' => 'home',
         ],
       ]
@@ -419,7 +421,7 @@ function az_barrio_primary_logo() {
         'attributes' => [
           'title' => $primary_title_text,
           'alt' => $primary_alt_text,
-          'class' => ['header_logo'],
+          'class' => $primary_logo_link_classes,
           'rel' => 'home',
         ],
       ]);
@@ -435,7 +437,9 @@ function az_barrio_primary_logo() {
 
 function az_barrio_footer_logo() {
   $return = '';
+  $footer_logo_link_classes = ['qs-site-logo', 'd-block', 'mt-0'];
   $footer_logo_path = theme_get_setting('footer_logo_path');
+  $footer_logo_default = theme_get_setting('footer_default_logo');
   $footer_logo_path_parts = pathinfo($footer_logo_path);
   $footer_link_destination = theme_get_setting('footer_logo_link_destination');
   $footer_alt_text = Html::escape(theme_get_setting('footer_logo_alt_text'));
@@ -447,38 +451,44 @@ function az_barrio_footer_logo() {
   }
 
   // Set footer logo.
-  if (!empty($footer_logo_path)) {
+  if (!empty($footer_logo_path) && !$footer_logo_default) {
     $filepath = \Drupal::service('file_system')->realpath($footer_logo_path);
     // Inline SVG logo.
     if (theme_get_setting('az_barrio_footer_logo_svg_inline') === TRUE && $footer_logo_path_parts['extension'] === 'svg') {
       $svg = file_get_contents($filepath);
       $rendered_image = render($svg);
       $image_markup = Markup::create($rendered_image);
-      $return = Link::createFromRoute($image_markup, '<front>', [], [
+      $footer_logo_link_classes[] = 'qs-logo-svg-inline';
+      $return = Link::createFromRoute($image_markup, $footer_link_destination, [], [
         'attributes' => [
           'title' => $footer_title_text,
           'alt' => $footer_alt_text,
-          'class' => ['footer_logo_svg'],
+          'class' => $footer_logo_link_classes,
           'rel' => 'home',
         ],
       ]);
     }
     else {
-      $image = '<img src=/"' . $footer_logo_path . '" alt="' . $footer_alt_text . '" class="img-fluid pb-4" />';
+      $image = '<img src="/' . $footer_logo_path . '" alt="' . $footer_alt_text . '" class="img-fluid" />';
       $rendered_image = render($image);
       $image_markup = Markup::create($rendered_image);
       $footer_link_destination = (!empty($footer_link_destination)) ? $footer_link_destination : '<front>';
       $return = Link::createFromRoute($image_markup, $footer_link_destination, [], [
         'attributes' => [
           'title' => $footer_title_text,
+          'alt' => $footer_alt_text,
           'rel' => 'home',
+          'class' => $footer_logo_link_classes,
         ],
       ]);
     }
   }
   // Fallback to primary logo when footer logo settings are not configured.
   else {
-    $return = az_barrio_primary_logo();
+    $footer_logo = az_barrio_primary_logo();
+    $footer_logo = $footer_logo->toRenderable();
+    $footer_logo['#attributes']['class'][] = 'mt-0';
+    $return = $footer_logo;
   }
 
   return $return;

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -424,8 +424,7 @@ function az_barrio_primary_logo() {
       ];
       $renderer = \Drupal::service('renderer');
       $renderer->addCacheableDependency($image_renderable, $config);
-      $image_rendered = $renderer->render($image_renderable);
-      $return = Link::createFromRoute($image_rendered,'<front>', [], [
+      $return = Link::createFromRoute($image_renderable,'<front>', [], [
         'attributes' => [
           'title' => $primary_title_text,
           'class' => $primary_logo_link_classes,
@@ -486,9 +485,8 @@ function az_barrio_footer_logo() {
       ];
       $renderer = \Drupal::service('renderer');
       $renderer->addCacheableDependency($image_renderable, $config);
-      $image_rendered = $renderer->render($image_renderable);
       $footer_link_destination = (!empty($footer_link_destination)) ? $footer_link_destination : '<front>';
-      $return = Link::createFromRoute($image_rendered, $footer_link_destination, [], [
+      $return = Link::createFromRoute($image_renderable, $footer_link_destination, [], [
         'attributes' => [
           'title' => $footer_title_text,
           'alt' => $footer_alt_text,

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -414,13 +414,12 @@ function az_barrio_primary_logo() {
       );
     }
     else {
-      $image = '<img src="/' . $primary_logo_path['path'] . '" alt="' . $primary_alt_text . '" class="img-fluid" />';
+      $image = '<img src="' . file_url_transform_relative(file_create_url($primary_logo_path['path'])) . '" alt="' . $primary_alt_text . '" class="img-fluid" />';
       $rendered_image = render($image);
       $image_markup = Markup::create($rendered_image);
       $return = Link::createFromRoute($image_markup, '<front>', [], [
         'attributes' => [
           'title' => $primary_title_text,
-          'alt' => $primary_alt_text,
           'class' => $primary_logo_link_classes,
           'rel' => 'home',
         ],
@@ -462,14 +461,13 @@ function az_barrio_footer_logo() {
       $return = Link::createFromRoute($image_markup, $footer_link_destination, [], [
         'attributes' => [
           'title' => $footer_title_text,
-          'alt' => $footer_alt_text,
           'class' => $footer_logo_link_classes,
           'rel' => 'home',
         ],
       ]);
     }
     else {
-      $image = '<img src="/' . $footer_logo_path . '" alt="' . $footer_alt_text . '" class="img-fluid" />';
+      $image = '<img src="' . file_url_transform_relative(file_create_url($footer_logo_path)). '" alt="' . $footer_alt_text . '" class="img-fluid" />';
       $rendered_image = render($image);
       $image_markup = Markup::create($rendered_image);
       $footer_link_destination = (!empty($footer_link_destination)) ? $footer_link_destination : '<front>';

--- a/themes/custom/az_barrio/css/style.css
+++ b/themes/custom/az_barrio/css/style.css
@@ -118,13 +118,6 @@ audio:not([controls]) {
     margin: 1.938rem 0;
   }
 }
-.qs-logo-svg-inline svg{
-}
-
-@media (min-width: 48em) {
-  .qs-logo-svg-inline svg{
-  }
-}
 
 /**
  * Inline styles.

--- a/themes/custom/az_barrio/css/style.css
+++ b/themes/custom/az_barrio/css/style.css
@@ -88,38 +88,41 @@ audio:not([controls]) {
  * Branding header.
  */
 /* Wrapping link for logo. */
-.header_logo {
-  width: 100%;
-  text-align: center;
-  margin: 24px 0;
-  margin: 1.5rem 0;
-  padding: 0;
+.qs-site-logo {
+  margin: 40px 0;
+  margin: 2.5rem 0;
 }
-
-@media (min-width: 48em) {
-  .header_logo {
-    width: auto;
-    text-align: left;
-    margin: 40px 0;
-    margin: 2.5rem 0;
+@media (min-width: 576px) {
+  .qs-site-logo {
+    margin: 22px 0;
+    margin: 1.375rem 0;
   }
 }
-/* Wrapping link for logo. */
-.header_logo_svg {
-  float: left;
-  width: 100%;
-  text-align: center;
-  margin: 24px 0;
-  margin: 1.5rem 0;
-  padding: 0;
+@media (min-width: 768px) {
+  .qs-site-logo {
+    margin: 31px 0;
+    margin: 1.938rem 0;
+  }
+}
+
+@media (min-width: 992px) {
+  .qs-site-logo {
+    margin: 29px 0;
+    margin: 1.813rem 0;
+  }
+}
+
+@media (min-width: 1200px) {
+  .qs-site-logo {
+    margin: 31px 0;
+    margin: 1.938rem 0;
+  }
+}
+.qs-logo-svg-inline svg{
 }
 
 @media (min-width: 48em) {
-  .header_logo_svg{
-    width: 100%;
-    text-align: left;
-    margin: 40px 0;
-    margin: 2.5rem 0;
+  .qs-logo-svg-inline svg{
   }
 }
 

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -282,12 +282,6 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   ];
-  $form['footer_logo']['az_barrio_footer_logo_svg_inline'] = [
-    '#type' => 'checkbox',
-    '#title' => t('Inline footer logo SVG'),
-    '#default_value' => theme_get_setting('az_barrio_footer_logo_svg_inline') ? TRUE : FALSE,
-    '#description' => t('If logo is SVG image then inline it content in the page instead of using image tag to render it. This is useful when you need to control SVG logo with theme CSS.'),
-  ];
   $form['footer_logo']['footer_default_logo'] = [
     '#type' => 'checkbox',
     '#title' => t('Use the default logo'),
@@ -306,30 +300,11 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
       ],
     ],
   ];
-  $form['footer_logo']['footer_logo_link_destination'] = [
-    '#type' => 'textfield',
-    '#title' => t('Footer logo link destination'),
-    '#description' => t('Where should the footer logo link to. Example: &#x3C;front&#x3E;'),
-    '#default_value' => theme_get_setting('footer_logo_link_destination'),
-  ];
-  $form['footer_logo']['footer_logo_alt_text'] = [
-    '#type' => 'textfield',
-    '#title' => t('Footer logo alt text'),
-    '#description' => t('Alternative text is used by screen readers, search engines, and when the image cannot be loaded. By adding alt text you improve accessibility and search engine optimization.'),
-    '#default_value' => theme_get_setting('footer_logo_alt_text'),
-    '#element_validate' => ['token_element_validate'],
-  ];
-  $form['footer_logo']['footer_logo_title_text'] = [
-    '#type' => 'textfield',
-    '#title' => t('Footer logo title text'),
-    '#description' => t('Title text is used in the tool tip when a user hovers their mouse over the image. Adding title text makes it easier to understand the context of an image and improves usability.'),
-    '#default_value' => theme_get_setting('footer_logo_title_text'),
-    '#element_validate' => ['token_element_validate'],
-  ];
-  $form['footer_logo']['tokens'] = [
-    '#theme' => 'token_tree_link',
-    '#global_types' => TRUE,
-    '#click_insert' => TRUE,
+  $form['footer_logo']['settings']['az_barrio_footer_logo_svg_inline'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Inline footer logo SVG'),
+    '#default_value' => theme_get_setting('az_barrio_footer_logo_svg_inline') ? TRUE : FALSE,
+    '#description' => t('If logo is SVG image then inline it content in the page instead of using image tag to render it. This is useful when you need to control SVG logo with theme CSS.'),
   ];
   $form['footer_logo']['settings']['footer_logo_path'] = [
     '#type' => 'textfield',
@@ -347,6 +322,35 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
         'png gif jpg jpeg apng svg',
       ],
     ],
+  ];
+
+  $form['footer_logo']['settings']['footer_logo_link_destination'] = [
+    '#required' => TRUE,
+    '#type' => 'textfield',
+    '#title' => t('Footer logo link destination'),
+    '#description' => t('Where should the footer logo link to. Example: &#x3C;front&#x3E;'),
+    '#default_value' => theme_get_setting('footer_logo_link_destination'),
+  ];
+  $form['footer_logo']['settings']['footer_logo_alt_text'] = [
+    '#required' => TRUE,
+    '#type' => 'textfield',
+    '#title' => t('Footer logo alt text'),
+    '#description' => t('Alternative text is used by screen readers, search engines, and when the image cannot be loaded. By adding alt text you improve accessibility and search engine optimization.'),
+    '#default_value' => theme_get_setting('footer_logo_alt_text'),
+    '#element_validate' => ['token_element_validate'],
+  ];
+  $form['footer_logo']['settings']['footer_logo_title_text'] = [
+    '#required' => TRUE,
+    '#type' => 'textfield',
+    '#title' => t('Footer logo title text'),
+    '#description' => t('Title text is used in the tool tip when a user hovers their mouse over the image. Adding title text makes it easier to understand the context of an image and improves usability.'),
+    '#default_value' => theme_get_setting('footer_logo_title_text'),
+    '#element_validate' => ['token_element_validate'],
+  ];
+  $form['footer_logo']['settings']['tokens'] = [
+    '#theme' => 'token_tree_link',
+    '#global_types' => TRUE,
+    '#click_insert' => TRUE,
   ];
   $form['#validate'][] = 'az_barrio_form_system_theme_settings_validate';
   $form['#submit'][] = 'az_barrio_form_system_theme_settings_submit';


### PR DESCRIPTION
## Description
Made the use default logo checkbox functional.
Made footer logo fields conditional to the default logo checkbox
Made footer logo fields for alt, title, destination required if using a custom logo.
Added styles to footer logo to comply with brand guidelines

<img width="709" alt="logo-control-space" src="https://user-images.githubusercontent.com/1023167/107439714-b9b05080-6aef-11eb-81c4-ad5158c2ef4a.png">

## Related Issue
Closes #473
Closes #497 

## How Has This Been Tested?
1. build site and see if the default logo looks appropriate.
2. in the footer logo area of the theme check the "use default logo" checkbox and see if the footer logo uses the default logo and is formatted correctly and check the inspector console for image mixed media errors
3. add a new SVG footer logo and SVG header logo and check if the two logos are different and styled appropriately and check the inspector console for image mixed media errors.
4. check the boxes to inline the svg logos and check that the logos are styled appropriately.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [ ] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.
