### PR TITLE
Fixes #490 Makes plain text fields formatted text with plain text

### DIFF
--- a/modules/custom/az_core/config/install/field.storage.node.field_az_caption.yml
+++ b/modules/custom/az_core/config/install/field.storage.node.field_az_caption.yml
@@ -3,13 +3,13 @@ status: true
 dependencies:
   module:
     - node
+    - text
 id: node.field_az_caption
 field_name: field_az_caption
 entity_type: node
-type: string_long
-settings:
-  case_sensitive: false
-module: core
+type: text_long
+settings: {  }
+module: text
 locked: false
 cardinality: 1
 translatable: true

--- a/modules/custom/az_core/config/install/field.storage.node.field_az_subheading.yml
+++ b/modules/custom/az_core/config/install/field.storage.node.field_az_subheading.yml
@@ -3,15 +3,14 @@ status: true
 dependencies:
   module:
     - node
+    - text
 id: node.field_az_subheading
 field_name: field_az_subheading
 entity_type: node
-type: string
+type: text
 settings:
   max_length: 255
-  is_ascii: false
-  case_sensitive: false
-module: core
+module: text
 locked: false
 cardinality: 1
 translatable: true

--- a/modules/custom/az_core/config/install/field.storage.node.field_az_summary.yml
+++ b/modules/custom/az_core/config/install/field.storage.node.field_az_summary.yml
@@ -3,13 +3,13 @@ status: true
 dependencies:
   module:
     - node
+    - text
 id: node.field_az_summary
 field_name: field_az_summary
 entity_type: node
-type: string_long
-settings:
-  case_sensitive: false
-module: core
+type: text_long
+settings: {  }
+module: text
 locked: false
 cardinality: 1
 translatable: true

--- a/modules/custom/az_event/config/install/core.entity_form_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_form_display.node.az_event.default.yml
@@ -4,8 +4,8 @@ dependencies:
   config:
     - field.field.node.az_event.field_az_attachments
     - field.field.node.az_event.field_az_body
-    - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_event_category
+    - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_link
     - field.field.node.az_event.field_az_location
     - field.field.node.az_event.field_az_photos
@@ -25,7 +25,6 @@ third_party_settings:
   field_group:
     group_summary:
       children:
-        - field_az_short_title
         - field_az_link
         - field_az_summary
       parent_name: ''
@@ -66,6 +65,12 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
+  field_az_event_category:
+    weight: 9
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   field_az_event_date:
     weight: 11
     settings:
@@ -84,12 +89,6 @@ content:
           MINUTELY: 0
           HOURLY: 0
     type: smartdate_default
-    region: content
-  field_az_event_category:
-    weight: 9
-    settings: {  }
-    third_party_settings: {  }
-    type: options_select
     region: content
   field_az_link:
     weight: 27
@@ -114,21 +113,21 @@ content:
       media_types: {  }
     third_party_settings: {  }
     region: content
-  field_az_summary:
-    weight: 28
-    settings:
-      rows: 5
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textarea
-    region: content
   field_az_subheading:
     weight: 8
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
+    type: text_textfield
+    region: content
+  field_az_summary:
+    weight: 28
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
     region: content
   path:
     type: path

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
@@ -5,18 +5,19 @@ dependencies:
     - core.entity_view_mode.node.az_row
     - field.field.node.az_event.field_az_attachments
     - field.field.node.az_event.field_az_body
-    - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_event_category
+    - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_link
     - field.field.node.az_event.field_az_location
     - field.field.node.az_event.field_az_photos
-    - field.field.node.az_event.field_az_summary
     - field.field.node.az_event.field_az_subheading
+    - field.field.node.az_event.field_az_summary
     - node.type.az_event
   module:
     - date_ap_style
     - field_group
     - smart_title
+    - text
     - user
 third_party_settings:
   field_group:
@@ -240,8 +241,8 @@ content:
       display_day: null
     third_party_settings: {  }
   field_az_summary:
-    type: basic_string
-    weight: 6
+    type: text_default
+    weight: 5
     region: content
     label: hidden
     settings: {  }

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
@@ -4,13 +4,13 @@ dependencies:
   config:
     - field.field.node.az_event.field_az_attachments
     - field.field.node.az_event.field_az_body
-    - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_event_category
+    - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_link
     - field.field.node.az_event.field_az_location
     - field.field.node.az_event.field_az_photos
-    - field.field.node.az_event.field_az_summary
     - field.field.node.az_event.field_az_subheading
+    - field.field.node.az_event.field_az_summary
     - node.type.az_event
   module:
     - date_ap_style
@@ -63,7 +63,7 @@ third_party_settings:
         - group_col_1
         - group_col_2
       parent_name: ''
-      weight: 6
+      weight: 5
       format_type: html_element
       region: content
       format_settings:
@@ -82,7 +82,7 @@ third_party_settings:
         - group_col_3
         - group_col_4
       parent_name: ''
-      weight: 7
+      weight: 6
       format_type: html_element
       region: content
       format_settings:
@@ -189,6 +189,14 @@ content:
     third_party_settings: {  }
     type: text_default
     region: content
+  field_az_event_category:
+    weight: 5
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   field_az_event_date:
     type: daterange_ap_style
     weight: 14
@@ -207,14 +215,6 @@ content:
       display_noon_and_midnight: 0
       display_day: null
     third_party_settings: {  }
-  field_az_event_category:
-    weight: 5
-    label: hidden
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
   field_az_location:
     type: link
     weight: 10
@@ -237,12 +237,11 @@ content:
     third_party_settings: {  }
     region: content
   field_az_subheading:
-    weight: 13
+    weight: 15
     label: hidden
-    settings:
-      link_to_entity: false
+    settings: {  }
     third_party_settings: {  }
-    type: string
+    type: text_default
     region: content
   links:
     weight: 0

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.teaser.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.teaser.yml
@@ -5,16 +5,20 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.az_event.field_az_attachments
     - field.field.node.az_event.field_az_body
-    - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_event_category
+    - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_link
     - field.field.node.az_event.field_az_location
     - field.field.node.az_event.field_az_photos
-    - field.field.node.az_event.field_az_summary
     - field.field.node.az_event.field_az_subheading
+    - field.field.node.az_event.field_az_summary
     - node.type.az_event
   module:
+    - smart_title
     - user
+third_party_settings:
+  smart_title:
+    enabled: false
 id: node.az_event.teaser
 targetEntityType: node
 bundle: az_event
@@ -22,19 +26,19 @@ mode: teaser
 content:
   links:
     weight: 100
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
   az_event_day: true
   az_event_month: true
   field_az_attachments: true
   field_az_body: true
-  field_az_event_date: true
   field_az_event_category: true
+  field_az_event_date: true
   field_az_link: true
   field_az_location: true
   field_az_photos: true
-  field_az_summary: true
   field_az_subheading: true
+  field_az_summary: true
   smart_title: true

--- a/modules/custom/az_event/config/install/field.field.node.az_event.field_az_subheading.yml
+++ b/modules/custom/az_event/config/install/field.field.node.az_event.field_az_subheading.yml
@@ -3,7 +3,10 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_az_subheading
+    - filter.format.plain_text
     - node.type.az_event
+  module:
+    - text
 id: node.az_event.field_az_subheading
 field_name: field_az_subheading
 entity_type: node
@@ -11,8 +14,10 @@ bundle: az_event
 label: Subtitle
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
-settings: {  }
-field_type: string
+settings:
+  allowed_formats:
+    - plain_text
+field_type: text

--- a/modules/custom/az_event/config/install/field.field.node.az_event.field_az_summary.yml
+++ b/modules/custom/az_event/config/install/field.field.node.az_event.field_az_summary.yml
@@ -3,7 +3,10 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_az_summary
+    - filter.format.plain_text
     - node.type.az_event
+  module:
+    - text
 id: node.az_event.field_az_summary
 field_name: field_az_summary
 entity_type: node
@@ -11,8 +14,10 @@ bundle: az_event
 label: Summary
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
-field_type: string_long
+settings:
+  allowed_formats:
+    - plain_text
+field_type: text_long

--- a/modules/custom/az_news/config/install/core.entity_form_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_form_display.node.az_news.default.yml
@@ -2,8 +2,8 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_attachments
+    - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_byline
     - field.field.node.az_news.field_az_caption
     - field.field.node.az_news.field_az_expiration_date
@@ -28,7 +28,6 @@ third_party_settings:
     group_summary:
       children:
         - field_az_short_title
-        - field_az_summary_link
         - field_az_summary
         - field_az_expiration_date
       parent_name: ''
@@ -69,6 +68,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_az_attachments:
+    weight: 14
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+    region: content
   field_az_body:
     weight: 6
     settings:
@@ -76,13 +82,6 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
-    region: content
-  field_az_attachments:
-    weight: 14
-    settings:
-      progress_indicator: throbber
-    third_party_settings: {  }
-    type: file_generic
     region: content
   field_az_byline:
     weight: 1
@@ -98,10 +97,10 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: string_textarea
+    type: text_textarea
     region: content
   field_az_expiration_date:
-    weight: 4
+    weight: 14
     settings:
       date_order: YMD
       time_type: '12'
@@ -149,7 +148,7 @@ content:
     region: content
   field_az_short_title:
     type: string_textfield
-    weight: 0
+    weight: 12
     region: content
     settings:
       size: 60
@@ -161,15 +160,15 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
+    type: text_textfield
     region: content
   field_az_summary:
-    weight: 3
+    weight: 13
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: string_textarea
+    type: text_textarea
     region: content
   path:
     type: path

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_media_list.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_media_list.yml
@@ -3,8 +3,8 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.az_media_list
-    - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_attachments
+    - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_byline
     - field.field.node.az_news.field_az_caption
     - field.field.node.az_news.field_az_expiration_date
@@ -20,6 +20,7 @@ dependencies:
     - date_ap_style
     - field_group
     - smart_title
+    - text
     - user
 third_party_settings:
   field_group:
@@ -209,8 +210,6 @@ third_party_settings:
       smart_title__tag: ''
       smart_title__classes: {  }
       smart_title__link: false
-_core:
-  default_config_hash: he6vYK4j3owcm5Bld_jcEPcuDXCysJ0f5hBwhDoVjfI
 id: node.az_news.az_media_list
 targetEntityType: node
 bundle: az_news
@@ -243,8 +242,8 @@ content:
       capitalize_noon_and_midnight: 0
     third_party_settings: {  }
   field_az_summary:
-    type: basic_string
-    weight: 8
+    type: text_default
+    weight: 1
     region: content
     label: hidden
     settings: {  }
@@ -260,8 +259,8 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
-  field_az_body: true
   field_az_attachments: true
+  field_az_body: true
   field_az_byline: true
   field_az_caption: true
   field_az_expiration_date: true

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
@@ -2,8 +2,8 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_attachments
+    - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_byline
     - field.field.node.az_news.field_az_caption
     - field.field.node.az_news.field_az_expiration_date
@@ -204,13 +204,6 @@ targetEntityType: node
 bundle: az_news
 mode: default
 content:
-  field_az_body:
-    weight: 7
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    type: text_default
-    region: content
   field_az_attachments:
     weight: 2
     label: hidden
@@ -218,6 +211,13 @@ content:
       use_description_as_link_text: true
     third_party_settings: {  }
     type: file_default
+    region: content
+  field_az_body:
+    weight: 7
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
     region: content
   field_az_byline:
     weight: 7
@@ -228,11 +228,11 @@ content:
     type: string
     region: content
   field_az_caption:
-    weight: 8
+    weight: 10
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: basic_string
+    type: text_default
     region: content
   field_az_main_content:
     type: entity_reference_revisions_entity_view
@@ -270,12 +270,11 @@ content:
     type: timestamp_ap_style
     region: content
   field_az_subheading:
-    weight: 7
+    weight: 9
     label: hidden
-    settings:
-      link_to_entity: false
+    settings: {  }
     third_party_settings: {  }
-    type: string
+    type: text_default
     region: content
   links:
     weight: 3

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.teaser.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.teaser.yml
@@ -3,8 +3,8 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
-    - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_attachments
+    - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_byline
     - field.field.node.az_news.field_az_caption
     - field.field.node.az_news.field_az_expiration_date
@@ -17,7 +17,11 @@ dependencies:
     - field.field.node.az_news.field_az_summary
     - node.type.az_news
   module:
+    - smart_title
     - user
+third_party_settings:
+  smart_title:
+    enabled: false
 id: node.az_news.teaser
 targetEntityType: node
 bundle: az_news
@@ -25,12 +29,12 @@ mode: teaser
 content:
   links:
     weight: 100
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
-  field_az_body: true
   field_az_attachments: true
+  field_az_body: true
   field_az_byline: true
   field_az_caption: true
   field_az_expiration_date: true

--- a/modules/custom/az_news/config/install/field.field.node.az_news.field_az_caption.yml
+++ b/modules/custom/az_news/config/install/field.field.node.az_news.field_az_caption.yml
@@ -3,16 +3,21 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_az_caption
+    - filter.format.plain_text
     - node.type.az_news
+  module:
+    - text
 id: node.az_news.field_az_caption
 field_name: field_az_caption
 entity_type: node
 bundle: az_news
-label: Photo Caption
+label: 'Photo Caption'
 description: 'Add a caption'
 required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
-field_type: string_long
+settings:
+  allowed_formats:
+    - plain_text
+field_type: text_long

--- a/modules/custom/az_news/config/install/field.field.node.az_news.field_az_subheading.yml
+++ b/modules/custom/az_news/config/install/field.field.node.az_news.field_az_subheading.yml
@@ -3,7 +3,10 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_az_subheading
+    - filter.format.plain_text
     - node.type.az_news
+  module:
+    - text
 id: node.az_news.field_az_subheading
 field_name: field_az_subheading
 entity_type: node
@@ -14,5 +17,7 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
-field_type: string
+settings:
+  allowed_formats:
+    - plain_text
+field_type: text

--- a/modules/custom/az_news/config/install/field.field.node.az_news.field_az_summary.yml
+++ b/modules/custom/az_news/config/install/field.field.node.az_news.field_az_summary.yml
@@ -3,7 +3,10 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_az_summary
+    - filter.format.plain_text
     - node.type.az_news
+  module:
+    - text
 id: node.az_news.field_az_summary
 field_name: field_az_summary
 entity_type: node
@@ -11,8 +14,10 @@ bundle: az_news
 label: Summary
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
-settings: {  }
-field_type: string_long
+settings:
+  allowed_formats:
+    - plain_text
+field_type: text_long


### PR DESCRIPTION
## Description
This pull request changes some identified fields from plain text to formatted text with the plain text format. This was decided in order to future proof those fields if it ever becomes allowed to use text formats with them.

The following fields are changed:
- `field_az_subheading` from text_plain to formatted (but not long, still rendered as plain for now )
- `field_az_summary` change to text (formatted, long) (rendered as plain text)
- `field_az_caption` change to (formatted, long) (rendered as plain text)

## Related Issue
#490 

## How Has This Been Tested?
Determine that summary, subheading and caption are now formatted text fields with the plain text format set.

Verify that events and news are still displaying as expected, in each of their view modes (full node, view displays, etc.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added this Pull Request to the AZ Quickstart project in the right column.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
