### PR TITLE
Fixes #494 Fix Event Pseudo Fields

### DIFF
--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -57,8 +57,8 @@ function az_event_entity_extra_field_info() {
 function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
 
   // We only know what to do with event pseudo fields if our date seems defined.
-  if ($entity->hasField('field_az_date') && !empty($entity->field_az_date->value)) {
-    $timestamp = $entity->field_az_date->value;
+  if ($entity->hasField('field_az_event_date') && !empty($entity->field_az_event_date->value)) {
+    $timestamp = $entity->field_az_event_date->value;
     $formatter = \Drupal::service('date.formatter');
 
     // Use the date.formatter service.


### PR DESCRIPTION
This PR fixes the display of event pseudo fields, which currently aren't displaying in `bug/471`.

## Description
During refactoring of field config, the calendar output of event month and day via pseudo field seems to have stopped working.

![image](https://user-images.githubusercontent.com/51835841/107540562-6a1b6480-6b83-11eb-9e39-2e999d90e2a7.png)


## Related Issue
#494 

## How Has This Been Tested?
Create an event and verify the side box day and month are displaying on `/calendar`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart project in the right column.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
