### PR TITLE
Updated Arizona Bootstrap to version 2.0.6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "az-digital/arizona-bootstrap": "2.0.5",
+        "az-digital/arizona-bootstrap": "2.0.6",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "drupal/auto_entitylabel": "3.0-beta3",

--- a/themes/custom/az_barrio/includes/common.inc
+++ b/themes/custom/az_barrio/includes/common.inc
@@ -7,7 +7,7 @@
  * Contains common functionality for the entire theme.
  */
 
-define('AZ_BOOTSTRAP_STABLE_VERSION', '2.0.5');
+define('AZ_BOOTSTRAP_STABLE_VERSION', '2.0.6');
 define('AZ_BRAND_ICONS_STABLE_VERSION', 'v1.1.0');
 
 /**


### PR DESCRIPTION
## Description
As part of creating the official Quickstart pre-release, we decided we also needed to incorporate the latest Arizona Bootstrap changes.
