### PR TITLE
#504: Replaced sensiolabs/security-checker script with symfonycorp/security-checker-action.

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check dependencies for vulnerabilities
         uses: symfonycorp/security-checker-action@038cecb1ee1bf871d1ef43e873f813d900a1125c
         with:
-          composer: az-quickstart-scaffolding
+          lock: az-quickstart-scaffolding/composer.lock
   code-check:
     name: Static Code Check
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,9 +37,7 @@ jobs:
           composer require --no-update az-digital/az_quickstart:dev-${AZ_TRIMMED_REF}
           composer install -o
       - name: Check dependencies for vulnerabilities
-        run: |
-          cd az-quickstart-scaffolding
-          composer security-check
+        uses: symfonycorp/security-checker-action@038cecb1ee1bf871d1ef43e873f813d900a1125c
   code-check:
     name: Static Code Check
     runs-on: ubuntu-latest
@@ -65,5 +63,3 @@ jobs:
         run: |
           cd az-quickstart-scaffolding
           composer phpcs
-
-

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,6 +38,8 @@ jobs:
           composer install -o
       - name: Check dependencies for vulnerabilities
         uses: symfonycorp/security-checker-action@038cecb1ee1bf871d1ef43e873f813d900a1125c
+        with:
+          composer: az-quickstart-scaffolding
   code-check:
     name: Static Code Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Replaces deprecated sensiolabs/security-checker script with symfonycorp GH action.

## Related Issue
#504 

## How Has This Been Tested?
Needs to be tested on GH actions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
