### PR TITLE
#491: Remove paste from word ckeditor option

### DIFF
--- a/modules/custom/az_paragraphs/config/optional/editor.editor.az_standard.yml
+++ b/modules/custom/az_paragraphs/config/optional/editor.editor.az_standard.yml
@@ -65,7 +65,6 @@ settings:
             - Source
             - Maximize
             - RemoveFormat
-            - PasteFromWord
   plugins:
     stylescombo:
       styles: "a.btn.btn-red|Button Red\r\na.btn.btn-blue|Button Blue\r\na.btn.btn-outline-red|Button Outline Red\r\na.btn.btn-outline-blue|Button Outline Blue\r\na.btn.btn-outline-white|Button Outline White\r\na.btn.btn-link|Button Link\r\nspan.text-white|Text White\r\nspan.text-sky|Text Sky\r\nspan.text-oasis|Text Oasis\r\nspan.text-azurite|Text Azurite\r\nspan.text-blue|Text Blue\r\nspan.text-midnight|Text Midnight\r\nspan.text-dark-silver|Text Dark Silver\r\nspan.text-ash|Text Ash\r\nspan.text-sans|Sanserif Text\r\nspan.text-capitalize|Capitalized Text\r\nspan.text-uppercase|UPPERCASE TEXT\r\nspan.text-lowercase|lowercase text\r\nul.ul-triangles|Triangle Bullets\r\nul.nav.nav-pills|Unordered List Pills\r\nspan.badge.badge-red|Label Red\r\nspan.badge.badge-blue|Label Blue\r\nspan.badge.badge-success|Label Green\r\nspan.badge.badge-info|Label Sky\r\nspan.badge.badge-warning|Label Warning\r\nspan.badge.badge-danger|Label Danger\r\nspan.small|Text Size Small\r\nspan.lead|Text Size Lead\r\nspan.h1|Text Size H1\r\nspan.h2|Text Size H2\r\nspan.h3|Text Size H3\r\nspan.h4|Text Size H4\r\nspan.h5|Text Size H5\r\nspan.h6|Text Size H6\r\nspan.align-top|Text Align Top\r\nspan.align-middle|Text Align Middle\r\nspan.align-bottom|Text Align Bottom\r\nspan.mt-0|Zero Margin Top\r\nspan.mb-0|Zero Margin Bottom"


### PR DESCRIPTION
## Description
The "paste from Word" option in CKEditor does not work with modern browsers, so this PR removes the button from the az_standard text format.

## Related Issue
#491 

## How Has This Been Tested?
Built and tested locally with Lando.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
