### PR TITLE
Bug/365 Fix how Jquery is loaded with HTML Paragraph

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
@@ -38,3 +38,8 @@ az_paragraphs.preview:
   dependencies:
     - az_barrio/global-styling
     - az_barrio/arizona-bootstrap
+az_paragraphs.az_html:
+  version: VERSION
+  header: true
+  dependencies:
+    - core/jquery

--- a/modules/custom/az_paragraphs/az_paragraphs_html/config/install/paragraphs.paragraphs_type.az_html.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_html/config/install/paragraphs.paragraphs_type.az_html.yml
@@ -10,4 +10,4 @@ icon_default: null
 description: 'Add markup that can not be added with a text area or embedded media.'
 behavior_plugins:
   az_default_paragraph_behavior:
-    enabled: false
+    enabled: true


### PR DESCRIPTION
Resolves #365

<!--- Provide a general summary of your changes in the Title above -->
Updated the az_paragraphs configurations so that Jquery is loaded earlier in the DOM.

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Thanks for a fellow developer at the Library (shout out to Ruiqi Yu!), who spoon fed me the solution, I committed the solution for this after wrapping my brain around it. Added a configuration to the az_paragraphs.libraries.yml file for az_html. That configuration adds core/jquery as a dependency for az_paragraphs_html. Then  enabled az_default_paragraph_behavior in the install config for az_html so that the library would get attached. This resolves #365 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Bug #365 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this by first enabling az_paragraphs_html. I then created a new page and added an HTML paragraph type to the page and inserted some JQuery into the HTML field. Before the fix the Jquery would not work, but after the code changes it seems to be working.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
