### PR TITLE
#350: Updated PHP versions to 7.4.  Added PHPCompatibility coding standard to PHPCS config.

### DIFF
--- a/.ddev/config.quickstart.yaml
+++ b/.ddev/config.quickstart.yaml
@@ -1,7 +1,7 @@
 # Recipe for AZ Quickstart local development
 type: php
 docroot: web
-php_version: "7.3"
+php_version: "7.4"
 webserver_type: nginx-fpm
 
 # Default application ports

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@d2f58713aaf7809d0c4d11e827c9e9dbbc55b34e
         with:
-          php-version: '7.3'
+          php-version: '7.4'
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@d2f58713aaf7809d0c4d11e827c9e9dbbc55b34e
         with:
-          php-version: '7.3'
+          php-version: '7.4'
       - name: Set variables
         run: |
           export AZ_TRIMMED_REF="${GITHUB_REF#refs/*/}"
@@ -49,7 +49,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@d2f58713aaf7809d0c4d11e827c9e9dbbc55b34e
         with:
-          php-version: '7.3'
+          php-version: '7.4'
       - name: Set variables
         run: echo "AZ_TRIMMED_REF=${GITHUB_REF#refs/*/}" >> ${GITHUB_ENV}
       - name: Install dependencies

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,7 +1,7 @@
 name: az_quickstart
 recipe: drupal8
 config:
-  php: '7.3'
+  php: '7.4'
   via: apache:2.4
   webroot: web
   database: mysql:5.7

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -1,4 +1,4 @@
-image: proboci/ubuntu:18.04-php7.3
+image: proboci/ubuntu:18.04-php7.4
 assets:
   - credentials.sh
 steps:

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,8 @@
                 "Editing menus user-experience issue" : "https://www.drupal.org/files/issues/2021-02-09/2957953-9.2.x-113.patch"
             },
             "drupal/config_distro": {
-                "fnmatch issue": "https://www.drupal.org/files/issues/2020-07-04/3144145-replace-fnmatch-with-preg-match-6.patch"
+                "fnmatch issue": "https://www.drupal.org/files/issues/2020-07-04/3144145-replace-fnmatch-with-preg-match-6.patch",
+                "missing parent class": "https://git.drupalcode.org/issue/config_distro-3199197/-/commit/c312096d486caa2f01703ca7de1abf2285b6fac8.diff"
             },
             "drupal/ctools": {
                 "3128339 - d9 test failures": "https://gist.githubusercontent.com/joeparsons/38e27d7d424e5b17575d2987a4b670fb/raw/d55182041e8c87ad26372e06802335ad734fa28e/3128339-11-tests-only.patch"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.3",
         "az-digital/arizona-bootstrap": "2.0.6",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -42,7 +42,7 @@ function az_core_pathauto_pattern_alter(PathautoPatternInterface $pattern, array
     $menu = $context['data']['node']->__get('menu');
 
     // Set pattern to fallback if menu is not enabled.
-    if ($menu['enabled'] === 0) {
+    if (isset($menu['enabled']) && $menu['enabled'] === 0) {
       $pattern->setPattern('[node:title]');
     }
   }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -85,4 +85,8 @@
   <rule ref="Security.Misc.IncludeMismatch"/>
   <rule ref="Security.Misc.TypeJuggle"/>
 
+  <!-- PHPCompatibility -->
+  <rule ref="PHPCompatibility"/>
+  <config name="testVersion" value="7.3-"/>
+
 </ruleset>


### PR DESCRIPTION
## Description
Changes PHP version for all of our local dev / CI tools to PHP 7.4.  Also addresses a PHP 7.4 compatibility issue in Config Distro and enables PHPCompatibility coding standard in our PHP CodeSniffer configuration.

## Related Issue
#350 

## How Has This Been Tested?
Locally with Lando

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## Related PRs
- Scaffolding repo PR: az-digital/az-quickstart-scaffolding#39
- Pantheon upstream repo PR: az-digital/az-quickstart-pantheon#5