### PR TITLE
Closes #532: Removed extra instance of footer_sub region in AZ Barrio's page template.

### DIFF
--- a/themes/custom/az_barrio/templates/page.html.twig
+++ b/themes/custom/az_barrio/templates/page.html.twig
@@ -310,7 +310,6 @@
             </div>
           </div>
           {% endif %}
-          {{ page.footer_sub }}
         </div>
         {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Description
Removes extra instance of `page.footer_sub` from AZ Barrio's `page.html.twig` template.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#532 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
