### PR TITLE
Closes #393: Use quickstart_branch script to require correct branch/version of Quickstart in GitHub actions security workflow.

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
           cd az-quickstart-scaffolding
           composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
           composer config use-github-api false
-          composer require --no-update az-digital/az_quickstart:dev-${AZ_TRIMMED_REF}
+          ./quickstart_branch.sh --branch ${AZ_TRIMMED_REF}
           composer install -o
       - name: Check dependencies for vulnerabilities
         uses: symfonycorp/security-checker-action@038cecb1ee1bf871d1ef43e873f813d900a1125c

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,7 +59,7 @@ jobs:
           cd az-quickstart-scaffolding
           composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
           composer config use-github-api false
-          composer require --no-update az-digital/az_quickstart:dev-${AZ_TRIMMED_REF}
+          ./quickstart_branch.sh --branch ${AZ_TRIMMED_REF}
           composer install -o
       - name: Run static code analysis
         run: |


### PR DESCRIPTION
## Description
Should fix #393 (GitHub actions security workflow is currently failing on 2.0.x branch).  This PR targets the 2.0.x branch directly.

## Related Issue
#393 

## How Has This Been Tested?
Has not been tested.  Need to see if it works on GitHub actions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
