### PR TITLE
az-digital/arizona-bootsrap#223: Removing unnecessary .nav class from main menu template.

### DIFF
--- a/themes/custom/az_barrio/templates/navigation/menu--main.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main.html.twig
@@ -30,7 +30,7 @@
   {% import _self as menus %}
   {% if items %}
     {% if menu_level == 0 %}
-      <ul{{ attributes.addClass('nav navbar-nav flex-lg-row') }}>
+      <ul{{ attributes.addClass('navbar-nav flex-lg-row') }}>
 {% else %}
   <div class="dropdown-menu">
 {% endif %}


### PR DESCRIPTION
## Description
While reviewing az-digital/arizona-bootstrap#240 with @danahertzberg we decided that the `.nav` class that is added to the main menu by Arizona Barrio is problematic and not needed.

## Related Issue
az-digital/arizona-bootstrap#223

## How Has This Been Tested?
In browser inspectors (a little).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
