### PR TITLE
Fixes #599: Fix broken Quickstart version indicator render array.

### DIFF
--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -35,7 +35,7 @@ function az_core_toolbar() {
   $items = [];
 
   $items['az_quickstart'] = [
-    'type' => 'toolbar_item',
+    '#type' => 'toolbar_item',
     'tab' => [
       '#type' => 'link',
       '#title' => t('Quickstart 2'),


### PR DESCRIPTION
## Description
Fixes incorrect render array for Quickstart version indicator toolbar item which is causing watchdog errors.

## Related Issue
#599 

## How Has This Been Tested?
Locally with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
