### PR TITLE
Closes #601 - Add patch 2552541-43 to core/views

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,8 @@
                 "Allow text field to enforce a specific text format.": "https://www.drupal.org/files/issues/2020-11-14/784672-178.patch",
                 "Remove Claro tabledrag.js replacement when core issues are resolved" : "https://www.drupal.org/files/issues/2020-11-11/3083051--29-REROLL-PLUS.patch",
                 "Allow editing area in Claro to span full width": "https://www.drupal.org/files/issues/2020-12-16/3184667-8.patch",
-                "Editing menus user-experience issue" : "https://www.drupal.org/files/issues/2021-02-09/2957953-9.2.x-113.patch"
+                "Editing menus user-experience issue" : "https://www.drupal.org/files/issues/2021-02-09/2957953-9.2.x-113.patch",
+                "Unable to select single view display for view settings": "https://www.drupal.org/files/issues/2020-11-03/2552541-43.patch"
             },
             "drupal/config_distro": {
                 "fnmatch issue": "https://www.drupal.org/files/issues/2020-07-04/3144145-replace-fnmatch-with-preg-match-6.patch",


### PR DESCRIPTION
## Description
Closes #601 by patching a bug that prevents you from selecting a single View Display or "all" View Displays when configuring a view.

Closes #535 

## Related Issue
- https://github.com/az-digital/az_quickstart/issues/601
- https://www.drupal.org/project/drupal/issues/2552541
- https://www.drupal.org/files/issues/2020-11-03/2552541-43.patch

## How Has This Been Tested?
- Added & active on the Registrar website. 
- Tested on a local build.

## Types of changes
[ x ] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
[ x ] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
[ x ] My code follows the code style of this project.
[ ] My change requires a change to the documentation.
[ ] I have updated the documentation accordingly.
[ ] I have read the **CONTRIBUTING** document.
[ ] I have added tests to cover my changes.
[ x ] All new and existing tests passed.
