### PR TITLE
Added patch for BlockquoteFilter issue.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,9 @@
             "dev-main": "2.1.x-dev"
         },
         "patches": {
+            "drupal/bootstrap_utilities": {
+                "Invalid arguments passed in BlockquoteFilter->process()": "https://git.drupalcode.org/project/bootstrap_utilities/-/merge_requests/2.diff"
+            },
             "drupal/config_sync": {
                 "Config_sync_test core constraint": "https://gist.githubusercontent.com/tadean/602c6412fbbdcc16a2d8a0fb58642f9e/raw/2ef503a4c0ae7d459f7c789d6ad3720d92945880/config_sync_test_core_requirement_issue.patch"
             },


### PR DESCRIPTION
## Description
While reviewing #598, I noticed that content containing blockquote elements with an existing class attribute triggers [this bug](https://www.drupal.org/project/bootstrap_utilities/issues/3204191) in the bootstrap_utilities module which causes PHP warnings to get logged in the watchdog log when the content is rendered.

This PR is against @barrettbaffert's existing PR (#598) branch and adds a patch from Drupal.org to fix the bootsrap_utilities bug.

## Related Issue
#401 

## How Has This Been Tested?
Locally with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
