### PR TITLE
Fixes #541: Update config settings for embed content

### DIFF
--- a/modules/custom/az_paragraphs/config/optional/embed.button.az_embed_content.yml
+++ b/modules/custom/az_paragraphs/config/optional/embed.button.az_embed_content.yml
@@ -2,9 +2,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.node.az_card
+    - core.entity_view_mode.node.az_media_list
     - core.entity_view_mode.node.full
     - core.entity_view_mode.node.teaser
+    - node.type.az_event
     - node.type.az_flexible_page
+    - node.type.az_news
+    - node.type.az_person
   module:
     - entity_embed
     - node
@@ -14,8 +19,13 @@ type_id: entity
 type_settings:
   entity_type: node
   bundles:
+    - az_event
+    - az_news
     - az_flexible_page
+    - az_person
   display_plugins:
+    - 'view_mode:node.az_card'
+    - 'view_mode:node.az_media_list'
     - 'view_mode:node.full'
     - 'view_mode:node.teaser'
   entity_browser: ''

--- a/modules/custom/az_paragraphs/config/optional/embed.button.az_embed_content.yml
+++ b/modules/custom/az_paragraphs/config/optional/embed.button.az_embed_content.yml
@@ -6,10 +6,6 @@ dependencies:
     - core.entity_view_mode.node.az_media_list
     - core.entity_view_mode.node.full
     - core.entity_view_mode.node.teaser
-    - node.type.az_event
-    - node.type.az_flexible_page
-    - node.type.az_news
-    - node.type.az_person
   module:
     - entity_embed
     - node
@@ -18,11 +14,7 @@ id: az_embed_content
 type_id: entity
 type_settings:
   entity_type: node
-  bundles:
-    - az_event
-    - az_news
-    - az_flexible_page
-    - az_person
+  bundles: {  }
   display_plugins:
     - 'view_mode:node.az_card'
     - 'view_mode:node.az_media_list'


### PR DESCRIPTION
## Description
Updates existing configuration for the content embed button. Adds in Event, News, and Person content types as options. Adds in Card and Media List view modes as options.

**Review site:** https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-609.probo.build/

## Related Issue
Closes #541.

## How Has This Been Tested?
Tested locally.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
