### PR TITLE
Fixes #407: AZ Person view contextual filter updates

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs_view/az_paragraphs_view.info.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/az_paragraphs_view.info.yml
@@ -3,7 +3,6 @@ type: module
 description: 'Provides a view paragraph type.'
 core_version_requirement: ^8.8 || ^9
 dependencies:
-  - az_paragraphs
   - drupal:field
   - paragraphs:paragraphs
   - drupal:views

--- a/modules/custom/az_paragraphs/az_paragraphs_view/az_paragraphs_view.info.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/az_paragraphs_view.info.yml
@@ -3,6 +3,7 @@ type: module
 description: 'Provides a view paragraph type.'
 core_version_requirement: ^8.8 || ^9
 dependencies:
+  - az_paragraphs
   - drupal:field
   - paragraphs:paragraphs
   - drupal:views

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/core.entity_form_display.paragraph.az_view_reference.default.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/core.entity_form_display.paragraph.az_view_reference.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.az_view_reference.field_az_title
     - field.field.paragraph.az_view_reference.field_az_view_reference
     - paragraphs.paragraphs_type.az_view_reference
   module:
@@ -11,8 +12,16 @@ targetEntityType: paragraph
 bundle: az_view_reference
 mode: default
 content:
-  field_az_view_reference:
+  field_az_title:
     weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_az_view_reference:
+    weight: 1
     settings: {  }
     third_party_settings: {  }
     type: viewsreference_select

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/core.entity_view_display.paragraph.az_view_reference.default.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/core.entity_view_display.paragraph.az_view_reference.default.yml
@@ -2,17 +2,47 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.az_view_reference.field_az_title
     - field.field.paragraph.az_view_reference.field_az_view_reference
     - paragraphs.paragraphs_type.az_view_reference
   module:
+    - field_group
     - viewsreference
+third_party_settings:
+  field_group:
+    group_title:
+      children:
+        - field_az_title
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        id: ''
+        classes: ''
+        element: h2
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+      label: Title
 id: paragraph.az_view_reference.default
 targetEntityType: paragraph
 bundle: az_view_reference
 mode: default
 content:
+  field_az_title:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   field_az_view_reference:
-    weight: 0
+    weight: 2
     label: hidden
     settings:
       plugin_types:

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_title.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_title.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_az_title
+    - paragraphs.paragraphs_type.az_view_reference
+id: paragraph.az_view_reference.field_az_title
+field_name: field_az_title
+entity_type: paragraph
+bundle: az_view_reference
+label: Title
+description: 'Add a custom title above this view.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string
+

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_view_reference.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_view_reference.yml
@@ -25,12 +25,30 @@ settings:
     default: default
     page: page
     block: block
+    attachment: 0
     feed: 0
-  preselect_views: {  }
+  preselect_views:
+    az_events: 0
+    az_news: 0
+    az_person: 0
+    az_reorder: 0
+    block_content: 0
+    content: 0
+    content_recent: 0
+    files: 0
+    frontpage: 0
+    media: 0
+    media_library: 0
+    redirect: 0
+    taxonomy_term: 0
+    user_admin_people: 0
+    watchdog: 0
+    who_s_new: 0
+    who_s_online: 0
   enabled_settings:
+    title: title
     argument: argument
     limit: limit
-    title: 0
-    offset: 0
     pager: 0
+    offset: 0
 field_type: viewsreference

--- a/modules/custom/az_person/config/install/views.view.az_person.yml
+++ b/modules/custom/az_person/config/install/views.view.az_person.yml
@@ -61,14 +61,10 @@ display:
       style:
         type: views_bootstrap_grid
         options:
-          grouping:
-            -
-              field: field_az_person_category
-              rendered: true
-              rendered_strip: false
+          grouping: {  }
           row_class: ''
           default_row_class: false
-          uses_fields: true
+          uses_fields: false
           col_xs: col-12
           col_sm: col-sm-6
           col_md: col-md-4
@@ -240,10 +236,10 @@ display:
           entity_type: node
           plugin_id: node_term_data
       arguments:
-        term_node_tid_depth:
-          id: term_node_tid_depth
-          table: node_field_data
-          field: term_node_tid_depth
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
           relationship: none
           group_type: group
           admin_label: ''
@@ -252,8 +248,8 @@ display:
             value: all
             title_enable: false
             title: All
-          title_enable: false
-          title: ''
+          title_enable: true
+          title: '<none>'
           default_argument_type: fixed
           default_argument_options:
             argument: ''
@@ -278,11 +274,16 @@ display:
             operation: view
             multiple: 1
             access: false
-          depth: 1
           break_phrase: true
-          use_taxonomy_term_path: false
-          entity_type: node
-          plugin_id: taxonomy_index_tid_depth
+          add_table: false
+          require_value: false
+          reduce_duplicates: true
+          plugin_id: taxonomy_index_tid
+        tid_1:
+          id: tid_1
+          table: taxonomy_index
+          field: tid
+          plugin_id: taxonomy_index_tid
       display_extenders: {  }
       css_class: az-person-grid
     cache_metadata:
@@ -372,20 +373,9 @@ display:
         fields: false
         relationships: false
         sorts: false
+        arguments: false
       relationships: {  }
       sorts:
-        field_az_person_category_target_id:
-          id: field_az_person_category_target_id
-          table: node__field_az_person_category
-          field: field_az_person_category_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: standard
         weight:
           id: weight
           table: draggableviews_structure
@@ -424,6 +414,50 @@ display:
           expose:
             label: ''
           plugin_id: standard
+      arguments:
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: true
+          title: '<none>'
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:taxonomy_term'
+            fail: ignore
+          validate_options:
+            bundles:
+              az_person_categories: az_person_categories
+              az_person_categories_secondary: az_person_categories_secondary
+            operation: view
+            multiple: 1
+            access: false
+          break_phrase: true
+          add_table: false
+          require_value: false
+          reduce_duplicates: true
+          plugin_id: taxonomy_index_tid
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/custom/az_person/config/install/views.view.az_person.yml
+++ b/modules/custom/az_person/config/install/views.view.az_person.yml
@@ -279,11 +279,6 @@ display:
           require_value: false
           reduce_duplicates: true
           plugin_id: taxonomy_index_tid
-        tid_1:
-          id: tid_1
-          table: taxonomy_index
-          field: tid
-          plugin_id: taxonomy_index_tid
       display_extenders: {  }
       css_class: az-person-grid
     cache_metadata:
@@ -499,18 +494,6 @@ display:
           relationship: none
           view_mode: az_row
       sorts:
-        field_az_person_category_target_id:
-          id: field_az_person_category_target_id
-          table: node__field_az_person_category
-          field: field_az_person_category_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: standard
         weight:
           id: weight
           table: draggableviews_structure

--- a/modules/custom/az_person/config/install/views.view.az_person.yml
+++ b/modules/custom/az_person/config/install/views.view.az_person.yml
@@ -368,7 +368,7 @@ display:
         fields: false
         relationships: false
         sorts: false
-        arguments: false
+        arguments: true
       relationships: {  }
       sorts:
         weight:
@@ -409,50 +409,6 @@ display:
           expose:
             label: ''
           plugin_id: standard
-      arguments:
-        tid:
-          id: tid
-          table: taxonomy_index
-          field: tid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: ignore
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: true
-          title: '<none>'
-          default_argument_type: fixed
-          default_argument_options:
-            argument: ''
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: true
-          validate:
-            type: 'entity:taxonomy_term'
-            fail: ignore
-          validate_options:
-            bundles:
-              az_person_categories: az_person_categories
-              az_person_categories_secondary: az_person_categories_secondary
-            operation: view
-            multiple: 1
-            access: false
-          break_phrase: true
-          add_table: false
-          require_value: false
-          reduce_duplicates: true
-          plugin_id: taxonomy_index_tid
     cache_metadata:
       max-age: -1
       contexts:
@@ -475,19 +431,16 @@ display:
       style:
         type: default
         options:
-          grouping:
-            -
-              field: field_az_person_category
-              rendered: true
-              rendered_strip: false
+          grouping: {  }
           row_class: az-person-row
           default_row_class: false
-          uses_fields: true
+          uses_fields: false
       defaults:
         style: false
         row: false
         sorts: false
         relationships: false
+        style_options: false
       row:
         type: 'entity:node'
         options:
@@ -533,6 +486,7 @@ display:
             label: ''
           plugin_id: standard
       relationships: {  }
+      style_options: null
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This a re-evaluation of how we handle contextual filters on the AZ Person views.

**New goal:** Make person views more user friendly to how people are already using views by providing expected outcomes when adding the view paragraph type.
- Expected outcome without any filters is to display all people in alphabetical order
- Expected outcome with a filter is to display only people associated with that filter
- Current experience without filters is display all people by category
- Current experience with filters requires second contextual filter to show only that filter
- If someone wants one page with people in category order, they can add multiple views
- Implementing second filter on D9 cannot be done in the same way as D7 because relationships are not available for selection by the `Content: Has taxonomy term ID` filter

### Summary of changes
#### AZ Person view
1. Removed `Content: Has taxonomy term ID (with depth)` filter
2. Removed grouping by category
3. Removed force using fields
4. Removed category sort criteria
5. Added `Content: Has taxonomy term ID` filter

#### Views reference paragraph type
1. Added custom `Title` field (H2)
2. Enabled `Display view title` checkbox

## Related Issue
Closes https://github.com/az-digital/az_quickstart/issues/407 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
