### PR TITLE
Closes #445: Added Contacts entity type (paragraph).

### DIFF
--- a/modules/custom/az_event/az_event.info.yml
+++ b/modules/custom/az_event/az_event.info.yml
@@ -6,6 +6,7 @@ package: 'The University of Arizona'
 dependencies:
   - az_core
   - az_media
+  - az_paragraphs_contact
   - date_ap_style
   - datetime_range
   - field

--- a/modules/custom/az_event/config/install/core.entity_form_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_form_display.node.az_event.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.node.az_event.field_az_attachments
     - field.field.node.az_event.field_az_body
+    - field.field.node.az_event.field_az_contacts
     - field.field.node.az_event.field_az_event_category
     - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_link
@@ -17,6 +18,7 @@ dependencies:
     - file
     - link
     - media_library
+    - paragraphs
     - path
     - smart_date
     - smart_date_recur
@@ -64,6 +66,18 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
+    region: content
+  field_az_contacts:
+    type: entity_reference_paragraphs
+    weight: 29
+    settings:
+      title: Contact
+      title_plural: Contacts
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: az_contact
+    third_party_settings: {  }
     region: content
   field_az_event_category:
     weight: 9

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
@@ -5,6 +5,7 @@ dependencies:
     - core.entity_view_mode.node.az_row
     - field.field.node.az_event.field_az_attachments
     - field.field.node.az_event.field_az_body
+    - field.field.node.az_event.field_az_contacts
     - field.field.node.az_event.field_az_event_category
     - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_link
@@ -260,6 +261,7 @@ content:
 hidden:
   field_az_attachments: true
   field_az_body: true
+  field_az_contacts: true
   field_az_event_category: true
   field_az_link: true
   field_az_location: true

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.node.az_event.field_az_attachments
     - field.field.node.az_event.field_az_body
+    - field.field.node.az_event.field_az_contacts
     - field.field.node.az_event.field_az_event_category
     - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_link
@@ -14,6 +15,7 @@ dependencies:
     - node.type.az_event
   module:
     - date_ap_style
+    - entity_reference_revisions
     - field_group
     - file
     - link
@@ -133,7 +135,8 @@ third_party_settings:
         speed: fast
       label: 'column 2'
     group_col_3:
-      children: {  }
+      children:
+        - field_az_contacts
       parent_name: group_row_2
       weight: 11
       format_type: html_element
@@ -188,6 +191,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: text_default
+    region: content
+  field_az_contacts:
+    type: entity_reference_revisions_entity_view
+    weight: 16
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
     region: content
   field_az_event_category:
     weight: 5

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.teaser.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.az_event.field_az_attachments
     - field.field.node.az_event.field_az_body
+    - field.field.node.az_event.field_az_contacts
     - field.field.node.az_event.field_az_event_category
     - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_link
@@ -34,6 +35,7 @@ hidden:
   az_event_month: true
   field_az_attachments: true
   field_az_body: true
+  field_az_contacts: true
   field_az_event_category: true
   field_az_event_date: true
   field_az_link: true

--- a/modules/custom/az_event/config/install/field.field.node.az_event.field_az_contacts.yml
+++ b/modules/custom/az_event/config/install/field.field.node.az_event.field_az_contacts.yml
@@ -1,0 +1,48 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_contacts
+    - node.type.az_event
+    - paragraphs.paragraphs_type.az_contact
+  module:
+    - entity_reference_revisions
+id: node.az_event.field_az_contacts
+field_name: field_az_contacts
+entity_type: node
+bundle: az_event
+label: Contacts
+description: 'Persons who can be contacted about the event.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      az_contact: az_contact
+    target_bundles_drag_drop:
+      az_accordion:
+        weight: 8
+        enabled: false
+      az_cards:
+        weight: 9
+        enabled: false
+      az_contact:
+        enabled: true
+        weight: 10
+      az_text:
+        weight: 11
+        enabled: false
+      az_text_background:
+        weight: 12
+        enabled: false
+      az_text_media:
+        weight: 13
+        enabled: false
+      az_view_reference:
+        weight: 14
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/custom/az_news/az_news.info.yml
+++ b/modules/custom/az_news/az_news.info.yml
@@ -21,6 +21,7 @@ dependencies:
   - az_media
   - az_paragraphs
   - az_paragraphs_cards
+  - az_paragraphs_contact
   - az_paragraphs_text
   - smart_title:smart_title
   - date_ap_style:date_ap_style

--- a/modules/custom/az_news/config/install/core.entity_form_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_form_display.node.az_news.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_byline
     - field.field.node.az_news.field_az_caption
+    - field.field.node.az_news.field_az_contacts
     - field.field.node.az_news.field_az_expiration_date
     - field.field.node.az_news.field_az_main_content
     - field.field.node.az_news.field_az_media_image
@@ -45,6 +46,7 @@ third_party_settings:
     group_az_extra_fields:
       children:
         - field_az_attachments
+        - field_az_contacts
       parent_name: ''
       weight: 10
       format_type: details_sidebar
@@ -98,6 +100,18 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
+    region: content
+  field_az_contacts:
+    weight: 15
+    settings:
+      title: Contact
+      title_plural: Contacts
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: az_contact
+    third_party_settings: {  }
+    type: entity_reference_paragraphs
     region: content
   field_az_expiration_date:
     weight: 14

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_card.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_card.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_byline
     - field.field.node.az_news.field_az_caption
+    - field.field.node.az_news.field_az_contacts
     - field.field.node.az_news.field_az_expiration_date
     - field.field.node.az_news.field_az_main_content
     - field.field.node.az_news.field_az_media_image
@@ -191,6 +192,7 @@ hidden:
   field_az_body: true
   field_az_byline: true
   field_az_caption: true
+  field_az_contacts: true
   field_az_expiration_date: true
   field_az_main_content: true
   field_az_news_tags: true

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_media_list.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_media_list.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_byline
     - field.field.node.az_news.field_az_caption
+    - field.field.node.az_news.field_az_contacts
     - field.field.node.az_news.field_az_expiration_date
     - field.field.node.az_news.field_az_main_content
     - field.field.node.az_news.field_az_media_image
@@ -263,6 +264,7 @@ hidden:
   field_az_body: true
   field_az_byline: true
   field_az_caption: true
+  field_az_contacts: true
   field_az_expiration_date: true
   field_az_main_content: true
   field_az_news_tags: true

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_minimal_media_list.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_minimal_media_list.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_byline
     - field.field.node.az_news.field_az_caption
+    - field.field.node.az_news.field_az_contacts
     - field.field.node.az_news.field_az_expiration_date
     - field.field.node.az_news.field_az_main_content
     - field.field.node.az_news.field_az_media_image
@@ -235,6 +236,7 @@ hidden:
   field_az_body: true
   field_az_byline: true
   field_az_caption: true
+  field_az_contacts: true
   field_az_expiration_date: true
   field_az_main_content: true
   field_az_news_tags: true

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_byline
     - field.field.node.az_news.field_az_caption
+    - field.field.node.az_news.field_az_contacts
     - field.field.node.az_news.field_az_expiration_date
     - field.field.node.az_news.field_az_main_content
     - field.field.node.az_news.field_az_media_image
@@ -234,6 +235,15 @@ content:
     third_party_settings: {  }
     type: text_default
     region: content
+  field_az_contacts:
+    weight: 3
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
   field_az_main_content:
     type: entity_reference_revisions_entity_view
     weight: 8
@@ -277,7 +287,7 @@ content:
     type: text_default
     region: content
   links:
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.teaser.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.az_news.field_az_body
     - field.field.node.az_news.field_az_byline
     - field.field.node.az_news.field_az_caption
+    - field.field.node.az_news.field_az_contacts
     - field.field.node.az_news.field_az_expiration_date
     - field.field.node.az_news.field_az_main_content
     - field.field.node.az_news.field_az_media_image
@@ -37,6 +38,7 @@ hidden:
   field_az_body: true
   field_az_byline: true
   field_az_caption: true
+  field_az_contacts: true
   field_az_expiration_date: true
   field_az_main_content: true
   field_az_media_image: true

--- a/modules/custom/az_news/config/install/field.field.node.az_news.field_az_contacts.yml
+++ b/modules/custom/az_news/config/install/field.field.node.az_news.field_az_contacts.yml
@@ -1,0 +1,48 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_contacts
+    - node.type.az_news
+    - paragraphs.paragraphs_type.az_contact
+  module:
+    - entity_reference_revisions
+id: node.az_news.field_az_contacts
+field_name: field_az_contacts
+entity_type: node
+bundle: az_news
+label: Contacts
+description: 'Persons who can be contacted about the news article.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      az_contact: az_contact
+    target_bundles_drag_drop:
+      az_accordion:
+        weight: 8
+        enabled: false
+      az_cards:
+        weight: 9
+        enabled: false
+      az_contact:
+        enabled: true
+        weight: 10
+      az_text:
+        weight: 11
+        enabled: false
+      az_text_background:
+        weight: 12
+        enabled: false
+      az_text_media:
+        weight: 13
+        enabled: false
+      az_view_reference:
+        weight: 14
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/custom/az_paragraphs/az_paragraphs.info.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs.info.yml
@@ -7,4 +7,7 @@ dependencies:
   - paragraphs:paragraphs
   - az_card
   - az_media
+  - drupal:email
+  - drupal:text
+  - drupal:telephone
   - entity_embed:entity_embed

--- a/modules/custom/az_paragraphs/az_paragraphs_contact/az_paragraphs_contact.info.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_contact/az_paragraphs_contact.info.yml
@@ -1,0 +1,13 @@
+name: 'Quickstart Paragraphs - Contact'
+type: module
+description: 'Provides a Contact paragraph type.'
+core_version_requirement: ^8.8 || ^9
+dependencies:
+  - az_paragraphs
+  - drupal:email
+  - drupal:field
+  - drupal:node
+  - drupal:telephone
+  - drupal:text
+  - paragraphs:paragraphs
+package: 'The University of Arizona'

--- a/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/core.entity_form_display.paragraph.az_contact.default.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/core.entity_form_display.paragraph.az_contact.default.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.az_contact.field_az_email
+    - field.field.paragraph.az_contact.field_az_phone
+    - field.field.paragraph.az_contact.field_az_title
+    - paragraphs.paragraphs_type.az_contact
+  module:
+    - telephone
+id: paragraph.az_contact.default
+targetEntityType: paragraph
+bundle: az_contact
+mode: default
+content:
+  field_az_email:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: email_default
+    region: content
+  field_az_phone:
+    weight: 2
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: telephone_default
+    region: content
+  field_az_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true

--- a/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/core.entity_view_display.paragraph.az_contact.default.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/core.entity_view_display.paragraph.az_contact.default.yml
@@ -1,0 +1,39 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.az_contact.field_az_email
+    - field.field.paragraph.az_contact.field_az_phone
+    - field.field.paragraph.az_contact.field_az_title
+    - paragraphs.paragraphs_type.az_contact
+  module:
+    - telephone
+id: paragraph.az_contact.default
+targetEntityType: paragraph
+bundle: az_contact
+mode: default
+content:
+  field_az_email:
+    weight: 1
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: email_mailto
+    region: content
+  field_az_phone:
+    weight: 2
+    label: hidden
+    settings:
+      title: ''
+    third_party_settings: {  }
+    type: telephone_link
+    region: content
+  field_az_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/field.field.paragraph.az_contact.field_az_email.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/field.field.paragraph.az_contact.field_az_email.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_az_email
+    - paragraphs.paragraphs_type.az_contact
+id: paragraph.az_contact.field_az_email
+field_name: field_az_email
+entity_type: paragraph
+bundle: az_contact
+label: 'Contact Email'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/field.field.paragraph.az_contact.field_az_phone.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/field.field.paragraph.az_contact.field_az_phone.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_az_phone
+    - paragraphs.paragraphs_type.az_contact
+  module:
+    - telephone
+id: paragraph.az_contact.field_az_phone
+field_name: field_az_phone
+entity_type: paragraph
+bundle: az_contact
+label: 'Contact Phone'
+description: '<strong>Suggested format:</strong> 520-626-0000'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: telephone

--- a/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/field.field.paragraph.az_contact.field_az_title.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/field.field.paragraph.az_contact.field_az_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_az_title
+    - paragraphs.paragraphs_type.az_contact
+id: paragraph.az_contact.field_az_title
+field_name: field_az_title
+entity_type: paragraph
+bundle: az_contact
+label: 'Contact Name'
+description: 'Full name if possible.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/field.storage.node.field_az_contacts.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/field.storage.node.field_az_contacts.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_az_contacts
+field_name: field_az_contacts
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/paragraphs.paragraphs_type.az_contact.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_contact/config/install/paragraphs.paragraphs_type.az_contact.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: az_contact
+label: Contact
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/modules/custom/az_paragraphs/config/install/field.storage.paragraph.field_az_email.yml
+++ b/modules/custom/az_paragraphs/config/install/field.storage.paragraph.field_az_email.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_az_email
+field_name: field_az_email
+entity_type: paragraph
+type: email
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_paragraphs/config/install/field.storage.paragraph.field_az_phone.yml
+++ b/modules/custom/az_paragraphs/config/install/field.storage.paragraph.field_az_phone.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - telephone
+id: paragraph.field_az_phone
+field_name: field_az_phone
+entity_type: paragraph
+type: telephone
+settings: {  }
+module: telephone
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## Description
Adds "Contacts" paragraph type and adds paragraphs field to both News & Events content types.  Replaces "Contacts" field collection used in D7.

## Related Issue
#445 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
