### PR TITLE
Setting permissions for flexible block

### DIFF
--- a/az_quickstart.info.yml
+++ b/az_quickstart.info.yml
@@ -35,6 +35,7 @@ install:
   - drupal:menu_link_content
   - drupal:datetime
   - drupal:block_content
+  - block_content_permissions:block_content_permissions
   - drupal:quickedit
   - drupal:editor
   - drupal:help

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/auto_entitylabel": "3.0-beta4",
         "drupal/background_image_formatter": "1.7",
+        "drupal/block_content_permissions": "1.10",
         "drupal/bootstrap_barrio": "4.30",
         "drupal/bootstrap_utilities": "1.0",
         "drupal/cas": "1.7",

--- a/config/install/user.role.az_content_admin.yml
+++ b/config/install/user.role.az_content_admin.yml
@@ -8,6 +8,7 @@ is_admin: false
 permissions:
   - 'access news feeds'
   - 'access taxonomy overview'
+  - 'administer blocks'
   - 'administer book outlines'
   - 'administer easy breadcrumb'
   - 'administer menu'
@@ -28,6 +29,7 @@ permissions:
   - 'delete any az_carousel_item content'
   - 'delete any az_document media'
   - 'delete any az_event content'
+  - 'delete any az_flexible_block block content'
   - 'delete any az_flexible_page content'
   - 'delete any az_image media'
   - 'delete any az_news content'

--- a/config/install/user.role.az_content_editor.yml
+++ b/config/install/user.role.az_content_editor.yml
@@ -32,6 +32,7 @@ permissions:
   - 'create az_carousel_item content'
   - 'create az_document media'
   - 'create az_event content'
+  - 'create az_flexible_block block content'
   - 'create az_flexible_page content'
   - 'create az_image media'
   - 'create az_news content'
@@ -94,6 +95,7 @@ permissions:
   - 'revert az_person revisions'
   - 'revert book revisions'
   - 'revert webform revisions'
+  - 'update any az_flexible_block block content'
   - 'update content translations'
   - 'update media'
   - 'use editorial transition archive'
@@ -122,4 +124,3 @@ permissions:
   - 'view webform revisions'
   - 'view webform submissions any node'
   - 'view webform submissions own node'
-


### PR DESCRIPTION
This PR is based on permissions work by myself and @danahertzberg during the 3/31 workshop.

## Description
When we added the flexible block, permissions were not set for content admins and content editors. This ticket address that:
- Added block_content_permissions contrib module to be able to set the permissions
- Set permissions so that content admins can create/delete flexible blocks
- Set permissions so that content admins can place flexible blocks in regions
- Set permissions so that content editors can edit existing blocks

Note: We did not give content editors the Administer Block role (although they do have it in QS1). We also did not set permissions for the basic block.

## Related Issue
#627 

## How Has This Been Tested?
Tested locally and in Probo.

How to test:
- Sign in and azcontentadmin
- Create a flexible block (Structure, Block Layout, Custom Block Library, Add Custom Block)
- Place your block in a region
- Sign out and sign in as azcontenteditor
- Verify that you can edit the existing block already made (using the contextual edit)
- Create a page with a paragraph element
- Verify that you can embed the exiting block via the CK editor

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
