### PR TITLE
Fixes #390, Fixes #427, Fixes #538, Fixes #613 Card Widget Updates

### DIFF
--- a/modules/custom/az_card/az_card.services.yml
+++ b/modules/custom/az_card/az_card.services.yml
@@ -1,0 +1,4 @@
+services:
+  az_card.image:
+    class: Drupal\az_card\AZCardImageHelper
+    arguments: ['@entity_type.manager', '@renderer']

--- a/modules/custom/az_card/css/az-card-widget.css
+++ b/modules/custom/az_card/css/az-card-widget.css
@@ -1,3 +1,20 @@
 tr.odd .az-card-elements .form-item {
   margin-bottom: 8px;
 }
+
+.az-card-elements .media-library-form-element .description {
+  display: none;
+}
+
+.az-card-elements .media-library-form-element {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.az-card-elements .media-library-form-element legend {
+  display: none;
+}
+
+.az-card-elements .media-library-selection {
+  margin: 0;
+}

--- a/modules/custom/az_card/css/az-card-widget.css
+++ b/modules/custom/az_card/css/az-card-widget.css
@@ -28,6 +28,7 @@ tr.odd .az-card-elements .form-item {
 .az-card-elements.az-card-elements-closed .form-type--url,
 .az-card-elements.az-card-elements-closed .form-type--textarea,
 .az-card-elements.az-card-elements-closed .filter-wrapper,
+.az-card-elements.az-card-elements-closed .form-type--select,
 .az-card-elements.az-card-elements-closed .media-library-form-element {
   display: none;
 }

--- a/modules/custom/az_card/css/az-card-widget.css
+++ b/modules/custom/az_card/css/az-card-widget.css
@@ -18,3 +18,16 @@ tr.odd .az-card-elements .form-item {
 .az-card-elements .media-library-selection {
   margin: 0;
 }
+
+.az-card-elements .card-preview {
+  max-height: 200px;
+  overflow: hidden;
+}
+
+.az-card-elements.az-card-elements-closed .form-type--textfield,
+.az-card-elements.az-card-elements-closed .form-type--url,
+.az-card-elements.az-card-elements-closed .form-type--textarea,
+.az-card-elements.az-card-elements-closed .filter-wrapper,
+.az-card-elements.az-card-elements-closed .media-library-form-element {
+  display: none;
+}

--- a/modules/custom/az_card/src/AZCardImageHelper.php
+++ b/modules/custom/az_card/src/AZCardImageHelper.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\az_card;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\media\MediaInterface;
+
+/**
+ * Class AZCardImageHelper generates image render arrays for card images.
+ */
+class AZCardImageHelper {
+
+  /**
+   * Drupal\Core\Entity\EntityTypeManagerInterface definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Drupal\Core\Render\RendererInterface definition.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * Constructs a new AZCardImageHelper object.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, RendererInterface $renderer) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->renderer = $renderer;
+  }
+
+  /**
+   * Prepare an image render array.
+   *
+   * @param \Drupal\media\MediaInterface $media
+   *   A Drupal media entity object.
+   *
+   * @return string[]
+   *   An image render array.
+   */
+  public function generateImageRenderArray(MediaInterface $media) {
+    $media_render_array = [];
+    $media_attributes = $media->get('field_media_az_image')->getValue();
+
+    if (empty($media_attributes[0]['target_id'])) {
+      return [];
+    }
+
+    if ($file = $this->entityTypeManager->getStorage('file')->load($media_attributes[0]['target_id'])) {
+      $image = new \stdClass();
+      $image->title = NULL;
+      $image->alt = isset($media_attributes[0]['alt']) ? $media_attributes[0]['alt'] : '';
+      $image->entity = $file;
+      $image->uri = $file->getFileUri();
+      $image->width = NULL;
+      $image->height = NULL;
+
+      // TODO: replace with responsive_image_formatter (?),
+      // add image style(s), add cache tags, add image classes(?).
+      $media_render_array = [
+        '#theme' => 'image_formatter',
+        '#item' => $image,
+        '#image_style' => 'az_card_image',
+        // Support images smaller than card width, eg. full width cards.
+        '#item_attributes' => [
+          'class' => ['card-img-top'],
+        ],
+        // '#url' => '',
+      ];
+      // Add the file entity to the cache dependencies.
+      // This will clear our cache when this entity updates.
+      $this->renderer->addCacheableDependency($media_render_array, $file);
+    }
+    return $media_render_array;
+  }
+
+}

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -130,11 +130,13 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
 
       // Media.
       $media_render_array = [];
-      if ($media = $this->entityTypeManager->getStorage('media')->load($item->media)) {
-        switch ($media->bundle()) {
-          case 'az_image':
-            $media_render_array = $this->generateImageRenderArray($media);
-            break;
+      if (!empty($item->media)) {
+        if ($media = $this->entityTypeManager->getStorage('media')->load($item->media)) {
+          switch ($media->bundle()) {
+            case 'az_image':
+              $media_render_array = $this->generateImageRenderArray($media);
+              break;
+          }
         }
       }
 

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -183,6 +183,9 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
       $column_classes = implode(' ', $column_classes);
       $column_classes = explode(' ', $column_classes);
       $column_classes[] = 'pb-4';
+      if (!empty($item->options['class'])) {
+        $card_classes .= ' ' . $item->options['class'];
+      }
 
       $element[] = [
         '#theme' => 'az_card',

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -2,15 +2,11 @@
 
 namespace Drupal\az_card\Plugin\Field\FieldFormatter;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
-use Drupal\media\MediaInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\paragraphs\ParagraphInterface;
 
@@ -35,55 +31,26 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
   protected $entityTypeManager;
 
   /**
-   * The renderer.
+   * The AZCardImageHelper service.
    *
-   * @var \Drupal\Core\Render\RendererInterface
+   * @var \Drupal\az_card\AZCardImageHelper
    */
-  protected $renderer;
-
-  /**
-   * Constructs a FormatterBase object.
-   *
-   * @param string $plugin_id
-   *   The plugin_id for the formatter.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
-   *   The definition of the field to which the formatter is associated.
-   * @param array $settings
-   *   The formatter settings.
-   * @param string $label
-   *   The formatter label display setting.
-   * @param string $view_mode
-   *   The view mode.
-   * @param array $third_party_settings
-   *   Any third party settings.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\Render\RendererInterface $renderer
-   *   The renderer.
-   */
-  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, EntityTypeManagerInterface $entity_type_manager, RendererInterface $renderer) {
-    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
-    $this->entityTypeManager = $entity_type_manager;
-    $this->renderer = $renderer;
-  }
+  protected $cardImageHelper;
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
+    $instance = parent::create(
+      $container,
+      $configuration,
       $plugin_id,
       $plugin_definition,
-      $configuration['field_definition'],
-      $configuration['settings'],
-      $configuration['label'],
-      $configuration['view_mode'],
-      $configuration['third_party_settings'],
-      $container->get('entity_type.manager'),
-      $container->get('renderer')
     );
+
+    $instance->cardImageHelper = $container->get('az_card.image');
+    $instance->entityTypeManager = $container->get('entity_type.manager');
+    return $instance;
   }
 
   /**
@@ -132,11 +99,7 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
       $media_render_array = [];
       if (!empty($item->media)) {
         if ($media = $this->entityTypeManager->getStorage('media')->load($item->media)) {
-          switch ($media->bundle()) {
-            case 'az_image':
-              $media_render_array = $this->generateImageRenderArray($media);
-              break;
-          }
+          $media_render_array = $this->cardImageHelper->generateImageRenderArray($media);
         }
       }
 
@@ -209,46 +172,6 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
     }
 
     return $element;
-  }
-
-  /**
-   * Prepare an image render array.
-   *
-   * @param \Drupal\media\MediaInterface $media
-   *   A Drupal media entity object.
-   *
-   * @return string[]
-   *   An image render array.
-   */
-  protected function generateImageRenderArray(MediaInterface $media) {
-    $media_render_array = [];
-    $media_attributes = $media->get('field_media_az_image')->getValue();
-    if ($file = $this->entityTypeManager->getStorage('file')->load($media_attributes[0]['target_id'])) {
-      $image = new \stdClass();
-      $image->title = NULL;
-      $image->alt = $media_attributes[0]['alt'];
-      $image->entity = $file;
-      $image->uri = $file->getFileUri();
-      $image->width = NULL;
-      $image->height = NULL;
-
-      // TODO: replace with responsive_image_formatter (?),
-      // add image style(s), add cache tags, add image classes(?).
-      $media_render_array = [
-        '#theme' => 'image_formatter',
-        '#item' => $image,
-        '#image_style' => 'az_card_image',
-        // Support images smaller than card width, eg. full width cards.
-        '#item_attributes' => [
-          'class' => ['card-img-top'],
-        ],
-        // '#url' => '',
-      ];
-      // Add the file entity to the cache dependencies.
-      // This will clear our cache when this entity updates.
-      $this->renderer->addCacheableDependency($media_render_array, $file);
-    }
-    return $media_render_array;
   }
 
 }

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -9,7 +9,6 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\NestedArray;
-use Drupal\file\Entity\File;
 
 /**
  * Defines the 'az_card' field widget.
@@ -39,6 +38,13 @@ class AZCardWidget extends WidgetBase {
   protected $pathValidator;
 
   /**
+   * Drupal\Core\Entity\EntityTypeManagerInterface definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
@@ -51,6 +57,7 @@ class AZCardWidget extends WidgetBase {
 
     $instance->imageFactory = ($container->get('image.factory'));
     $instance->pathValidator = ($container->get('path.validator'));
+    $instance->entityTypeManager = $container->get('entity_type.manager');
     return $instance;
   }
 
@@ -127,7 +134,7 @@ class AZCardWidget extends WidgetBase {
       // Check and see if we can construct a valid image to preview.
       $media_hint = $items[$delta]->media ?? NULL;
       if ($media_hint) {
-        $file = File::load($media_hint);
+        $file = $this->entityTypeManager->getStorage('file')->load($media_hint);
         if ($file) {
           $image = $this->imageFactory->get($file->getFileUri());
           if ($image && $image->isValid()) {

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -90,27 +90,11 @@ class AZCardWidget extends WidgetBase {
     }
 
     $title_hint = isset($items[$delta]->title) ? $items[$delta]->title : ('Card ' . ($delta + 1));
-    $media_hint = isset($items[$delta]->media) ? $items[$delta]->media : NULL;
 
     if (!$status) {
       $element['title_hint'] = [
-        '#markup' => ('<h5>' . $title_hint . '</h5>'),
+        '#markup' => ('<h5 class="mb-0">' . $title_hint . '</h5>'),
       ];
-      $file = File::load($media_hint);
-      if ($file) {
-        $image = $this->imageFactory->get($file->getFileUri());
-        if ($image && $image->isValid()) {
-          $element['media_hint'] = [
-            '#prefix' => '<div>',
-            '#suffix' => '</div>',
-            '#theme' => 'image_style',
-            '#width' => $image->getWidth(),
-            '#height' => $image->getHeight(),
-            '#style_name' => 'media_library',
-            '#uri' => $file->getFileUri(),
-          ];
-        }
-      }
     }
 
     $element['title'] = [
@@ -128,22 +112,16 @@ class AZCardWidget extends WidgetBase {
       '#access' => $status,
     ];
 
+    $element['media'] = [
+      '#type' => 'media_library',
+      '#default_value' => isset($items[$delta]->media) ? $items[$delta]->media : NULL,
+      '#allowed_bundles' => ['az_image'],
+      '#delta' => $delta,
+      '#cardinality' => 1,
+    ];
     if ($status) {
-      $element['media'] = [
-        '#type' => 'media_library',
-        '#title' => $this->t('Card Media'),
-        '#default_value' => isset($items[$delta]->media) ? $items[$delta]->media : NULL,
-        '#allowed_bundles' => ['az_image'],
-        '#delta' => $delta,
-        '#cardinality' => 1,
-      ];
-    }
-    else {
-      // If we are collapsed, just keep record of the current media.
-      $element['media'] = [
-        '#type' => 'value',
-        '#value' => isset($items[$delta]->media) ? $items[$delta]->media : NULL,
-      ];
+      // Only show the title in open mode due to its size.
+      $element['media']['#title'] = $this->t('Card Media');
     }
 
     $element['link_title'] = [

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -67,7 +67,7 @@ class AZCardWidget extends WidgetBase {
   public function form(FieldItemListInterface $items, array &$form, FormStateInterface $form_state, $get_delta = NULL) {
 
     // Create shared settings for widget elements.
-    // This is necessary because wigets have to be AJAX replaced together,
+    // This is necessary because widgets have to be AJAX replaced together,
     // And in general we need a place to store shared settings.
     $wrapper_id = Html::getUniqueId('az-card-wrapper');
     $field_name = $this->fieldDefinition->getName();

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -66,7 +66,7 @@ class AZCardWidget extends WidgetBase {
    */
   public function form(FieldItemListInterface $items, array &$form, FormStateInterface $form_state, $get_delta = NULL) {
 
-    // Create shared settings for widget elemeents.
+    // Create shared settings for widget elements.
     // This is necessary because wigets have to be AJAX replaced together,
     // And in general we need a place to store shared settings.
     $wrapper_id = Html::getUniqueId('az-card-wrapper');

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -224,7 +224,7 @@ class AZCardWidget extends WidgetBase {
 
     $element['link_uri'] = [
       '#type' => 'url',
-      '#title' => $this->t('Card Link URI'),
+      '#title' => $this->t('Card Link URL'),
       '#default_value' => isset($items[$delta]->link_uri) ? $items[$delta]->link_uri : NULL,
     ];
 

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -65,6 +65,10 @@ class AZCardWidget extends WidgetBase {
    * {@inheritdoc}
    */
   public function form(FieldItemListInterface $items, array &$form, FormStateInterface $form_state, $get_delta = NULL) {
+
+    // Create shared settings for widget elemeents.
+    // This is necessary because wigets have to be AJAX replaced together,
+    // And in general we need a place to store shared settings.
     $wrapper_id = Html::getUniqueId('az-card-wrapper');
     $field_name = $this->fieldDefinition->getName();
     $field_parents = $form['#parents'];

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -6,6 +6,10 @@ use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\NestedArray;
+use Drupal\file\Entity\File;
 
 /**
  * Defines the 'az_card' field widget.
@@ -21,14 +25,99 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
 class AZCardWidget extends WidgetBase {
 
   /**
+   * Drupal\Core\Image\ImageFactory definition.
+   *
+   * @var \Drupal\Core\Image\ImageFactory
+   */
+  protected $imageFactory;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = parent::create(
+      $container,
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+    );
+
+    $instance->imageFactory = ($container->get('image.factory'));
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(FieldItemListInterface $items, array &$form, FormStateInterface $form_state, $get_delta = NULL) {
+    $wrapper_id = Html::getUniqueId('az-card-wrapper');
+    $field_name = $this->fieldDefinition->getName();
+    $field_parents = $form['#parents'];
+    $field_state = static::getWidgetState($field_parents, $field_name, $form_state);
+    $field_state['ajax_wrapper_id'] = $wrapper_id;
+    $field_state['items_count'] = count($items);
+    $field_state['array_parents'] = [];
+    if (empty($field_state['open_status'])) {
+      $field_state['open_status'] = [];
+    }
+
+    // Persist the widget state so formElement() can access it.
+    static::setWidgetState($field_parents, $field_name, $form_state, $field_state);
+
+    $container = parent::form($items, $form, $form_state, $get_delta);
+    $container['widget']['#prefix'] = '<div id="' . $wrapper_id . '">';
+    $container['widget']['#suffix'] = '</div>';
+
+    if (isset($container['widget']['add_more']['#ajax']['wrapper'])) {
+      $container['widget']['add_more']['#ajax']['wrapper'] = $wrapper_id;
+    }
+    return $container;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+
+    // Get current collapse status.
+    $field_name = $this->fieldDefinition->getName();
+    $field_parents = $element['#field_parents'];
+    $widget_state = static::getWidgetState($field_parents, $field_name, $form_state);
+    $wrapper = $widget_state['ajax_wrapper_id'];
+    $status = (isset($widget_state['open_status'][$delta])) ? $widget_state['open_status'][$delta] : FALSE;
+    if ($items[$delta]->isEmpty()) {
+      $status = TRUE;
+    }
+
+    $title_hint = isset($items[$delta]->title) ? $items[$delta]->title : ('Card ' . ($delta + 1));
+    $media_hint = isset($items[$delta]->media) ? $items[$delta]->media : NULL;
+
+    if (!$status) {
+      $element['title_hint'] = [
+        '#markup' => ('<h5>' . $title_hint . '</h5>'),
+      ];
+      $file = File::load($media_hint);
+      if ($file) {
+        $image = $this->imageFactory->get($file->getFileUri());
+        if ($image && $image->isValid()) {
+          $element['media_hint'] = [
+            '#prefix' => '<div>',
+            '#suffix' => '</div>',
+            '#theme' => 'image_style',
+            '#width' => $image->getWidth(),
+            '#height' => $image->getHeight(),
+            '#style_name' => 'media_library',
+            '#uri' => $file->getFileUri(),
+          ];
+        }
+      }
+    }
 
     $element['title'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Card Title'),
       '#default_value' => isset($items[$delta]->title) ? $items[$delta]->title : NULL,
+      '#access' => $status,
     ];
 
     $element['body'] = [
@@ -36,27 +125,39 @@ class AZCardWidget extends WidgetBase {
       '#title' => $this->t('Card Body'),
       '#default_value' => isset($items[$delta]->body) ? $items[$delta]->body : NULL,
       '#format' => $items[$delta]->body_format ?? 'basic_html',
+      '#access' => $status,
     ];
 
-    $element['media'] = [
-      '#type' => 'media_library',
-      '#title' => $this->t('Card Media'),
-      '#default_value' => isset($items[$delta]->media) ? $items[$delta]->media : NULL,
-      '#allowed_bundles' => ['az_image'],
-      '#delta' => $delta,
-      '#cardinality' => 1,
-    ];
+    if ($status) {
+      $element['media'] = [
+        '#type' => 'media_library',
+        '#title' => $this->t('Card Media'),
+        '#default_value' => isset($items[$delta]->media) ? $items[$delta]->media : NULL,
+        '#allowed_bundles' => ['az_image'],
+        '#delta' => $delta,
+        '#cardinality' => 1,
+      ];
+    }
+    else {
+      // If we are collapsed, just keep record of the current media.
+      $element['media'] = [
+        '#type' => 'value',
+        '#value' => isset($items[$delta]->media) ? $items[$delta]->media : NULL,
+      ];
+    }
 
     $element['link_title'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Card Link Title'),
       '#default_value' => isset($items[$delta]->link_title) ? $items[$delta]->link_title : NULL,
+      '#access' => $status,
     ];
 
     $element['link_uri'] = [
       '#type' => 'url',
       '#title' => $this->t('Card Link URI'),
       '#default_value' => isset($items[$delta]->link_uri) ? $items[$delta]->link_uri : NULL,
+      '#access' => $status,
     ];
 
     // TODO: card style(s) selection form.
@@ -68,9 +169,75 @@ class AZCardWidget extends WidgetBase {
       '#access' => FALSE,
     ];
 
+    if (!$items[$delta]->isEmpty()) {
+      $button_name = implode('-', array_merge($field_parents,
+        [$field_name, $delta, 'toggle']
+      ));
+      $element['toggle'] = [
+        '#type' => 'submit',
+        '#limit_validation_errors' => [],
+        '#attributes' => ['class' => ['button--extrasmall']],
+        '#submit' => [[$this, 'cardSubmit']],
+        '#value' => ($status ? $this->t('Collapse Card') : $this->t('Edit Card')),
+        '#name' => $button_name,
+        '#ajax' => [
+          'callback' => [$this, 'cardAjax'],
+          'wrapper' => $wrapper,
+        ],
+      ];
+    }
+
     $element['#theme_wrappers'] = ['container', 'form_element'];
     $element['#attributes']['class'][] = 'az-card-elements';
     $element['#attached']['library'][] = 'az_card/az_card';
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function cardSubmit(array $form, FormStateInterface $form_state) {
+
+    // Get triggering element.
+    $triggering_element = $form_state->getTriggeringElement();
+    $array_parents = $triggering_element['#array_parents'];
+    array_pop($array_parents);
+
+    // Determine delta.
+    $delta = array_pop($array_parents);
+
+    // Get the widget.
+    $element = NestedArray::getValue($form, $array_parents);
+    $field_name = $element['#field_name'];
+    $field_parents = $element['#field_parents'];
+
+    // Load current widget settings.
+    $settings = static::getWidgetState($field_parents, $field_name, $form_state);
+
+    // Prepare to toggle state.
+    $status = TRUE;
+    if (isset($settings['open_status'][$delta])) {
+      $status = !$settings['open_status'][$delta];
+    }
+    $settings['open_status'][$delta] = $status;
+
+    // Save new state and rebuild form.
+    static::setWidgetState($field_parents, $field_name, $form_state, $settings);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function cardAjax(array $form, FormStateInterface $form_state) {
+
+    // Find the widget and return it.
+    $element = [];
+    $triggering_element = $form_state->getTriggeringElement();
+    $oops = $triggering_element['#array_parents'];
+    $array_parents = array_slice($triggering_element['#array_parents'], 0, -2);
+    $element = NestedArray::getValue($form, $array_parents);
 
     return $element;
   }

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -104,10 +104,8 @@ class AZCardWidget extends WidgetBase {
       // Bootstrap wrapper.
       $element['preview_container'] = [
         '#type' => 'container',
-        '#prefix' => '<div class="container"><div class="row">',
-        '#suffix' => '</div></div>',
         '#attributes' => [
-          'class' => ['col-12', 'col-sm-6', 'col-md-4', 'col-md-4', 'card-preview',
+          'class' => ['col-12', 'col-sm-6', 'col-md-6', 'col-lg-4', 'card-preview',
           ],
         ],
       ];
@@ -121,6 +119,10 @@ class AZCardWidget extends WidgetBase {
           $items[$delta]->body_format ?? 'basic_html'),
         '#attributes' => ['class' => ['card']],
       ];
+      // Add card class from options.
+      if (!empty($items[$delta]->options['class'])) {
+        $element['preview_container']['card_preview']['#attributes']['class'][] = $items[$delta]->options['class'];
+      }
 
       // Check and see if we can construct a valid image to preview.
       $media_hint = $items[$delta]->media ?? NULL;
@@ -187,13 +189,29 @@ class AZCardWidget extends WidgetBase {
       '#default_value' => isset($items[$delta]->link_uri) ? $items[$delta]->link_uri : NULL,
     ];
 
-    // TODO: card style(s) selection form.
     $element['options'] = [
-      '#type' => 'textarea',
-      '#title' => $this->t('Card Options'),
-      '#default_value' => isset($items[$delta]->options) ? $items[$delta]->options : NULL,
-      // Hide element until implemented.
-      '#access' => FALSE,
+      '#type' => 'select',
+      '#options' => [
+        'bg-white' => $this->t('White'),
+        'bg-transparent' => $this->t('Transparent'),
+        'bg-red' => $this->t('Arizona Red'),
+        'bg-blue' => $this->t('Arizona Blue'),
+        'bg-sky' => $this->t('Sky'),
+        'bg-oasis' => $this->t('Oasis'),
+        'bg-azurite' => $this->t('Azurite'),
+        'bg-midnight' => $this->t('Midnight'),
+        'bg-bloom' => $this->t('Bloom'),
+        'bg-chili' => $this->t('Chili'),
+        'bg-cool-gray' => $this->t('Cool Gray'),
+        'bg-warm-gray' => $this->t('Warm Gray'),
+        'bg-leaf' => $this->t('Leaf'),
+        'bg-river' => $this->t('River'),
+        'bg-silver' => $this->t('Silver'),
+        'bg-ash' => $this->t('Ash'),
+      ],
+      '#required' => TRUE,
+      '#title' => $this->t('Card Background'),
+      '#default_value' => (!empty($items[$delta]->options['class'])) ? $items[$delta]->options['class'] : 'bg-white',
     ];
 
     if (!$items[$delta]->isEmpty()) {
@@ -297,8 +315,8 @@ class AZCardWidget extends WidgetBase {
       if ($value['link_uri'] === '') {
         $values[$delta]['link_uri'] = NULL;
       }
-      if ($value['options'] === '') {
-        $values[$delta]['options'] = NULL;
+      if (!empty($value['options'])) {
+        $values[$delta]['options'] = ['class' => $value['options']];
       }
       $values[$delta]['body'] = $value['body']['value'];
       $values[$delta]['body_format'] = $value['body']['format'];

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -116,8 +116,8 @@ class AZCardWidget extends WidgetBase {
       $element['preview_container'] = [
         '#type' => 'container',
         '#attributes' => [
-          'class' => ['col-12', 'col-sm-6', 'col-md-6', 'col-lg-4', 'card-preview',
-          ],
+          'class' =>
+            ['col-12', 'col-sm-6', 'col-md-6', 'col-lg-4', 'card-preview'],
         ],
       ];
 

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -169,6 +169,31 @@ class AZCardWidget extends WidgetBase {
       }
     }
 
+    $element['options'] = [
+      '#type' => 'select',
+      '#options' => [
+        'bg-white' => $this->t('White'),
+        'bg-transparent' => $this->t('Transparent'),
+        'bg-red' => $this->t('Arizona Red'),
+        'bg-blue' => $this->t('Arizona Blue'),
+        'bg-sky' => $this->t('Sky'),
+        'bg-oasis' => $this->t('Oasis'),
+        'bg-azurite' => $this->t('Azurite'),
+        'bg-midnight' => $this->t('Midnight'),
+        'bg-bloom' => $this->t('Bloom'),
+        'bg-chili' => $this->t('Chili'),
+        'bg-cool-gray' => $this->t('Cool Gray'),
+        'bg-warm-gray' => $this->t('Warm Gray'),
+        'bg-leaf' => $this->t('Leaf'),
+        'bg-river' => $this->t('River'),
+        'bg-silver' => $this->t('Silver'),
+        'bg-ash' => $this->t('Ash'),
+      ],
+      '#required' => TRUE,
+      '#title' => $this->t('Card Background'),
+      '#default_value' => (!empty($items[$delta]->options['class'])) ? $items[$delta]->options['class'] : 'bg-white',
+    ];
+
     $element['title'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Card Title'),
@@ -201,31 +226,6 @@ class AZCardWidget extends WidgetBase {
       '#type' => 'url',
       '#title' => $this->t('Card Link URI'),
       '#default_value' => isset($items[$delta]->link_uri) ? $items[$delta]->link_uri : NULL,
-    ];
-
-    $element['options'] = [
-      '#type' => 'select',
-      '#options' => [
-        'bg-white' => $this->t('White'),
-        'bg-transparent' => $this->t('Transparent'),
-        'bg-red' => $this->t('Arizona Red'),
-        'bg-blue' => $this->t('Arizona Blue'),
-        'bg-sky' => $this->t('Sky'),
-        'bg-oasis' => $this->t('Oasis'),
-        'bg-azurite' => $this->t('Azurite'),
-        'bg-midnight' => $this->t('Midnight'),
-        'bg-bloom' => $this->t('Bloom'),
-        'bg-chili' => $this->t('Chili'),
-        'bg-cool-gray' => $this->t('Cool Gray'),
-        'bg-warm-gray' => $this->t('Warm Gray'),
-        'bg-leaf' => $this->t('Leaf'),
-        'bg-river' => $this->t('River'),
-        'bg-silver' => $this->t('Silver'),
-        'bg-ash' => $this->t('Ash'),
-      ],
-      '#required' => TRUE,
-      '#title' => $this->t('Card Background'),
-      '#default_value' => (!empty($items[$delta]->options['class'])) ? $items[$delta]->options['class'] : 'bg-white',
     ];
 
     if (!$items[$delta]->isEmpty()) {

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -248,7 +248,12 @@ class AZCardWidget extends WidgetBase {
   }
 
   /**
-   * {@inheritdoc}
+   * Submit handler for toggle button.
+   *
+   * @param array $form
+   *   The build form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
    */
   public function cardSubmit(array $form, FormStateInterface $form_state) {
 
@@ -281,9 +286,17 @@ class AZCardWidget extends WidgetBase {
   }
 
   /**
-   * {@inheritdoc}
+   * Ajax callback returning list widget container for ajax submit.
+   *
+   * @param array $form
+   *   The build form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return array
+   *   Ajax response as render array.
    */
-  public function cardAjax(array $form, FormStateInterface $form_state) {
+  public function cardAjax(array &$form, FormStateInterface $form_state) {
 
     // Find the widget and return it.
     $element = [];

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -9,7 +9,6 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\NestedArray;
-use Drupal\file\Entity\File;
 
 /**
  * Defines the 'az_card' field widget.

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -194,6 +194,15 @@ class AZCardWidget extends WidgetBase {
       '#default_value' => (!empty($items[$delta]->options['class'])) ? $items[$delta]->options['class'] : 'bg-white',
     ];
 
+    $element['media'] = [
+      '#type' => 'media_library',
+      '#title' => $this->t('Card Media'),
+      '#default_value' => isset($items[$delta]->media) ? $items[$delta]->media : NULL,
+      '#allowed_bundles' => ['az_image'],
+      '#delta' => $delta,
+      '#cardinality' => 1,
+    ];
+
     $element['title'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Card Title'),
@@ -205,15 +214,6 @@ class AZCardWidget extends WidgetBase {
       '#title' => $this->t('Card Body'),
       '#default_value' => isset($items[$delta]->body) ? $items[$delta]->body : NULL,
       '#format' => $items[$delta]->body_format ?? self::AZ_CARD_DEFAULT_TEXT_FORMAT,
-    ];
-
-    $element['media'] = [
-      '#type' => 'media_library',
-      '#title' => $this->t('Card Media'),
-      '#default_value' => isset($items[$delta]->media) ? $items[$delta]->media : NULL,
-      '#allowed_bundles' => ['az_image'],
-      '#delta' => $delta,
-      '#cardinality' => 1,
     ];
 
     $element['link_title'] = [

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -23,6 +23,9 @@ use Drupal\Component\Utility\NestedArray;
  */
 class AZCardWidget extends WidgetBase {
 
+  // Default initial text format for cards.
+  const AZ_CARD_DEFAULT_TEXT_FORMAT = 'az_standard';
+
   /**
    * Drupal\Core\Image\ImageFactory definition.
    *
@@ -127,7 +130,7 @@ class AZCardWidget extends WidgetBase {
         '#title' => $items[$delta]->title ?? '',
         '#body' => check_markup(
           $items[$delta]->body ?? '',
-          $items[$delta]->body_format ?? 'basic_html'),
+          $items[$delta]->body_format ?? self::AZ_CARD_DEFAULT_TEXT_FORMAT),
         '#attributes' => ['class' => ['card']],
       ];
       // Add card class from options.
@@ -176,7 +179,7 @@ class AZCardWidget extends WidgetBase {
       '#type' => 'text_format',
       '#title' => $this->t('Card Body'),
       '#default_value' => isset($items[$delta]->body) ? $items[$delta]->body : NULL,
-      '#format' => $items[$delta]->body_format ?? 'basic_html',
+      '#format' => $items[$delta]->body_format ?? self::AZ_CARD_DEFAULT_TEXT_FORMAT,
     ];
 
     $element['media'] = [

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -27,11 +27,11 @@ class AZCardWidget extends WidgetBase {
   const AZ_CARD_DEFAULT_TEXT_FORMAT = 'az_standard';
 
   /**
-   * Drupal\Core\Image\ImageFactory definition.
+   * The AZCardImageHelper service.
    *
-   * @var \Drupal\Core\Image\ImageFactory
+   * @var \Drupal\az_card\AZCardImageHelper
    */
-  protected $imageFactory;
+  protected $cardImageHelper;
 
   /**
    * Drupal\Core\Path\PathValidator definition.
@@ -58,8 +58,8 @@ class AZCardWidget extends WidgetBase {
       $plugin_definition,
     );
 
-    $instance->imageFactory = ($container->get('image.factory'));
-    $instance->pathValidator = ($container->get('path.validator'));
+    $instance->cardImageHelper = $container->get('az_card.image');
+    $instance->pathValidator = $container->get('path.validator');
     $instance->entityTypeManager = $container->get('entity_type.manager');
     return $instance;
   }
@@ -139,20 +139,12 @@ class AZCardWidget extends WidgetBase {
       }
 
       // Check and see if we can construct a valid image to preview.
-      $media_hint = $items[$delta]->media ?? NULL;
-      if ($media_hint) {
-        $file = $this->entityTypeManager->getStorage('file')->load($media_hint);
-        if ($file) {
-          $image = $this->imageFactory->get($file->getFileUri());
-          if ($image && $image->isValid()) {
-            $element['preview_container']['card_preview']['#media'] = [
-              '#theme' => 'image_style',
-              '#style_name' => 'az_card_image',
-              '#uri' => $file->getFileUri(),
-              '#attributes' => [
-                'class' => ['card-img-top'],
-              ],
-            ];
+      $media_id = $items[$delta]->media ?? NULL;
+      if (!empty($media_id)) {
+        if ($media = $this->entityTypeManager->getStorage('media')->load($media_id)) {
+          $media_render_array = $this->cardImageHelper->generateImageRenderArray($media);
+          if (!empty($media_render_array)) {
+            $element['preview_container']['card_preview']['#media'] = $media_render_array;
           }
         }
       }

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -94,7 +94,7 @@ class AZCardWidget extends WidgetBase {
         $values[$delta]['body'] = NULL;
       }
       if (empty($value['media'])) {
-        $values[$delta]['media'] = 0;
+        $values[$delta]['media'] = NULL;
       }
       if ($value['link_title'] === '') {
         $values[$delta]['link_title'] = NULL;


### PR DESCRIPTION
This pull request updates many aspects of the card widget of our custom card field, primarily the introduction of card previews and two-step editor forms so that the entire deck does not open at once.

## Description
The following changes are made to the card type and card widgets:

- Storage of the media ID is sanitized so that it may be NULL
- Corrected issue where the media widget was providing a comma delimited list of Media IDs
- Card field forms are now a two-step AJAX process where an `Edit Card` button is pressed to edit an individual card, as opposed to all field inputs showing simultaneously.
- Card background color selection
- Card background color implementation
- On the edit screen, a rendered preview is provided for collapsed cards.

## Related Issue
#538 
#427 
#390 
#613 
#377 

## How Has This Been Tested?

- Create a page
- Add cards
- Verify that for new cards they do not initially appear collapsed (eg. all fields are accessible for cards newly added to the entity)
- Save page
- Edit page
- Edit cards paragraph
- Verify that each card you added has a visible preview, but that the form fields are hidden
- Click `Edit Card` and verify it expands to make its form fields accessible.
- Make changes
- Verify that an image can be removed from the card (Fixes #538)
- Click `Collapse Card` and verify it reverts back to preview mode with changes reflected. (or skip this step and leave it expanded)
- Save page
- Verify changes were updated
- Verify background colors can be set for cards
- Verify background colors appear for cards.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
