### PR TITLE
Run tests faster! (#507)

### DIFF
--- a/.ddev/commands/web/phpunit-fastest
+++ b/.ddev/commands/web/phpunit-fastest
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+## Description: Run all PHPUnit tests in parallel via Fastest.
+## Usage: phpunit-fastest
+## Example: "ddev phpunit-fastest"
+
+find web/profiles/custom/az_quickstart/ -name "*Test.php" | vendor/bin/fastest -vvv "vendor/bin/phpunit {} --configuration web/profiles/custom/az_quickstart/phpunit.xml.dist --bootstrap web/core/tests/bootstrap.php web/profiles/custom/az_quickstart;"

--- a/.lando.yml
+++ b/.lando.yml
@@ -57,6 +57,9 @@ tooling:
   phpunit:
     service: appserver
     cmd: /app/vendor/bin/phpunit --configuration web/profiles/custom/az_quickstart/phpunit.xml.dist --bootstrap web/core/tests/bootstrap.php web/profiles/custom/az_quickstart
+  phpunit-fastest:
+    service: appserver
+    cmd: find web/profiles/custom/az_quickstart/ -name "*Test.php" | /app/vendor/bin/fastest -vvv "/app/vendor/bin/phpunit {} --configuration web/profiles/custom/az_quickstart/phpunit.xml.dist --bootstrap web/core/tests/bootstrap.php web/profiles/custom/az_quickstart;"
   # Provide phpstan tooling to check for code quality and deprecated code.
   phpstan:
     service: appserver

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -11,7 +11,7 @@ steps:
       - cd az-quickstart-scaffolding
       - composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
       - composer config use-github-api false
-      - composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${BRANCH_NAME}
+      - composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${BRANCH_NAME} liuggio/fastest
       - composer install -o
   - name: Run PHP_CodeSniffer coding standards checks
     plugin: Shell

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -11,7 +11,7 @@ steps:
       - cd az-quickstart-scaffolding
       - composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
       - composer config use-github-api false
-      - composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${BRANCH_NAME} liuggio/fastest
+      - composer require --no-update drupal/core-recommended:* zaporylie/composer-drupal-optimizations:* az-digital/az_quickstart:dev-${BRANCH_NAME}
       - composer install -o
   - name: Run PHP_CodeSniffer coding standards checks
     plugin: Shell

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -50,6 +50,8 @@ steps:
     script:
       - mkdir -p /var/www/html/sites/simpletest
       - chown www-data:www-data -R /var/www/html/sites/simpletest
+      - mkdir -p /var/www/html/sites/default/files/simpletest
+      - chown www-data:www-data -R /var/www/html/sites/default/files/simpletest
       - source $ASSET_DIR/credentials.sh
       - export SIMPLETEST_BASE_URL="http://localhost"
       - export SIMPLETEST_DB="mysql://${DATABASE_USER}:${DATABASE_PASS}@localhost/${DATABASE_NAME}"

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -54,4 +54,4 @@ steps:
       - export SIMPLETEST_BASE_URL="http://localhost"
       - export SIMPLETEST_DB="mysql://${DATABASE_USER}:${DATABASE_PASS}@localhost/${DATABASE_NAME}"
       - cd /var/www/html/profiles/custom/az_quickstart
-      - sudo -u www-data -E find $SRC_DIR/az-quickstart-scaffolding/web/profiles/custom/az_quickstart/ -name "*Test.php" | $SRC_DIR/az-quickstart-scaffolding/vendor/bin/fastest -vvv "$SRC_DIR/az-quickstart-scaffolding/vendor/bin/phpunit {} --colors="always" --verbose;"
+      - sudo -u www-data -E find $SRC_DIR/az-quickstart-scaffolding/web/profiles/custom/az_quickstart/ -name "*Test.php" | sudo -u www-data -E $SRC_DIR/az-quickstart-scaffolding/vendor/bin/fastest -vvv "$SRC_DIR/az-quickstart-scaffolding/vendor/bin/phpunit {} --colors="always" --verbose;"

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -54,4 +54,4 @@ steps:
       - export SIMPLETEST_BASE_URL="http://localhost"
       - export SIMPLETEST_DB="mysql://${DATABASE_USER}:${DATABASE_PASS}@localhost/${DATABASE_NAME}"
       - cd /var/www/html/profiles/custom/az_quickstart
-      - sudo -u www-data -E $SRC_DIR/az-quickstart-scaffolding/vendor/bin/phpunit --colors="always" --verbose
+      - sudo -u www-data -E find $SRC_DIR/az-quickstart-scaffolding/web/profiles/custom/az_quickstart/ -name "*Test.php" | $SRC_DIR/az-quickstart-scaffolding/vendor/bin/fastest -vvv "$SRC_DIR/az-quickstart-scaffolding/vendor/bin/phpunit {} --colors="always" --verbose;"

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
         "drupal/xmlsitemap": "1.0"
     },
     "require-dev": {
-        "az-digital/az-quickstart-dev": "~1"
+        "az-digital/az-quickstart-dev": "~1",
+        "liuggio/fastest": "^1.8"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -72,8 +72,7 @@
         "drupal/xmlsitemap": "1.0"
     },
     "require-dev": {
-        "az-digital/az-quickstart-dev": "~1",
-        "liuggio/fastest": "^1.8"
+        "az-digital/az-quickstart-dev": "~1"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Or rather, run multiple tests at once.

This uses [Fastest](https://github.com/liuggio/fastest) to parallelize PHPUnit test classes.

## Description
Modify the probo build to use Fastest to run more jobs at once. Also provide a new lando command:

```
lando phpunit-fastest
```

to run all the tests locally.

## Related Issue
az-digital/az_quickstart/issues/507

## How Has This Been Tested?
Details including terminal output are on the issue. In summary, I've run this many times locally and multiple times in Probo (much faster in Probo!)

Additionally, I verified that these parallel test runs won't conflict because the Drupal test runner automatically prefixes database tables for each test.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
