### PR TITLE
Fix bootstrap release PR action issues

### DIFF
--- a/.github/workflows/arizona-bootstrap-release.yml
+++ b/.github/workflows/arizona-bootstrap-release.yml
@@ -19,11 +19,12 @@ jobs:
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_ACTOR}"
           git checkout -b 'az-bootstrap-${{ github.event.client_payload.version }}'
-          jq '.require."az-digital/arizona-bootstrap" |= "${{ github.event.client_payload.version }}"' composer.json > composer.json.new
+          jq --indent 4 '.require."az-digital/arizona-bootstrap" |= "${{ github.event.client_payload.version }}"' composer.json > composer.json.new
           mv composer.json.new composer.json
           cat themes/custom/az_barrio/includes/common.inc | sed "s/^define('AZ_BOOTSTRAP_STABLE_VERSION'.*/define('AZ_BOOTSTRAP_STABLE_VERSION', '${{ github.event.client_payload.version }}');/g" > common.inc.new
           mv common.inc.new themes/custom/az_barrio/includes/common.inc
           git add composer.json themes/custom/az_barrio/includes/common.inc
           git commit -m 'Update Arizona Bootstrap to ${{ github.event.client_payload.version }}'
           git push --set-upstream origin 'az-bootstrap-${{ github.event.client_payload.version }}'
+          gh auth login --with-token ${{ secrets.GITHUB_TOKEN }}
           gh pr create --title 'Update Arizona Bootstrap to ${{ github.event.client_payload.version }}' --body ''

--- a/.github/workflows/arizona-bootstrap-release.yml
+++ b/.github/workflows/arizona-bootstrap-release.yml
@@ -26,5 +26,5 @@ jobs:
           git add composer.json themes/custom/az_barrio/includes/common.inc
           git commit -m 'Update Arizona Bootstrap to ${{ github.event.client_payload.version }}'
           git push --set-upstream origin 'az-bootstrap-${{ github.event.client_payload.version }}'
-          gh auth login --with-token ${{ secrets.GITHUB_TOKEN }}
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
           gh pr create --title 'Update Arizona Bootstrap to ${{ github.event.client_payload.version }}' --body ''


### PR DESCRIPTION
This PR fixes two issues:

1. The `gh` tool needs to be authenticated before it can create a PR
2. `jq` needs to be explicitly told to use 4 spaces for indentation