### PR TITLE
Fixes #545 Create Photo Gallery Paragraph Type

### DIFF
--- a/az_quickstart.info.yml
+++ b/az_quickstart.info.yml
@@ -12,6 +12,7 @@ install:
   - az_paragraphs
   - az_paragraphs_accordion
   - az_paragraphs_cards
+  - az_paragraphs_photo_gallery
   - az_paragraphs_text
   - az_paragraphs_text_background
   - az_paragraphs_text_media

--- a/modules/custom/az_media/config/install/core.entity_form_display.media.az_image.default.yml
+++ b/modules/custom/az_media/config/install/core.entity_form_display.media.az_image.default.yml
@@ -24,10 +24,10 @@ content:
   field_az_caption:
     weight: 5
     settings:
-      size: 60
+      rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: text_textfield
+    type: text_textarea
     region: content
   field_media_az_image:
     settings:

--- a/modules/custom/az_media/config/install/core.entity_form_display.media.az_image.default.yml
+++ b/modules/custom/az_media/config/install/core.entity_form_display.media.az_image.default.yml
@@ -2,12 +2,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
     - image.style.thumbnail
     - media.type.az_image
   module:
     - image_widget_crop
     - path
+    - text
 id: media.az_image.default
 targetEntityType: media
 bundle: az_image
@@ -15,10 +17,18 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_az_caption:
+    weight: 5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textfield
+    region: content
   field_media_az_image:
     settings:
       show_default_crop: true
@@ -37,7 +47,7 @@ content:
     region: content
   path:
     type: path
-    weight: 30
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -45,12 +55,12 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 100
+    weight: 4
     region: content
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 1
     settings:
       match_operator: CONTAINS
       match_limit: 10

--- a/modules/custom/az_media/config/install/core.entity_form_display.media.az_image.media_library.yml
+++ b/modules/custom/az_media/config/install/core.entity_form_display.media.az_image.media_library.yml
@@ -3,19 +3,29 @@ status: true
 dependencies:
   config:
     - core.entity_form_mode.media.media_library
+    - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
     - image.style.thumbnail
     - media.type.az_image
   module:
     - image_widget_crop
+    - text
 id: media.az_image.media_library
 targetEntityType: media
 bundle: az_image
 mode: media_library
 content:
+  field_az_caption:
+    type: text_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_media_az_image:
     type: image_widget_crop
-    weight: 1
+    weight: 0
     region: content
     settings:
       show_default_crop: true

--- a/modules/custom/az_media/config/install/core.entity_form_display.media.az_image.media_library.yml
+++ b/modules/custom/az_media/config/install/core.entity_form_display.media.az_image.media_library.yml
@@ -16,11 +16,11 @@ bundle: az_image
 mode: media_library
 content:
   field_az_caption:
-    type: text_textfield
+    type: text_textarea
     weight: 1
     region: content
     settings:
-      size: 60
+      rows: 5
       placeholder: ''
     third_party_settings: {  }
   field_media_az_image:

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_background.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_background.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.az_background
+    - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
     - image.style.large
     - media.type.az_image
@@ -24,6 +25,7 @@ content:
     region: content
 hidden:
   created: true
+  field_az_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_card_image.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_card_image.yml
@@ -2,6 +2,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.az_card_image
+    - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
     - image.style.az_card_image
     - media.type.az_image
@@ -23,6 +25,7 @@ content:
     region: content
 hidden:
   created: true
+  field_az_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_carousel_item.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_carousel_item.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.az_carousel_item
+    - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
     - image.style.az_carousel_item
     - media.type.az_image
@@ -24,6 +25,7 @@ content:
     region: content
 hidden:
   created: true
+  field_az_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_large.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_large.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.az_large
+    - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
     - image.style.az_large
     - media.type.az_image
@@ -24,6 +25,7 @@ content:
     region: content
 hidden:
   created: true
+  field_az_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_medium.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_medium.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.az_medium
+    - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
     - image.style.az_medium
     - media.type.az_image
@@ -24,6 +25,7 @@ content:
     region: content
 hidden:
   created: true
+  field_az_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.az_natural_size
+    - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
     - media.type.az_image
   module:
@@ -23,6 +24,7 @@ content:
     region: content
 hidden:
   created: true
+  field_az_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_thumbnail.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_thumbnail.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.az_thumbnail
+    - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
     - image.style.thumbnail
     - media.type.az_image
@@ -24,6 +25,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_az_caption: true
   field_media_az_image: true
   name: true
   uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.default.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
     - image.style.large
     - media.type.az_image
@@ -15,14 +16,15 @@ content:
   field_media_az_image:
     label: visually_hidden
     settings:
-      image_style: 'large'
+      image_style: large
       image_link: ''
     third_party_settings: {  }
     type: image
-    weight: 1
+    weight: 0
     region: content
 hidden:
   created: true
+  field_az_caption: true
+  name: true
   thumbnail: true
   uid: true
-  name: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.media_library.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.media_library.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.media_library
+    - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
     - image.style.medium
     - media.type.az_image
@@ -24,6 +25,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_az_caption: true
   field_media_az_image: true
   name: true
   uid: true

--- a/modules/custom/az_media/config/install/field.field.media.az_image.field_az_caption.yml
+++ b/modules/custom/az_media/config/install/field.field.media.az_image.field_az_caption.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_az_caption
+    - filter.format.plain_text
+    - media.type.az_image
+  module:
+    - text
+id: media.az_image.field_az_caption
+field_name: field_az_caption
+entity_type: media
+bundle: az_image
+label: Caption
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - plain_text
+field_type: text

--- a/modules/custom/az_media/config/install/field.field.media.az_image.field_az_caption.yml
+++ b/modules/custom/az_media/config/install/field.field.media.az_image.field_az_caption.yml
@@ -20,4 +20,4 @@ default_value_callback: ''
 settings:
   allowed_formats:
     - plain_text
-field_type: text
+field_type: text_long

--- a/modules/custom/az_media/config/install/field.storage.media.field_az_caption.yml
+++ b/modules/custom/az_media/config/install/field.storage.media.field_az_caption.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - text
+id: media.field_az_caption
+field_name: field_az_caption
+entity_type: media
+type: text
+settings:
+  max_length: 255
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_media/config/install/field.storage.media.field_az_caption.yml
+++ b/modules/custom/az_media/config/install/field.storage.media.field_az_caption.yml
@@ -7,9 +7,8 @@ dependencies:
 id: media.field_az_caption
 field_name: field_az_caption
 entity_type: media
-type: text
-settings:
-  max_length: 255
+type: text_long
+settings: {  }
 module: text
 locked: false
 cardinality: 1

--- a/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
@@ -22,6 +22,14 @@ az_paragraphs.az_text_media:
   dependencies:
     - az_barrio/global-styling
     - az_barrio/arizona-bootstrap
+az_paragraphs.az_photo_gallery:
+  version: VERSION
+  css:
+    theme:
+      css/az_paragraphs_az_photo_gallery.css: {}
+  dependencies:
+    - az_barrio/global-styling
+    - az_barrio/arizona-bootstrap
 az_paragraphs.az_cards:
   version: VERSION
   css:

--- a/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/az_paragraphs_photo_gallery.info.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/az_paragraphs_photo_gallery.info.yml
@@ -1,0 +1,10 @@
+name: 'Quickstart Paragraphs - Photo Gallery'
+type: module
+description: 'Provides a photo gallery paragraph type.'
+core_version_requirement: ^8.8 || ^9
+dependencies:
+  - az_paragraphs
+  - drupal:field
+  - paragraphs:paragraphs
+  - az_media
+package: 'The University of Arizona'

--- a/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/config/install/core.entity_form_display.paragraph.az_photo_gallery.default.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/config/install/core.entity_form_display.paragraph.az_photo_gallery.default.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.az_photo_gallery.field_az_photos
+    - paragraphs.paragraphs_type.az_photo_gallery
+  module:
+    - media_library
+id: paragraph.az_photo_gallery.default
+targetEntityType: paragraph
+bundle: az_photo_gallery
+mode: default
+content:
+  field_az_photos:
+    type: media_library_widget
+    weight: 0
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  status: true

--- a/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/config/install/core.entity_view_display.paragraph.az_photo_gallery.default.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/config/install/core.entity_view_display.paragraph.az_photo_gallery.default.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.az_photo_gallery.field_az_photos
+    - paragraphs.paragraphs_type.az_photo_gallery
+id: paragraph.az_photo_gallery.default
+targetEntityType: paragraph
+bundle: az_photo_gallery
+mode: default
+content:
+  field_az_photos:
+    type: entity_reference_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: az_carousel_item
+      link: false
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/config/install/field.field.paragraph.az_photo_gallery.field_az_photos.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/config/install/field.field.paragraph.az_photo_gallery.field_az_photos.yml
@@ -11,7 +11,7 @@ entity_type: paragraph
 bundle: az_photo_gallery
 label: Photos
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/config/install/field.field.paragraph.az_photo_gallery.field_az_photos.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/config/install/field.field.paragraph.az_photo_gallery.field_az_photos.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_az_photos
+    - media.type.az_image
+    - paragraphs.paragraphs_type.az_photo_gallery
+id: paragraph.az_photo_gallery.field_az_photos
+field_name: field_az_photos
+entity_type: paragraph
+bundle: az_photo_gallery
+label: Photos
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      az_image: az_image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/config/install/field.storage.paragraph.field_az_photos.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/config/install/field.storage.paragraph.field_az_photos.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - paragraphs
+id: paragraph.field_az_photos
+field_name: field_az_photos
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/config/install/paragraphs.paragraphs_type.az_photo_gallery.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/config/install/paragraphs.paragraphs_type.az_photo_gallery.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - az_paragraphs
+id: az_photo_gallery
+label: 'Photo Gallery'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins:
+  az_photo_gallery_paragraph_behavior:
+    enabled: true

--- a/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/templates/paragraph--az-photo-gallery.html.twig
+++ b/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/templates/paragraph--az-photo-gallery.html.twig
@@ -65,7 +65,7 @@
               '#alt':        item.entity.field_media_az_image.0.entity.uri.alt,
               '#attributes': { class: [ 'photo-gallery-grid-img' ] },
             } %}
-            <div class="col-xs-6 col-sm-6 col-md-4 col-lg-3 px-min py-min" data-toggle="modal" data-target="#{{ modal }}">
+            <div class="col-6 col-md-4 col-lg-3 px-min py-min" data-toggle="modal" data-target="#{{ modal }}">
               <a href="#{{ gallery }}" data-slide-to="{{ loop.index0 }}">
                 <picture class="card-img img-responsive">
                  {{ modalimage }}

--- a/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/templates/paragraph--az-photo-gallery.html.twig
+++ b/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/templates/paragraph--az-photo-gallery.html.twig
@@ -1,0 +1,132 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ * - grid: whether the gallery is a grid, e.g. photo gallery.
+ * - modal: unique id for the modal element.
+ * - gallery: unique id for the carousel element.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished'
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+    <div class="container">
+  		<div class="row">
+        {% if content.field_az_photos[0] %}
+        {% if grid %}
+          {# Render the images for the gallery grid display. #}
+          {% for key, item in paragraph.field_az_photos if key|first != '#' %}
+            {% set modalimage = {
+              '#theme':      'image_style',
+              '#style_name': 'az_card_image',
+              '#uri':        item.entity.field_media_az_image.0.entity.uri.value,
+              '#alt':        item.entity.field_media_az_image.0.entity.uri.alt,
+              '#attributes': { class: [ 'photo-gallery-grid-img' ] },
+            } %}
+            <div class="col-xs-6 col-sm-6 col-md-4 col-lg-3 px-min py-min" data-toggle="modal" data-target="#{{ modal }}">
+              <a href="#{{ gallery }}" data-slide-to="{{ loop.index0 }}">
+                <picture class="card-img img-responsive">
+                 {{ modalimage }}
+                </picture>
+              </a>
+            </div>
+          {% endfor %}
+          {# Modal wrapper for grid. #}
+          <div id="{{ modal }}" class="modal bg-transparent-black az-gallery-modal" tabindex="-1" role="dialog">
+        {% endif %}
+
+          <div id="{{ gallery }}" class="carousel slide{% if grid %} az-gallery{% endif %}" data-ride="carousel" data-interval="false">
+            {% if grid %}
+              {# Button for modal closer. #}
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">×</span>
+              </button>
+            {% endif %}
+            <div class="carousel-inner{% if grid %} az-gallery-inner{% endif %}">
+              {% for key, item in paragraph.field_az_photos if key|first != '#' %}
+
+                {# Create the actual image for this element. #}
+                {% set imagestyle = {
+                  '#theme':      'image_style',
+                  '#style_name': 'az_large',
+                  '#uri':        item.entity.field_media_az_image.0.entity.uri.value,
+                  '#alt':        item.entity.field_media_az_image.0.entity.uri.alt,
+                  '#attributes': { class: [ 'd-block', not grid ? 'w-100' : 'az-gallery-img' ] },
+                } %}
+
+                {# Wrapper for the individual carousel item. #}
+                <div class="carousel-item{% if grid %} az-gallery-item{% endif %}{% if loop.first %} active{% endif %}">
+                  <div class="carousel-image">
+                    {{ imagestyle }}
+                  </div>
+
+                  {# Render the caption, if one exists. #}
+                  {% if item.entity.field_az_caption.value %}
+                    <div class="carousel-caption{% if grid %} az-gallery-caption d-block{% else %} d-none d-md-block{% endif %}">
+                      <p>{{ item.entity.field_az_caption.value }}</p>
+                    </div>
+                  {% endif %}
+                </div>
+              {% endfor %}
+            </div>
+            <a class="carousel-control-prev" href="#{{ gallery }}" role="button" data-slide="prev">
+              <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+              <span class="sr-only">Previous</span>
+            </a>
+            <a class="carousel-control-next" href="#{{ gallery }}" role="button" data-slide="next">
+              <span class="carousel-control-next-icon" aria-hidden="true"></span>
+              <span class="sr-only">Next</span>
+            </a>
+          </div>
+          {% if grid %}
+          {# Modal wrapper for grid. #}
+          </div>
+          {% endif %}
+        {% endif %}
+        </div>
+      </div>
+    {% endblock %}
+  </div>
+{% endblock paragraph %}

--- a/modules/custom/az_paragraphs/css/az_paragraphs_az_photo_gallery.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_az_photo_gallery.css
@@ -1,0 +1,1 @@
+/* Styles for az_photo_gallery paragraph type. */

--- a/modules/custom/az_paragraphs/css/az_paragraphs_az_photo_gallery.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_az_photo_gallery.css
@@ -1,1 +1,6 @@
 /* Styles for az_photo_gallery paragraph type. */
+
+/* Hide focus ring in claro previews. */
+.page-wrapper .paragraph--type--az-photo-gallery.paragraph--view-mode--preview *:focus {
+  box-shadow: none;
+}

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZPhotoGalleryParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZPhotoGalleryParagraphBehavior.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\az_paragraphs\Plugin\paragraphs\Behavior;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\paragraphs\ParagraphInterface;
+
+/**
+ * Provides a behavior for photo gallery paragraphs.
+ *
+ * @ParagraphsBehavior(
+ *   id = "az_photo_gallery_paragraph_behavior",
+ *   label = @Translation("Quickstart Photo Gallery Paragraph Behavior"),
+ *   description = @Translation("Provides gallery type selection."),
+ *   weight = 0
+ * )
+ */
+class AZPhotoGalleryParagraphBehavior extends AZDefaultParagraphsBehavior {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildBehaviorForm(ParagraphInterface $paragraph, array &$form, FormStateInterface $form_state) {
+    $config = $this->getSettings($paragraph);
+
+    $form['gallery_display'] = [
+      '#title' => $this->t('Photo Gallery Display'),
+      '#type' => 'select',
+      '#options' => [
+        'slider' => $this->t('Slider'),
+        'grid' => $this->t('Grid'),
+      ],
+      '#required' => TRUE,
+      '#default_value' => $config['gallery_display'] ?? 'slider',
+      '#description' => $this->t('The type of display to use for the photo gallery.'),
+    ];
+
+    parent::buildBehaviorForm($paragraph, $form, $form_state);
+
+    // This places the form fields on the content tab rather than behavior tab.
+    // Note that form is passed by reference.
+    // @see https://www.drupal.org/project/paragraphs/issues/2928759
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preprocess(&$variables) {
+    parent::preprocess($variables);
+  }
+
+}

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZPhotoGalleryParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZPhotoGalleryParagraphBehavior.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\az_paragraphs\Plugin\paragraphs\Behavior;
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\paragraphs\ParagraphInterface;
 
@@ -48,6 +49,25 @@ class AZPhotoGalleryParagraphBehavior extends AZDefaultParagraphsBehavior {
    */
   public function preprocess(&$variables) {
     parent::preprocess($variables);
+
+    /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
+    $paragraph = $variables['paragraph'];
+
+    // Get the configuration for this paragraph.
+    $config = $this->getSettings($paragraph);
+
+    // Create a unique id for the carousel.
+    $variables['gallery'] = Html::getUniqueId('az-photo-gallery-id');
+
+    // Create a unique id for the modal, if needed.
+    $variables['modal'] = Html::getUniqueId('az-photo-gallery-modal-id');
+
+    // Variable to control whether to use the grid or slider display.
+    $variables['grid'] = FALSE;
+    // Set variable for grid.
+    if (!empty($config['gallery_display'])) {
+      $variables['grid'] = ($config['gallery_display'] === 'grid');
+    }
   }
 
 }


### PR DESCRIPTION
This pull request adds a dual purpose Photo Gallery paragraph that covers the functionality of the old photo gallery and carousel types from QS1.

## Description
This PR contains the following:

- a paragraph module (`az_paragraphs_photo_gallery`) that contains `az_photo_gallery`
- the addition of a `caption` field to the `az_image` media bundle
- a paragraph behavior plugin that allows choosing between the grid display and the slider display as an option.
- a template that handles rendering both cases; the grid uses a modal display with hint images, and the slider display uses a carousel.

## Related Issue
#545 

## How Has This Been Tested?
- Create a Flexible Page
- Add a Photo Gallery paragraph
- Add several media items to the paragraph
- Choose a display type, eg. Slider or Grid.
- Save content
- Verify functionality of the Photo Gallery based on type:
- Grid should open a Modal when previews are clicked on.
- Grid modal's close button should operate.
- Slider's carousel controls should operate.
- Verify that the gallery continues to function in preview mode (on the edit page)
- Verify that multiple galleries can co-exist on the same page.
- Verify that other content types/paragraphs are not impacted by the addition of the caption field, eg. cards, news, etc.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
