### PR TITLE
Closes #671: Add pheremone/phpcs-security-audit fork as composer repository.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,11 @@
         {
             "type": "composer",
             "url": "https://asset-packagist.org"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/az-digital/phpcs-security-audit",
+            "no-api": true
         }
     ],
     "require": {


### PR DESCRIPTION
## Description
Adds our custom `pheremone/phpcs-security-audit` [fork](https://github.com/az-digital/phpcs-security-audit)  as a composer repository so that _some_ composer operations can be performed directly on this repo (e.g. dependabot update checks) without using a scaffolding / site-specific repository.

## Related Issue
#671 

## How Has This Been Tested?
- Verified that a local `compser install` operation is able to complete successfully (even though the resulting build is unusable as a Drupal site).
- Will probably be impossible to test dependabot without merging this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
