### PR TITLE
Closes #670: April 2021 Drupal contrib maintenance updates.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "drupal/cas": "1.7",
         "drupal/chosen": "3.0.1",
         "drupal/ckeditor_bs_grid": "2.0.5",
-        "drupal/coffee": "1.0",
+        "drupal/coffee": "1.2",
         "drupal/config_distro": "1.0-alpha4",
         "drupal/config_provider": "2.0-rc4",
         "drupal/config_snapshot": "1.0-rc2",
@@ -45,10 +45,10 @@
         "drupal/config_update": "1.7",
         "drupal/core-recommended": "9.1.7",
         "drupal/crop": "2.1",
-        "drupal/ctools": "3.4",
+        "drupal/ctools": "3.5",
         "drupal/date_ap_style": "1.0",
         "drupal/draggableviews": "2.0.0",
-        "drupal/easy_breadcrumb": "1.13",
+        "drupal/easy_breadcrumb": "1.15",
         "drupal/embed": "1.4",
         "drupal/entity_embed": "1.1",
         "drupal/exclude_node_title": "1.2",
@@ -60,16 +60,16 @@
         "drupal/media_library_form_element": "2.0.3",
         "drupal/media_library_theme_reset": "1.0",
         "drupal/menu_block": "1.6",
-        "drupal/metatag": "1.15",
+        "drupal/metatag": "1.16",
         "drupal/migrate_plus": "5.1",
         "drupal/migrate_tools": "5.0",
         "drupal/paragraphs": "1.12",
         "drupal/pathauto": "1.8",
         "drupal/redirect": "1.6",
         "drupal/search_exclude": "2.0.0-beta2",
-        "drupal/slick": "2.2",
-        "drupal/slick_views": "2.3",
-        "drupal/smart_date": "3.1.1",
+        "drupal/slick": "2.3",
+        "drupal/slick_views": "2.4",
+        "drupal/smart_date": "3.2.0",
         "drupal/smart_title": "1.0-beta1",
         "drupal/smtp": "1.0",
         "drupal/token": "1.9",
@@ -111,20 +111,11 @@
                 "missing parent class": "https://git.drupalcode.org/issue/config_distro-3199197/-/commit/c312096d486caa2f01703ca7de1abf2285b6fac8.diff",
                 "Storage comparer issue": "https://gist.githubusercontent.com/tadean/4ad67c67a56d9fcec83db8f403ac58d7/raw/9a6762de5b014dffecf06c9a5b311f75c534fce4/config_distro_comparer.patch"
             },
-            "drupal/ctools": {
-                "3128339 - d9 test failures": "https://gist.githubusercontent.com/joeparsons/38e27d7d424e5b17575d2987a4b670fb/raw/d55182041e8c87ad26372e06802335ad734fa28e/3128339-11-tests-only.patch"
-            },
             "drupal/date_ap_style": {
                 "Smart date compatibility": "https://www.drupal.org/files/issues/2020-08-25/3167284-support-smartdate-2.patch"
             },
-            "drupal/easy_breadcrumb": {
-                "Easy_breadcrumb schema issue": "https://www.drupal.org/files/issues/2020-07-27/missing_schema_keys-3161765-4.patch"
-            },
             "drupal/draggableviews": {
                 "Draggableviews select view that stores order issue": "https://www.drupal.org/files/issues/2019-12-17/draggableviews-sort_handler_specify_order_view-2767437-66.patch"
-            },
-            "drupal/coffee": {
-                "Coffee test, support for Drupal 9 core_version_requirement": "https://www.drupal.org/files/issues/2020-10-27/3174680-5-make-test-module-d9-compatible.patch"
             },
             "drupal/menu_block": {
                 "Module test core_version_requirement": "https://www.drupal.org/files/issues/2020-11-11/3146665_7.patch",


### PR DESCRIPTION
## Description
Latest Drupal contrib module updates.  Intentionally omitted Bootstrap Barrio theme updates since I think we'll want to tackle that separately (or potentially really fork Bootstrap Barrio).

3 of the existing contrib module patches we were using are no longer needed with these updates.

## Related Issue
#670 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified composer install still worked inside lando

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
