### PR TITLE
Increase dependabot frequency and add reviewers to dependabot PRs.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,6 @@ updates:
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    reviewers:
+      - "az-digital/developers"


### PR DESCRIPTION
## Description
- Run dependabot daily instead of weekly
- Automatically add reviewers to dependabot PRs