### PR TITLE
Fixes #719: Don't use magic credentials.sh filename in ProboCI config.

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -1,6 +1,6 @@
 image: proboci/ubuntu:18.04-php7.4
 assets:
-  - credentials.sh
+  - test-credentials.sh
 steps:
   - name: Build Arizona Quickstart
     plugin: Script
@@ -52,8 +52,8 @@ steps:
       - chown www-data:www-data -R /var/www/html/sites/simpletest
       - mkdir -p /var/www/html/sites/default/files/simpletest
       - chown www-data:www-data -R /var/www/html/sites/default/files/simpletest
-      - source $ASSET_DIR/credentials.sh
+      - source $ASSET_DIR/test-credentials.sh
       - export SIMPLETEST_BASE_URL="http://localhost"
-      - export SIMPLETEST_DB="mysql://${DATABASE_USER}:${DATABASE_PASS}@localhost/${DATABASE_NAME}"
+      - export SIMPLETEST_DB="mysql://${TEST_DATABASE_USER}:${TEST_DATABASE_PASS}@localhost/${TEST_DATABASE_NAME}"
       - cd /var/www/html/profiles/custom/az_quickstart
       - sudo -u www-data -E find $SRC_DIR/az-quickstart-scaffolding/web/profiles/custom/az_quickstart/ -name "*Test.php" | sudo -u www-data -E $SRC_DIR/az-quickstart-scaffolding/vendor/bin/fastest -vvv "$SRC_DIR/az-quickstart-scaffolding/vendor/bin/phpunit {} --colors="always" --verbose;"


### PR DESCRIPTION
## Description
Updates ProboCI config to stop referencing the `credentials.sh` asset filename since it turns out that specific filename has special significance in Probo and if it exists, it gets loaded all the time which was causing problems for the migration testing pipeline we're working on adding to our ProboCI config.

## Related Issue
#719 

## How Has This Been Tested?
ProboCI FTW

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
