### PR TITLE
Add styling to event category taxonomy terms (Closes #727)

### DIFF
--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -57,10 +57,10 @@ function az_event_entity_extra_field_info() {
 function az_event_preprocess_field(&$variables, $hook) {
   $element = $variables['element'];
   if ($element['#field_name'] == 'field_az_event_category') {
-    foreach ($variables['items'] as $key => $item){
+    foreach ($variables['items'] as $key => $item){ 
       $variables['items'][$key]['content']['#options']['attributes']['class'][] = 'badge badge-link badge-light';
-      }
     }
+  }
 }
 
 /**

--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -56,9 +56,9 @@ function az_event_entity_extra_field_info() {
  */
 function az_event_preprocess_field(&$variables, $hook) {
   $element = $variables['element'];
-  if ($element['#field_name'] == 'field_az_event_category') {
+  if ($element['#field_name'] === 'field_az_event_category') {
     foreach ($variables['items'] as $key => $item) {
-      $variables['items'][$key]['content']['#options']['attributes']['class'][] = 'badge badge-link badge-light';
+      $variables['items'][$key]['content']['#options']['attributes']['class'][] = 'badge badge-link badge-light float-left mr-2';
     }
   }
 }

--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -58,7 +58,7 @@ function az_event_preprocess_field(&$variables, $hook) {
   $element = $variables['element'];
   if ($element['#field_name'] === 'field_az_event_category') {
     foreach ($variables['items'] as $key => $item) {
-      $variables['items'][$key]['content']['#options']['attributes']['class'][] = 'badge badge-link badge-light float-left mr-2';
+      $variables['items'][$key]['content']['#options']['attributes']['class'][] = 'badge badge-link badge-light float-left mr-2 mb-2';
     }
   }
 }

--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -52,6 +52,16 @@ function az_event_entity_extra_field_info() {
 }
 
 /**
+ * Implements hook_preprocess_field().
+ */
+function az_event_preprocess_field(&$variables, $hook) {
+  $element = $variables['element'];
+  if ($element['#field_name'] == 'field_az_event_category') {
+    $variables['items'][0]['content']['#options']['attributes']['class'][] = 'badge badge-link badge-light';
+  }
+}
+
+/**
  * Implements hook_ENTITY_TYPE_view().
  */
 function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {

--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -57,7 +57,7 @@ function az_event_entity_extra_field_info() {
 function az_event_preprocess_field(&$variables, $hook) {
   $element = $variables['element'];
   if ($element['#field_name'] == 'field_az_event_category') {
-    foreach ($variables['items'] as $key => $item){ 
+    foreach ($variables['items'] as $key => $item) {
       $variables['items'][$key]['content']['#options']['attributes']['class'][] = 'badge badge-link badge-light';
     }
   }

--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -57,8 +57,10 @@ function az_event_entity_extra_field_info() {
 function az_event_preprocess_field(&$variables, $hook) {
   $element = $variables['element'];
   if ($element['#field_name'] == 'field_az_event_category') {
-    $variables['items'][0]['content']['#options']['attributes']['class'][] = 'badge badge-link badge-light';
-  }
+    foreach ($variables['items'] as $key => $item){
+      $variables['items'][$key]['content']['#options']['attributes']['class'][] = 'badge badge-link badge-light';
+      }
+    }
 }
 
 /**

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
@@ -51,7 +51,7 @@ third_party_settings:
       region: content
       format_settings:
         id: ''
-        classes: ''
+        classes: 'clearfix'
         element: div
         show_label: false
         label_element: h3


### PR DESCRIPTION
Event tags had no styling so this PR adds the need styling to match what was done for Person

## Description
This PR adds a function to `modules/custom/az_event/az_event.module` to add the needed styling to field_az_event_category. 

This was based on what was done in QS1: https://bitbucket.org/ua_drupal/ua_quickstart/pull-requests/424
And on this discussion: https://drupal.stackexchange.com/questions/181341/add-class-to-content-field-link/260232#260232

Thanks @trackleft for some help getting the terms inline.

## Related Issue
#727 

## How Has This Been Tested?
Probo and local dev

How to test:

1. Create at least two taxonomy terms in the Event Category taxonomy
2. Add an event and apply event categories to it
3. Verify that the taxonomy terms display with correct styling

![image](https://user-images.githubusercontent.com/10873398/119201904-9ed16e80-ba44-11eb-89ca-9bfa47855879.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
