### PR TITLE
Fixes #638: Added patch for Image Widget Crop module bug affecting media library UX.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,6 +127,9 @@
             "drupal/draggableviews": {
                 "Draggableviews select view that stores order issue": "https://www.drupal.org/files/issues/2019-12-17/draggableviews-sort_handler_specify_order_view-2767437-66.patch"
             },
+            "drupal/image_widget_crop": {
+                "Reset crop triggered when ENTER is pressed in the form": "https://www.drupal.org/files/issues/2020-03-04/image_widget_crop-3117828-2.patch"
+            },
             "drupal/metatag": {
                 "Module to support migrate upgrade": "https://www.drupal.org/files/issues/2020-12-11/support_migrate_upgrade-3187898-2.patch"
             }


### PR DESCRIPTION
## Description
Adds patch for a [known bug in the Image Widget Crop module](https://www.drupal.org/project/image_widget_crop/issues/3117828) that was causing the mysterious Ajax fatal errors when the "enter" key was pressed within the Add media dialog when embedding media in CKeditor fields using the media library editor plugin.

## Related Issue
Fixes #638 

## How Has This Been Tested?
Verified composer build still worked in Lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
