### PR TITLE
Fixes #691: Added spacing (padding) setting to text with background paragraph type.

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs_text_background/az_paragraphs_text_background.install
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_background/az_paragraphs_text_background.install
@@ -8,14 +8,26 @@
 use Drupal\paragraphs\Entity\Paragraph;
 
 /**
- * Add default text_background_padding setting for existing text with background paragraphs.
+ * Add default text_background_padding behavior setting to existing Text with Background paragraphs.
  */
 function az_paragraphs_text_background_update_9201() {
-  $query = \Drupal::entityQuery('paragraph')
-    ->condition('type', 'az_text_background');
-  $paragraph_ids = $query->execute();
+  if (!isset($sandbox['total'])) {
+    $count = \Drupal::entityQuery('paragraph')
+      ->condition('type', 'az_text_background')
+      ->count()
+      ->execute();
+    $sandbox['total'] = $count;
+    $sandbox['current'] = 0;
+    $sandbox['updated_count'] = 0;
+  }
 
-  $updated_count = 0;
+  $paragraphs_per_batch = 25;
+
+  $paragraph_ids = \Drupal::entityQuery('paragraph')
+    ->condition('type', 'az_text_background')
+    ->range($sandbox['current'], $sandbox['current'] + $paragraphs_per_batch)
+    ->execute();
+
   foreach ($paragraph_ids as $id) {
     $paragraph = Paragraph::load($id);
     $behavior_settings = $paragraph->getAllBehaviorSettings();
@@ -23,9 +35,12 @@ function az_paragraphs_text_background_update_9201() {
       $behavior_settings['az_text_background_paragraph_behavior']['text_background_padding'] = 'py-5';
       $paragraph->setAllBehaviorSettings($behavior_settings);
       $paragraph->save();
-      $updated_count++;
+      $sandbox['updated_count']++;
     }
+    $sandbox['current']++;
   }
 
-  return t('Default padding setting added to %count Text with Background paragraphs.', ['%count' => $updated_count]);
+  $sandbox['#finished'] = ($sandbox['total'] == 0) ? 1 : ($sandbox['current'] / $sandbox['total']);
+
+  return t('Default padding setting added to %count Text with Background paragraphs.', ['%count' => $sandbox['updated_count']]);
 }

--- a/modules/custom/az_paragraphs/az_paragraphs_text_background/az_paragraphs_text_background.install
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_background/az_paragraphs_text_background.install
@@ -30,12 +30,14 @@ function az_paragraphs_text_background_update_9201() {
 
   foreach ($paragraph_ids as $id) {
     $paragraph = Paragraph::load($id);
-    $behavior_settings = $paragraph->getAllBehaviorSettings();
-    if (!isset($behavior_settings['az_text_background_paragraph_behavior']['text_background_padding'])) {
-      $behavior_settings['az_text_background_paragraph_behavior']['text_background_padding'] = 'py-5';
-      $paragraph->setAllBehaviorSettings($behavior_settings);
-      $paragraph->save();
-      $sandbox['updated_count']++;
+    if (!empty($paragraph)) {
+      $behavior_settings = $paragraph->getAllBehaviorSettings();
+      if (!isset($behavior_settings['az_text_background_paragraph_behavior']['text_background_padding'])) {
+        $behavior_settings['az_text_background_paragraph_behavior']['text_background_padding'] = 'py-5';
+        $paragraph->setAllBehaviorSettings($behavior_settings);
+        $paragraph->save();
+        $sandbox['updated_count']++;
+      }
     }
     $sandbox['current']++;
   }

--- a/modules/custom/az_paragraphs/az_paragraphs_text_background/az_paragraphs_text_background.install
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_background/az_paragraphs_text_background.install
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for az_paragraphs_text_background module.
+ */
+
+use Drupal\paragraphs\Entity\Paragraph;
+
+/**
+ * Add default text_background_behavior setting for existing text with background paragraphs.
+ */
+function az_paragraphs_text_background_update_9201() {
+  $query = \Drupal::entityQuery('paragraph')
+    ->condition('type', 'az_text_background');
+  $paragraph_ids = $query->execute();
+
+  foreach ($paragraph_ids as $id) {
+    $paragraph = Paragraph::load($id);
+    $behavior_settings = $paragraph->getAllBehaviorSettings();
+    if (!isset($behavior_settings['az_text_background_paragraph_behavior']['text_background_padding'])) {
+      $behavior_settings['az_text_background_paragraph_behavior']['text_background_padding'] = 'py-5';
+      $paragraph->setAllBehaviorSettings($behavior_settings);
+      $paragraph->save();
+    }
+  }
+}

--- a/modules/custom/az_paragraphs/az_paragraphs_text_background/az_paragraphs_text_background.install
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_background/az_paragraphs_text_background.install
@@ -8,13 +8,14 @@
 use Drupal\paragraphs\Entity\Paragraph;
 
 /**
- * Add default text_background_behavior setting for existing text with background paragraphs.
+ * Add default text_background_padding setting for existing text with background paragraphs.
  */
 function az_paragraphs_text_background_update_9201() {
   $query = \Drupal::entityQuery('paragraph')
     ->condition('type', 'az_text_background');
   $paragraph_ids = $query->execute();
 
+  $updated_count = 0;
   foreach ($paragraph_ids as $id) {
     $paragraph = Paragraph::load($id);
     $behavior_settings = $paragraph->getAllBehaviorSettings();
@@ -22,6 +23,9 @@ function az_paragraphs_text_background_update_9201() {
       $behavior_settings['az_text_background_paragraph_behavior']['text_background_padding'] = 'py-5';
       $paragraph->setAllBehaviorSettings($behavior_settings);
       $paragraph->save();
+      $updated_count++;
     }
   }
+
+  return t('Default padding setting added to %count Text with Background paragraphs.', ['%count' => $updated_count]);
 }

--- a/modules/custom/az_paragraphs/az_paragraphs_text_background/templates/paragraph--az-text-background--default.html.twig
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_background/templates/paragraph--az-text-background--default.html.twig
@@ -42,7 +42,6 @@
   set classes = [
   'paragraph',
   'background-wrapper',
-  'text-with-background',
   'paragraph--type--' ~ paragraph.bundle|clean_class,
   view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
   not paragraph.isPublished() ? 'paragraph--unpublished',

--- a/modules/custom/az_paragraphs/az_paragraphs_text_background/templates/paragraph--az-text-background--default.html.twig
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_background/templates/paragraph--az-text-background--default.html.twig
@@ -48,6 +48,7 @@
   not paragraph.isPublished() ? 'paragraph--unpublished',
   text_with_background.text_background_pattern,
   text_with_background.text_background_color,
+  text_with_background.text_background_padding,
   text_with_background.text_background_full_width
 ]
 %}

--- a/modules/custom/az_paragraphs/css/az_paragraphs_az_text_background.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_az_text_background.css
@@ -1,9 +1,5 @@
 /* Styles for az_text_background paragraph type. */
 
-.text-with-background {
-  padding: 3em 0;
-}
-
 .background-wrapper.full-width-background {
   width: initial;
 }

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithBackgroundParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithBackgroundParagraphBehavior.php
@@ -78,6 +78,26 @@ class AZTextWithBackgroundParagraphBehavior extends AZDefaultParagraphsBehavior 
         ]),
     ];
 
+    $form['text_background_padding'] = [
+      '#title' => $this->t('Space Around Content'),
+      '#type' => 'select',
+      '#options' => [
+        'py-0' => $this->t('Zero'),
+        'py-1' => $this->t('1 (0.25rem | ~4px)'),
+        'py-2' => $this->t('2 (0.5rem | ~8px)'),
+        'py-3' => $this->t('3 (1.0rem | ~16px)'),
+        'py-4' => $this->t('4 (1.5rem | ~24px)'),
+        'py-5' => $this->t('5 (3.0rem | ~48px) - Default'),
+        'py-6' => $this->t('6 (4.0rem | ~64px)'),
+        'py-7' => $this->t('7 (5.0rem | ~80px)'),
+        'py-8' => $this->t('8 (6.0rem | ~96px)'),
+        'py-9' => $this->t('9 (7.0rem | ~112px)'),
+        'py-10' => $this->t('10 (8.0rem | ~128px)'),
+      ],
+      '#default_value' => $config['text_background_padding'] ?? 'py-5',
+      '#description' => $this->t('Adds padding above and below the text.'),
+    ];
+
     parent::buildBehaviorForm($paragraph, $form, $form_state);
 
     // This places the form fields on the content tab rather than behavior tab.


### PR DESCRIPTION
## Description
Adds additional spacing (padding) setting to existing Text with Background paragraph behavior settings.

The database update contained here is still untested and probably needs work.

## Related Issue
#691 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with lando (but not the DB update yet).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
