### PR TITLE
Fixes #738: Add #maxlength to title field form element in Accordion and Card FieldWidgets.

### DIFF
--- a/modules/custom/az_accordion/src/Plugin/Field/FieldWidget/AZAccordionWidget.php
+++ b/modules/custom/az_accordion/src/Plugin/Field/FieldWidget/AZAccordionWidget.php
@@ -29,6 +29,7 @@ class AZAccordionWidget extends WidgetBase {
       '#type' => 'textfield',
       '#title' => $this->t('Accordion Item Title'),
       '#default_value' => isset($items[$delta]->title) ? $items[$delta]->title : NULL,
+      '#maxlength' => 255,
     ];
 
     $element['body'] = [

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -199,6 +199,7 @@ class AZCardWidget extends WidgetBase {
       '#type' => 'textfield',
       '#title' => $this->t('Card Title'),
       '#default_value' => isset($items[$delta]->title) ? $items[$delta]->title : NULL,
+      '#maxlength' => 255,
     ];
 
     $element['body'] = [


### PR DESCRIPTION
## Description
The form elements for the title field in the Accordion and Card FieldWidget plugins was missing a `#maxlength` value so the default textfield form element value was being used (128).

## Related Issue
#738 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ProboCI FTW

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
