### PR TITLE
Closes #813: Set 'When' field to not show extra empty widget on Event form display

### DIFF
--- a/modules/custom/az_event/config/install/core.entity_form_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_form_display.node.az_event.default.yml
@@ -88,7 +88,7 @@ content:
   field_az_event_date:
     weight: 11
     settings:
-      show_extra: true
+      show_extra: false
       modal: false
       default_duration: 60
       default_duration_increments: "30\n60|1 hour\n90\n120|2 hours\ncustom"


### PR DESCRIPTION
When working on an issue around Event end dates, Dana noticed that an extra 'When' field automatically gets added on the edit form. This is an easy configuration change.

## Description
Having the extra widget is potentially confusing to content editors. It can easily be turned off on the form display for the field.

## Related Issue
#813 

## How Has This Been Tested?
Tested locally and in Probo

To test:

1. Create an event and save
2. Go back in to edit that same event
3. Confirm that extra 'When' field with start date does not appear unless you click on Add another item.

Probo site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-815.probo.build/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
