### PR TITLE
Closes #745: Polish display for News content type nodes

### DIFF
--- a/modules/custom/az_news/config/install/core.entity_form_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_form_display.node.az_news.default.yml
@@ -85,7 +85,7 @@ content:
     type: text_textarea
     region: content
   field_az_byline:
-    weight: 1
+    weight: 2
     settings:
       size: 60
       placeholder: ''
@@ -93,7 +93,7 @@ content:
     type: string_textfield
     region: content
   field_az_caption:
-    weight: 4
+    weight: 5
     settings:
       rows: 5
       placeholder: ''
@@ -108,7 +108,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: '_none'
+      default_paragraph_type: _none
     third_party_settings: {  }
     type: entity_reference_paragraphs
     region: content
@@ -141,7 +141,7 @@ content:
     third_party_settings: {  }
     region: content
   field_az_media_image:
-    weight: 3
+    weight: 4
     settings:
       media_types: {  }
     third_party_settings: {  }
@@ -154,7 +154,7 @@ content:
     type: options_select
     region: content
   field_az_published:
-    weight: 2
+    weight: 1
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
@@ -168,7 +168,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_az_subheading:
-    weight: 5
+    weight: 3
     settings:
       size: 60
       placeholder: ''

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
@@ -119,7 +119,7 @@ third_party_settings:
         effect: none
         speed: fast
         id: ''
-        classes: 'col-lg-8 offset-lg-2'
+        classes: 'col-lg-10 offset-lg-1'
       label: 'Text Column'
     group_lead:
       children:
@@ -129,7 +129,7 @@ third_party_settings:
       format_type: html_element
       region: content
       format_settings:
-        element: p
+        element: div
         show_label: false
         label_element: h3
         label_element_classes: ''
@@ -192,13 +192,14 @@ third_party_settings:
         effect: none
         speed: fast
         id: ''
-        classes: 'border-bottom pb-3'
+        classes: 'border-bottom pb-2 small'
       label: 'Fig Caption'
   smart_title:
     enabled: true
     settings:
       smart_title__tag: h1
-      smart_title__classes: {  }
+      smart_title__classes:
+        - text-midnight
       smart_title__link: false
 id: node.az_news.default
 targetEntityType: node
@@ -257,7 +258,7 @@ content:
     weight: 6
     label: hidden
     settings:
-      view_mode: default
+      view_mode: az_large
       link: false
     third_party_settings: {  }
     type: entity_reference_entity_view

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
@@ -192,7 +192,7 @@ third_party_settings:
         effect: none
         speed: fast
         id: ''
-        classes: 'border-bottom pb-2 small'
+        classes: 'border-bottom mb-5 small'
       label: 'Fig Caption'
   smart_title:
     enabled: true


### PR DESCRIPTION
Closes #745 

There were several elements we said we'd come back to later to polish how news stories appear for the news content type.

Before:
![image](https://user-images.githubusercontent.com/10873398/120086063-10876900-c092-11eb-9a25-93714ba38361.png)

-Lead body copy not applying to subheading
-Column width appears too narrow on large displays
-Image not full width
-Caption same size as body text

## Description
Changes made by this PR:
-Set column width to `col-lg-10 offset-lg-1`
-Made headline `text-midnight` to match how we have it in other news displays
-Fixed bug where subhead not displaying as lead body copy size (would still love for this to be larger in bootstrap)
-Set image size to large
-Set caption to `small`

Column width is now similar to QS1 and gives about 85 characters max per line. We could make more readable by increasing both text size and line height in bootstrap. 

After:
![image](https://user-images.githubusercontent.com/10873398/120086712-3adb2580-c096-11eb-9132-0d6ac4cfd0ff.png)

Bonus: Updated order of fields on editing form to match same order as they display (since it was bugging me when entering demo content)

## Related Issue
#745 

## How Has This Been Tested?
Tested locally and in Probo

To test:
Create/view news stories at different display sizes

Probo: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-816.probo.build/news/fruit-flies-and-cellular-demise-zeroing-causes-als

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
