### PR TITLE
Closes 743: Updating image styles and display modes

### DIFF
--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_small.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_small.yml
@@ -2,16 +2,17 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.az_small
     - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
     - image.style.az_small
     - media.type.az_image
   module:
     - image
-id: media.az_image.default
+id: media.az_image.az_small
 targetEntityType: media
 bundle: az_image
-mode: default
+mode: az_small
 content:
   field_media_az_image:
     label: visually_hidden

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_square.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_square.yml
@@ -2,21 +2,22 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.media.az_square
     - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_media_az_image
-    - image.style.az_small
+    - image.style.az_square
     - media.type.az_image
   module:
     - image
-id: media.az_image.default
+id: media.az_image.az_square
 targetEntityType: media
 bundle: az_image
-mode: default
+mode: az_square
 content:
   field_media_az_image:
     label: visually_hidden
     settings:
-      image_style: az_small
+      image_style: az_square
       image_link: ''
     third_party_settings: {  }
     type: image

--- a/modules/custom/az_media/config/install/core.entity_view_mode.media.az_large.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_mode.media.az_large.yml
@@ -4,6 +4,6 @@ dependencies:
   module:
     - media
 id: media.az_large
-label: Large
+label: 'Large (100% width)'
 targetEntityType: media
 cache: true

--- a/modules/custom/az_media/config/install/core.entity_view_mode.media.az_large.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_mode.media.az_large.yml
@@ -4,6 +4,6 @@ dependencies:
   module:
     - media
 id: media.az_large
-label: 'Large (100% width)'
+label: 'Large (1140px)'
 targetEntityType: media
 cache: true

--- a/modules/custom/az_media/config/install/core.entity_view_mode.media.az_medium.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_mode.media.az_medium.yml
@@ -4,6 +4,6 @@ dependencies:
   module:
     - media
 id: media.az_medium
-label: 'Medium (66% width)'
+label: 'Medium (760px)'
 targetEntityType: media
 cache: true

--- a/modules/custom/az_media/config/install/core.entity_view_mode.media.az_natural_size.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_mode.media.az_natural_size.yml
@@ -4,6 +4,6 @@ dependencies:
   module:
     - media
 id: media.az_natural_size
-label: 'Natural Size'
+label: 'Original Size'
 targetEntityType: media
 cache: true

--- a/modules/custom/az_media/config/install/core.entity_view_mode.media.az_natural_size.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_mode.media.az_natural_size.yml
@@ -4,6 +4,6 @@ dependencies:
   module:
     - media
 id: media.az_natural_size
-label: 'Original Size'
+label: 'Natural Size'
 targetEntityType: media
 cache: true

--- a/modules/custom/az_media/config/install/core.entity_view_mode.media.az_small.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_mode.media.az_small.yml
@@ -4,6 +4,6 @@ dependencies:
   module:
     - media
 id: media.az_small
-label: 'Small (33% width)'
+label: 'Small (360px)'
 targetEntityType: media
 cache: true

--- a/modules/custom/az_media/config/install/core.entity_view_mode.media.az_small.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_mode.media.az_small.yml
@@ -3,7 +3,7 @@ status: true
 dependencies:
   module:
     - media
-id: media.az_medium
-label: 'Medium (66% width)'
+id: media.az_small
+label: 'Small (33% width)'
 targetEntityType: media
 cache: true

--- a/modules/custom/az_media/config/install/core.entity_view_mode.media.az_square.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_mode.media.az_square.yml
@@ -4,6 +4,6 @@ dependencies:
   module:
     - media
 id: media.az_square
-label: Square
+label: 'Square (220X220px)'
 targetEntityType: media
 cache: true

--- a/modules/custom/az_media/config/install/filter.format.az_standard.yml
+++ b/modules/custom/az_media/config/install/filter.format.az_standard.yml
@@ -1,10 +1,17 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - core.entity_view_mode.media.az_card_image
+    - core.entity_view_mode.media.az_large
+    - core.entity_view_mode.media.az_medium
+    - core.entity_view_mode.media.az_natural_size
+    - core.entity_view_mode.media.az_small
+    - core.entity_view_mode.media.az_square
   module:
+    - bootstrap_utilities
     - entity_embed
     - media
-    - bootstrap_utilities
 name: Standard
 format: az_standard
 weight: -10
@@ -47,16 +54,12 @@ filters:
       allowed_media_types: {  }
       allowed_view_modes:
         default: default
-        az_background: az_background
         az_card_image: az_card_image
         az_large: az_large
         az_medium: az_medium
         az_natural_size: az_natural_size
+        az_small: az_small
         az_square: az_square
-        az_thumbnail: az_thumbnail
-        full: full
-        media_library: media_library
-        token: token
   entity_embed:
     id: entity_embed
     provider: entity_embed
@@ -69,3 +72,14 @@ filters:
     status: true
     weight: 0
     settings: {  }
+  bootstrap_utilities_table_filter:
+    id: bootstrap_utilities_table_filter
+    provider: bootstrap_utilities
+    status: false
+    weight: 0
+    settings:
+      table_remove_width_height: '1'
+      table_row_striping: '0'
+      table_bordered: '0'
+      table_row_hover: '0'
+      table_small: '0'

--- a/modules/custom/az_media/config/install/filter.format.az_standard.yml
+++ b/modules/custom/az_media/config/install/filter.format.az_standard.yml
@@ -46,7 +46,6 @@ filters:
       default_view_mode: default
       allowed_media_types: {  }
       allowed_view_modes:
-        default: default
         az_small: az_small
         az_medium: az_medium
         az_large: az_large

--- a/modules/custom/az_media/config/install/filter.format.az_standard.yml
+++ b/modules/custom/az_media/config/install/filter.format.az_standard.yml
@@ -54,12 +54,12 @@ filters:
       allowed_media_types: {  }
       allowed_view_modes:
         default: default
-        az_card_image: az_card_image
-        az_large: az_large
-        az_medium: az_medium
-        az_natural_size: az_natural_size
         az_small: az_small
+        az_medium: az_medium
+        az_large: az_large
         az_square: az_square
+        az_card_image: az_card_image        
+        az_natural_size: az_natural_size        
   entity_embed:
     id: entity_embed
     provider: entity_embed

--- a/modules/custom/az_media/config/install/filter.format.az_standard.yml
+++ b/modules/custom/az_media/config/install/filter.format.az_standard.yml
@@ -1,17 +1,10 @@
 langcode: en
 status: true
 dependencies:
-  config:
-    - core.entity_view_mode.media.az_card_image
-    - core.entity_view_mode.media.az_large
-    - core.entity_view_mode.media.az_medium
-    - core.entity_view_mode.media.az_natural_size
-    - core.entity_view_mode.media.az_small
-    - core.entity_view_mode.media.az_square
   module:
-    - bootstrap_utilities
     - entity_embed
     - media
+    - bootstrap_utilities
 name: Standard
 format: az_standard
 weight: -10
@@ -57,9 +50,8 @@ filters:
         az_small: az_small
         az_medium: az_medium
         az_large: az_large
-        az_square: az_square
-        az_card_image: az_card_image        
-        az_natural_size: az_natural_size        
+        az_square: az_square        
+        az_natural_size: az_natural_size   
   entity_embed:
     id: entity_embed
     provider: entity_embed
@@ -72,14 +64,3 @@ filters:
     status: true
     weight: 0
     settings: {  }
-  bootstrap_utilities_table_filter:
-    id: bootstrap_utilities_table_filter
-    provider: bootstrap_utilities
-    status: false
-    weight: 0
-    settings:
-      table_remove_width_height: '1'
-      table_row_striping: '0'
-      table_bordered: '0'
-      table_row_hover: '0'
-      table_small: '0'

--- a/modules/custom/az_media/config/install/image.style.az_medium.yml
+++ b/modules/custom/az_media/config/install/image.style.az_medium.yml
@@ -1,13 +1,13 @@
 langcode: en
 status: true
 name: az_medium
-label: 'Medium (360px wide)'
+label: 'Medium (760px wide)'
 effects:
   a8a842a4-6670-4288-8f98-3b161f597ec9:
     uuid: a8a842a4-6670-4288-8f98-3b161f597ec9
     id: image_scale
     weight: 1
     data:
-      width: 360
+      width: 760
       height: null
       upscale: true

--- a/modules/custom/az_media/config/install/image.style.az_small.yml
+++ b/modules/custom/az_media/config/install/image.style.az_small.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+name: az_small
+label: 'Small (360px)'
+effects:
+  a5aee9bc-6dd3-4b48-b04e-027cc8017630:
+    uuid: a5aee9bc-6dd3-4b48-b04e-027cc8017630
+    id: image_scale
+    weight: 1
+    data:
+      width: 360
+      height: null
+      upscale: true

--- a/modules/custom/az_media/config/install/image.style.az_square.yml
+++ b/modules/custom/az_media/config/install/image.style.az_square.yml
@@ -1,0 +1,14 @@
+langcode: en
+status: true
+dependencies: {  }
+name: az_square
+label: 'Square (220x220)'
+effects:
+  c9a0104f-9943-426f-813a-0b5e2cb765c0:
+    uuid: c9a0104f-9943-426f-813a-0b5e2cb765c0
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 220
+      height: 220
+      anchor: center-center


### PR DESCRIPTION
This PR adds needed image styles, view modes, and displays for using images at different sizes (more closely matching QS1)

## Description
Currently some image styles/displays are missing or do not work properly. This PR:

- Adds view mode, image style, and display for "small" - set to 360px (same as QS1)
- Adds image style and updates display for "square" - set to 220x220 (same as QS1)
- Updates image style for medium to 760px (to match QS1, was 360px)
- Updates which embed media is used by Standard text formatter (now: default, small, medium, large, original, card image)
- Set default display to use the small image style (default in QS1 is small)

Some questions/issues:
- Images do not scale based on the column width of where the are placed (I believe they do in QS1, but not sure how that is achieved. (Note: discussed at PR review on 6/2 and seemed like we may be ok with just going with set pixel sizes for now as long as responsive on small screens)
- Should the default be small? Should default view mode be removed as an option?
- Should card image be a selectable option? (It is not in QS1)
- Are all sizes correct?

## Related Issue
#743 

## How Has This Been Tested?
Locally and in Probo
https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-817.probo.build/image-sizes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
