### PR TITLE
Closes #831 Adding az-icons as dependency of arizona-bootstrap

### DIFF
--- a/themes/custom/az_barrio/az_barrio.libraries.yml
+++ b/themes/custom/az_barrio/az_barrio.libraries.yml
@@ -12,6 +12,10 @@ az-proxima-nova:
   css:
     theme:
       https://use.typekit.net/emv3zbo.css: {}
+az-icons:
+  css:
+    theme:
+      https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css: {}
 arizona-bootstrap:
   css:
     theme:
@@ -20,10 +24,7 @@ arizona-bootstrap:
     /libraries/arizona-bootstrap/js/arizona-bootstrap.bundle.min.js: {}
   dependencies:
     - core/jquery
-az-brand-icons:
-  css:
-    theme:
-      libraries/ua-brand-icons/ua-brand-icons.min.css: {}
+    - az_barrio/az-icons
 material-design-icons-sharp:
   css:
     theme:


### PR DESCRIPTION
## Description
Added cdn link in library file for az_barrio as a dependency of arizona-bootstrap library.


## Related Issue
#831 

## How Has This Been Tested?
Added 
```
<img style="height: 450px;width:auto;" src="https://cdn.digital.arizona.edu/lib/az-icons/main/svg/arizona.svg">
<i class="az-icon-arizona"></i>
```
to `page.html.twig` locally and icon appeared.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
