### PR TITLE
Closes #736: Adding patch to fix claro dialog with ckeditor_bs_grid plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "drupal/config_snapshot": "1.0-rc2",
         "drupal/config_sync": "2.0-beta7",
         "drupal/config_update": "1.7",
+        "drupal/console": "^1.9",
         "drupal/core-recommended": "9.1.9",
         "drupal/crop": "2.1",
         "drupal/ctools": "3.6",
@@ -101,6 +102,9 @@
             "drupal/cas": {
                 "ServiceNotFoundException when logging out": "https://www.drupal.org/files/issues/cas_logout_error-2948185-2.patch",
                 "Module add migration for D7": "https://www.drupal.org/files/issues/2021-02-24/add-migration-for-d7-3038662-10.patch"
+            },
+            "drupal/ckeditor_bs_grid": {
+                "Remove overrides to Claro defaults for dialog (3218760)": "https://git.drupalcode.org/issue/ckeditor_bs_grid-3218760/-/commit/55b5726b9a0b6bc5bd5703257c6b720a297e3f5b.diff"
             },
             "drupal/config_sync": {
                 "Config_sync_test core constraint": "https://gist.githubusercontent.com/tadean/602c6412fbbdcc16a2d8a0fb58642f9e/raw/2ef503a4c0ae7d459f7c789d6ad3720d92945880/config_sync_test_core_requirement_issue.patch"

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
         "drupal/config_snapshot": "1.0-rc2",
         "drupal/config_sync": "2.0-beta7",
         "drupal/config_update": "1.7",
-        "drupal/console": "^1.9",
         "drupal/core-recommended": "9.1.9",
         "drupal/crop": "2.1",
         "drupal/ctools": "3.6",


### PR DESCRIPTION
## Description
Added patch to Drupal.org for issue https://www.drupal.org/project/ckeditor_bs_grid/issues/3218760
Have not tested if this breaks core, and not sure if we should worry about that.

There is also some discussion about setting equal width as the default option 
https://www.drupal.org/project/ckeditor_bs_grid/issues/3208113
which has been blocked by https://www.drupal.org/project/ckeditor_bs_grid/issues/3193368

## Related Issue
https://github.com/az-digital/az_quickstart/issues/736


## How Has This Been Tested?
Probo and local.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] All new and existing tests passed.
