### PR TITLE
Closes #842: Add photo gallery to news

### DIFF
--- a/modules/custom/az_news/az_news.info.yml
+++ b/modules/custom/az_news/az_news.info.yml
@@ -22,7 +22,7 @@ dependencies:
   - az_paragraphs
   - az_paragraphs_cards
   - az_paragraphs_contact
-  - az_paragraphs _photo_gallery
+  - az_paragraphs_photo_gallery
   - az_paragraphs_text
   - smart_title:smart_title
   - date_ap_style:date_ap_style

--- a/modules/custom/az_news/az_news.info.yml
+++ b/modules/custom/az_news/az_news.info.yml
@@ -22,6 +22,7 @@ dependencies:
   - az_paragraphs
   - az_paragraphs_cards
   - az_paragraphs_contact
+  - az_paragraphs _photo_gallery
   - az_paragraphs_text
   - smart_title:smart_title
   - date_ap_style:date_ap_style

--- a/modules/custom/az_news/az_news.install.php
+++ b/modules/custom/az_news/az_news.install.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * az_news.install
+ * Install, update and uninstall functions for az_news module.
  */
 
 /**

--- a/modules/custom/az_news/az_news.install.php
+++ b/modules/custom/az_news/az_news.install.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * az_news.install
+ */
+
+/**
+ * Install az_paragraphs_photo_gallery.
+ */
+function az_news_update_9201() {
+  \Drupal::service('module_installer')->install(['az_paragraphs_photo_gallery']);
+}

--- a/modules/custom/az_news/config/install/field.field.node.az_news.field_az_main_content.yml
+++ b/modules/custom/az_news/config/install/field.field.node.az_news.field_az_main_content.yml
@@ -5,6 +5,7 @@ dependencies:
     - field.storage.node.field_az_main_content
     - node.type.az_news
     - paragraphs.paragraphs_type.az_cards
+    - paragraphs.paragraphs_type.az_photo_gallery
     - paragraphs.paragraphs_type.az_text
   module:
     - entity_reference_revisions
@@ -24,6 +25,7 @@ settings:
     negate: 0
     target_bundles:
       az_cards: az_cards
+      az_photo_gallery: az_photo_gallery
       az_text: az_text
     target_bundles_drag_drop:
       az_cards:
@@ -32,7 +34,10 @@ settings:
       az_text:
         enabled: true
         weight: 5
-      az_view_reference:
+      az_photo_gallery:
+        enabled: true
         weight: 6
+      az_view_reference:
+        weight: 7
         enabled: false
 field_type: entity_reference_revisions


### PR DESCRIPTION
This adds the 'Photo Gallery' paragraph type to the extra body field on News

## Description
The photo gallery paragraph was not available when we first built the News content type, but it is a useful way for editors to add images to stories.

![image](https://user-images.githubusercontent.com/10873398/122139601-2e78fb80-cdfe-11eb-8f03-b70c93e72d2d.png)

## Related Issue
#842

## How Has This Been Tested?
Tested locally and in Probo.

To test:
1. Add Content > News
2. Add the the photo gallery paragraph at the bottom of your story.
3. Verify that the grid or slider appears

https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-846.probo.build/news/test-news-photo-gallery

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
