### PR TITLE
Closes #864, Relates az-digital/arizona-bootstrap#318: Active state of sidebar nav.

### DIFF
--- a/themes/custom/az_barrio/css/style.css
+++ b/themes/custom/az_barrio/css/style.css
@@ -489,6 +489,32 @@ a.nolink + ul .sf-clone-parent {
   background: none 0 0 scroll no-repeat transparent;
 }
 
+/* SIDE MENUS */
+.sidebar ul.menu {
+  list-style: none outside none;
+  padding: 0;
+  margin: 0;
+}
+.sidebar ul.menu li {
+  list-style: none outside none;
+  padding: 0;
+  margin: 0;
+  display: block;
+}
+.sidebar ul.menu li > a,
+.sidebar ul.menu li > a:link,
+.sidebar ul.menu li > a:visited {
+  position: relative;
+  padding: 10px 16px;
+  padding: 0.625rem 1rem;
+  text-decoration: none;
+  font-weight: normal;
+  display: block;
+  color: #333;
+}
+
+@media screen and (min-width: 60em) {
+
 .region-sidebar-first .block,
 .region-sidebar-second .block {
   margin-bottom: 24px !important;

--- a/themes/custom/az_barrio/css/style.css
+++ b/themes/custom/az_barrio/css/style.css
@@ -489,52 +489,6 @@ a.nolink + ul .sf-clone-parent {
   background: none 0 0 scroll no-repeat transparent;
 }
 
-/* SIDE MENUS */
-@media screen and (min-width: 60em) {
-  .sidebar ul.menu {
-    list-style: none outside none;
-    padding: 0;
-    margin: 0;
-  }
-  .sidebar ul.menu li {
-    list-style: none outside none;
-    padding: 0;
-    margin: 0;
-    display: block;
-  }
-  .sidebar ul.menu li > a,
-  .sidebar ul.menu li > a:link,
-  .sidebar ul.menu li > a:visited {
-    position: relative;
-    padding: 10px 16px;
-    padding: 0.625rem 1rem;
-    text-decoration: none;
-    font-weight: normal;
-    display: block;
-    color: #333;
-  }
-
-  .region-sidebar-first .menu > li > a:hover,
-  .region-sidebar-first .menu > li > a:focus,
-  .region-sidebar-first .menu > li.active a,
-  .region-sidebar-first .menu > li a.active {
-    background: url("../images/sidebar-menu-chevron-left.png") no-repeat scroll 100% center/30px 100% #dee8e7;
-    border-bottom: 0 solid transparent;
-    color: #076873;
-    text-decoration: none;
-  }
-
-  .region-sidebar-second .menu > li > a:hover,
-  .region-sidebar-second .menu > li > a:focus,
-  .region-sidebar-second .menu > li.active a,
-  .region-sidebar-second .menu > li a.active {
-    background: url("../images/sidebar-menu-chevron-right.png") no-repeat scroll 0 center/30px 100% #dee8e7;
-    border-bottom: 0 solid transparent;
-    color: #076873;
-    text-decoration: none;
-  }
-}
-
 .region-sidebar-first .block,
 .region-sidebar-second .block {
   margin-bottom: 24px !important;

--- a/themes/custom/az_barrio/templates/navigation/menu--sidebar.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--sidebar.html.twig
@@ -46,7 +46,6 @@
         {%
           set link_classes = [
             'nav-link',
-            item.in_active_trail ? 'active',
             item.url.getOption('attributes').class ? item.url.getOption('attributes').class | join(''),
             'nav-link-' ~ item.url.toString() | clean_class,
           ]


### PR DESCRIPTION
## Description
Removed active class from active trail items because arizona bootstrap reserves the active class for actually active links.
Blocked by https://github.com/az-digital/arizona-bootstrap/pull/319


## Related Issue
Blocked by https://github.com/az-digital/arizona-bootstrap/issues/318
Closes #864

## How Has This Been Tested?
Locally by compiling arizona bootstrap from PR 318 and moving it into az_quickstart

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (for anyone using the `active` class in custom css)

## Checklist:
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
