### PR TITLE
Closes #886: Force install of field_az_metatag field storage to resolve config dependencies preventing config distro import.

### DIFF
--- a/modules/custom/az_seo/az_seo.install
+++ b/modules/custom/az_seo/az_seo.install
@@ -1,0 +1,19 @@
+<?php
+
+use Drupal\Core\Config\FileStorage;
+
+/**
+ * @file
+ * Install, update and uninstall functions for az_seo module.
+ */
+
+/**
+ * Force import of field.storage.node.field_az_metatag config.
+ */
+function az_seo_update_9201() {
+  $module_handler = \Drupal::service('module_handler');
+  $config_path = $module_handler->getModule('az_seo')->getPath() . '/config/install';
+  $storage = new FileStorage($config_path);
+  $config_installer = \Drupal::service('config.installer');
+  $config_installer->installOptionalConfig($storage);
+}

--- a/modules/custom/az_seo/az_seo.install
+++ b/modules/custom/az_seo/az_seo.install
@@ -1,11 +1,11 @@
 <?php
 
-use Drupal\Core\Config\FileStorage;
-
 /**
  * @file
  * Install, update and uninstall functions for az_seo module.
  */
+
+use Drupal\Core\Config\FileStorage;
 
 /**
  * Force import of field.storage.node.field_az_metatag config.


### PR DESCRIPTION
## Description
Adds DB update to force install of `field_az_metatag` field storage to resolve config dependencies preventing config distro import.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#886 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on multidev version of existing Quicsktart 2 site on Pantheon.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
