### PR TITLE
Closes #447 #448: Add captions and credit field to inline images

### DIFF
--- a/modules/custom/az_media/config/install/core.entity_form_display.media.az_image.default.yml
+++ b/modules/custom/az_media/config/install/core.entity_form_display.media.az_image.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.media.az_image.field_az_caption
+    - field.field.media.az_image.field_az_credit
     - field.field.media.az_image.field_media_az_image
     - image.style.thumbnail
     - media.type.az_image
@@ -28,6 +29,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
+    region: content
+  field_az_credit:
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textfield
     region: content
   field_media_az_image:
     settings:

--- a/modules/custom/az_media/config/install/core.entity_form_display.media.az_image.media_library.yml
+++ b/modules/custom/az_media/config/install/core.entity_form_display.media.az_image.media_library.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_form_mode.media.media_library
     - field.field.media.az_image.field_az_caption
+    - field.field.media.az_image.field_az_credit
     - field.field.media.az_image.field_media_az_image
     - image.style.thumbnail
     - media.type.az_image
@@ -21,6 +22,14 @@ content:
     region: content
     settings:
       rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_credit:
+    type: text_textfield
+    weight: 2
+    region: content
+    settings:
+      size: 60
       placeholder: ''
     third_party_settings: {  }
   field_media_az_image:

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_large.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_large.yml
@@ -4,16 +4,91 @@ dependencies:
   config:
     - core.entity_view_mode.media.az_large
     - field.field.media.az_image.field_az_caption
+    - field.field.media.az_image.field_az_credit
     - field.field.media.az_image.field_media_az_image
     - image.style.az_large
     - media.type.az_image
   module:
+    - field_group
     - image
+    - text
+third_party_settings:
+  field_group:
+    group_figure:
+      children:
+        - field_media_az_image
+        - group_fig_caption
+      parent_name: ''
+      weight: 3
+      format_type: html_element
+      region: content
+      format_settings:
+        element: figure
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: 'style="max-width: 1140px;"'
+        effect: none
+        speed: fast
+        id: ''
+        classes: ''
+      label: Figure
+    group_fig_caption:
+      children:
+        - field_az_caption
+        - group_cite
+      parent_name: group_figure
+      weight: 1
+      format_type: html_element
+      region: content
+      format_settings:
+        id: ''
+        classes: fig-caption
+        element: figcaption
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+      label: 'Fig Caption'
+    group_cite:
+      children:
+        - field_az_credit
+      parent_name: group_fig_caption
+      weight: 2
+      format_type: html_element
+      region: content
+      format_settings:
+        element: cite
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: small
+        effect: none
+        speed: fast
+        id: ''
+        classes: ''
+      label: Cite
 id: media.az_image.az_large
 targetEntityType: media
 bundle: az_image
 mode: az_large
 content:
+  field_az_caption:
+    type: text_default
+    weight: 1
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_az_credit:
+    type: text_default
+    weight: 2
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
   field_media_az_image:
     label: visually_hidden
     settings:
@@ -21,11 +96,10 @@ content:
       image_link: ''
     third_party_settings: {  }
     type: image
-    weight: 1
+    weight: 0
     region: content
 hidden:
   created: true
-  field_az_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_large.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_large.yml
@@ -43,7 +43,7 @@ third_party_settings:
       region: content
       format_settings:
         id: ''
-        classes: fig-caption
+        classes: figure-caption
         element: figcaption
         show_label: false
         label_element: h3
@@ -64,11 +64,11 @@ third_party_settings:
         show_label: false
         label_element: h3
         label_element_classes: ''
-        attributes: small
+        attributes: ''
         effect: none
         speed: fast
         id: ''
-        classes: ''
+        classes: small
       label: Cite
 id: media.az_image.az_large
 targetEntityType: media

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_medium.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_medium.yml
@@ -43,7 +43,7 @@ third_party_settings:
       region: content
       format_settings:
         id: ''
-        classes: fig-caption
+        classes: figure-caption
         element: figcaption
         show_label: false
         label_element: h3

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_medium.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_medium.yml
@@ -4,16 +4,91 @@ dependencies:
   config:
     - core.entity_view_mode.media.az_medium
     - field.field.media.az_image.field_az_caption
+    - field.field.media.az_image.field_az_credit
     - field.field.media.az_image.field_media_az_image
     - image.style.az_medium
     - media.type.az_image
   module:
+    - field_group
     - image
+    - text
+third_party_settings:
+  field_group:
+    group_figure:
+      children:
+        - field_media_az_image
+        - group_fig_caption
+      parent_name: ''
+      weight: 1
+      format_type: html_element
+      region: content
+      format_settings:
+        element: figure
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: 'style="max-width: 760px;"'
+        effect: none
+        speed: fast
+        id: ''
+        classes: ''
+      label: Figure
+    group_fig_caption:
+      children:
+        - field_az_caption
+        - group_cite
+      parent_name: group_figure
+      weight: 1
+      format_type: html_element
+      region: content
+      format_settings:
+        id: ''
+        classes: fig-caption
+        element: figcaption
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+      label: 'Fig Caption'
+    group_cite:
+      children:
+        - field_az_credit
+      parent_name: group_fig_caption
+      weight: 3
+      format_type: html_element
+      region: content
+      format_settings:
+        element: cite
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        id: ''
+        classes: small
+      label: Cite
 id: media.az_image.az_medium
 targetEntityType: media
 bundle: az_image
 mode: az_medium
 content:
+  field_az_caption:
+    type: text_default
+    weight: 2
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_az_credit:
+    type: text_default
+    weight: 3
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
   field_media_az_image:
     label: visually_hidden
     settings:
@@ -21,11 +96,10 @@ content:
       image_link: ''
     third_party_settings: {  }
     type: image
-    weight: 1
+    weight: 0
     region: content
 hidden:
   created: true
-  field_az_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml
@@ -42,7 +42,7 @@ third_party_settings:
       region: content
       format_settings:
         id: ''
-        classes: fig-caption
+        classes: figure-caption
         element: figcaption
         show_label: false
         label_element: h3

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml
@@ -4,15 +4,90 @@ dependencies:
   config:
     - core.entity_view_mode.media.az_natural_size
     - field.field.media.az_image.field_az_caption
+    - field.field.media.az_image.field_az_credit
     - field.field.media.az_image.field_media_az_image
     - media.type.az_image
   module:
+    - field_group
     - image
+    - text
+third_party_settings:
+  field_group:
+    group_figure:
+      children:
+        - field_media_az_image
+        - group_fig_caption
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        id: ''
+        classes: ''
+        element: figure
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+      label: Figure
+    group_fig_caption:
+      children:
+        - field_az_caption
+        - group_cite
+      parent_name: group_figure
+      weight: 2
+      format_type: html_element
+      region: content
+      format_settings:
+        id: ''
+        classes: fig-caption
+        element: figcaption
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+      label: 'Fig Caption'
+    group_cite:
+      children:
+        - field_az_credit
+      parent_name: group_fig_caption
+      weight: 4
+      format_type: html_element
+      region: content
+      format_settings:
+        element: cite
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        id: ''
+        classes: small
+      label: Cite
 id: media.az_image.az_natural_size
 targetEntityType: media
 bundle: az_image
 mode: az_natural_size
 content:
+  field_az_caption:
+    type: text_default
+    weight: 3
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_az_credit:
+    type: text_default
+    weight: 5
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
   field_media_az_image:
     label: visually_hidden
     settings:
@@ -24,7 +99,6 @@ content:
     region: content
 hidden:
   created: true
-  field_az_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_small.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_small.yml
@@ -43,7 +43,7 @@ third_party_settings:
       region: content
       format_settings:
         id: ''
-        classes: fig-caption
+        classes: figure-caption
         element: figcaption
         show_label: false
         label_element: h3

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_small.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_small.yml
@@ -4,16 +4,91 @@ dependencies:
   config:
     - core.entity_view_mode.media.az_small
     - field.field.media.az_image.field_az_caption
+    - field.field.media.az_image.field_az_credit
     - field.field.media.az_image.field_media_az_image
     - image.style.az_small
     - media.type.az_image
   module:
+    - field_group
     - image
+    - text
+third_party_settings:
+  field_group:
+    group_figure:
+      children:
+        - field_media_az_image
+        - group_fig_caption
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        element: figure
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: 'style="max-width: 360px;"'
+        effect: none
+        speed: fast
+        id: ''
+        classes: ''
+      label: Figure
+    group_fig_caption:
+      children:
+        - field_az_caption
+        - group_cite
+      parent_name: group_figure
+      weight: 2
+      format_type: html_element
+      region: content
+      format_settings:
+        id: ''
+        classes: fig-caption
+        element: figcaption
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+      label: 'Fig Caption'
+    group_cite:
+      children:
+        - field_az_credit
+      parent_name: group_fig_caption
+      weight: 3
+      format_type: html_element
+      region: content
+      format_settings:
+        id: ''
+        classes: small
+        element: cite
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+      label: Cite
 id: media.az_image.az_small
 targetEntityType: media
 bundle: az_image
 mode: az_small
 content:
+  field_az_caption:
+    type: text_default
+    weight: 2
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_az_credit:
+    type: text_default
+    weight: 1
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
   field_media_az_image:
     label: visually_hidden
     settings:
@@ -21,11 +96,10 @@ content:
       image_link: ''
     third_party_settings: {  }
     type: image
-    weight: 0
+    weight: 1
     region: content
 hidden:
   created: true
-  field_az_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_square.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_square.yml
@@ -4,16 +4,91 @@ dependencies:
   config:
     - core.entity_view_mode.media.az_square
     - field.field.media.az_image.field_az_caption
+    - field.field.media.az_image.field_az_credit
     - field.field.media.az_image.field_media_az_image
     - image.style.az_square
     - media.type.az_image
   module:
+    - field_group
     - image
+    - text
+third_party_settings:
+  field_group:
+    group_figure:
+      children:
+        - field_media_az_image
+        - group_fig
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        element: figure
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: 'style="max-width: 220px;"'
+        effect: none
+        speed: fast
+        id: ''
+        classes: ''
+      label: Figure
+    group_fig:
+      children:
+        - field_az_caption
+        - group_cite
+      parent_name: group_figure
+      weight: 2
+      format_type: html_element
+      region: content
+      format_settings:
+        element: figcaption
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        id: ''
+        classes: figure-caption
+      label: 'Fig Caption'
+    group_cite:
+      children:
+        - field_az_credit
+      parent_name: group_fig
+      weight: 4
+      format_type: html_element
+      region: content
+      format_settings:
+        id: ''
+        classes: small
+        element: cite
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+      label: Cite
 id: media.az_image.az_square
 targetEntityType: media
 bundle: az_image
 mode: az_square
 content:
+  field_az_caption:
+    type: text_default
+    weight: 3
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_az_credit:
+    type: text_default
+    weight: 4
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
   field_media_az_image:
     label: visually_hidden
     settings:
@@ -21,11 +96,10 @@ content:
       image_link: ''
     third_party_settings: {  }
     type: image
-    weight: 0
+    weight: 1
     region: content
 hidden:
   created: true
-  field_az_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.default.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.default.yml
@@ -3,16 +3,143 @@ status: true
 dependencies:
   config:
     - field.field.media.az_image.field_az_caption
+    - field.field.media.az_image.field_az_credit
     - field.field.media.az_image.field_media_az_image
     - image.style.az_small
     - media.type.az_image
   module:
+    - field_group
     - image
+    - text
+third_party_settings:
+  field_group:
+    group_figure:
+      children:
+        - field_media_az_image
+        - group_fig_caption
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        element: figure
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: 'style="max-width: 360px;"'
+        effect: none
+        speed: fast
+        id: ''
+        classes: ''
+      label: Figure
+    group_fig_caption:
+      children:
+        - field_az_caption
+        - group_cite
+      parent_name: group_figure
+      weight: 2
+      format_type: html_element
+      region: content
+      format_settings:
+        element: figcaption
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        id: ''
+        classes: figure-caption
+      label: 'Fig Caption'
+    group_content:
+      children:
+        - group_row
+      parent_name: ''
+      weight: 5
+      format_type: html_element
+      region: hidden
+      format_settings:
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        id: ''
+        classes: ''
+      label: Content
+    group_cite:
+      children:
+        - field_az_credit
+      parent_name: group_fig_caption
+      weight: 4
+      format_type: html_element
+      region: content
+      format_settings:
+        element: cite
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        id: ''
+        classes: small
+      label: Cite
+    group_row:
+      children: {  }
+      parent_name: group_content
+      weight: 2
+      format_type: html_element
+      region: hidden
+      format_settings:
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        id: ''
+        classes: row
+      label: 'Image Row'
+    group_caption:
+      children: {  }
+      parent_name: ''
+      weight: 6
+      format_type: html_element
+      region: hidden
+      format_settings:
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        id: ''
+        classes: row
+      label: 'Caption Row'
 id: media.az_image.default
 targetEntityType: media
 bundle: az_image
 mode: default
 content:
+  field_az_caption:
+    type: text_default
+    weight: 3
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_az_credit:
+    weight: 4
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
   field_media_az_image:
     label: visually_hidden
     settings:
@@ -20,11 +147,10 @@ content:
       image_link: ''
     third_party_settings: {  }
     type: image
-    weight: 0
+    weight: 1
     region: content
 hidden:
   created: true
-  field_az_caption: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/custom/az_media/config/install/field.field.media.az_image.field_az_credit.yml
+++ b/modules/custom/az_media/config/install/field.field.media.az_image.field_az_credit.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_az_credit
+    - filter.format.plain_text
+    - media.type.az_image
+  module:
+    - text
+id: media.az_image.field_az_credit
+field_name: field_az_credit
+entity_type: media
+bundle: az_image
+label: 'Image Credit'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - plain_text
+field_type: text

--- a/modules/custom/az_media/config/install/field.storage.media.field_az_credit.yml
+++ b/modules/custom/az_media/config/install/field.storage.media.field_az_credit.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - text
+id: media.field_az_credit
+field_name: field_az_credit
+entity_type: media
+type: text
+settings:
+  max_length: 255
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
This PR adds captions to each view mode of inline images and also creates/adds a field for image credit

## Description
A caption field already exists, but was not displaying on images add via the ckeditor. This PR adds the caption field to each view mode (default, small, medium, large, natural, square) and also creates a new field for image credit.

Styling needs to be added for figcaption but may be best as a separate bootstrap ticket ([#322](https://app.zenhub.com/workspaces/quickstart-20-5e8f25351c5b8596956ebb92/issues/az-digital/arizona-bootstrap/322))

## Related Issue
#447
#448 


## How Has This Been Tested?
Tested locally and in Probo:
https://cd6b51a5-110f-4cd6-8d2d-6aaaeec8ff25.probo.build/test-captions

To test:

1. Create a page
2. Add an image
3. Enter caption and credit when adding
4. Edit media and set a size
5. Verify image, caption, and credit field appear.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
