### PR TITLE
Fixes #873 Add default timezone settings.

### DIFF
--- a/config/install/system.date.yml
+++ b/config/install/system.date.yml
@@ -1,0 +1,9 @@
+country:
+  default: ''
+first_day: 0
+timezone:
+  default: America/Phoenix
+  user:
+    configurable: true
+    warn: false
+    default: 0


### PR DESCRIPTION
## Description
This sets a default timezone to Arizona/Phoenix for Quickstart sites, which hadn't previously been set. This resulted in the default timezone being UTC, and making most user accounts default to UTC for their own timezone settings. This resulted in dates being a little confusing on new builds.

## Related Issue
#873 

## How Has This Been Tested?
- Visit `admin/config/regional/settings` and verify the timezone has been set to Phoenix.
- Visit the edit page of individidual users and verify that their default timezone is Phoenix rather than UTC.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
