### PR TITLE
Closes #748: Set video display modes

### DIFF
--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_remote_video.az_large.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_remote_video.az_large.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.az_large
+    - field.field.media.az_remote_video.field_media_az_oembed_video
+    - media.type.az_remote_video
+  module:
+    - field_group
+    - media
+third_party_settings:
+  field_group:
+    group_16x9:
+      children:
+        - field_media_az_oembed_video
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        id: ''
+        classes: 'embed-responsive embed-responsive-16by9'
+      label: '16:9 Responsive'
+id: media.az_remote_video.az_large
+targetEntityType: media
+bundle: az_remote_video
+mode: az_large
+content:
+  field_media_az_oembed_video:
+    type: oembed
+    weight: 1
+    label: hidden
+    settings:
+      max_width: 0
+      max_height: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_remote_video.az_medium.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_remote_video.az_medium.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.az_medium
+    - field.field.media.az_remote_video.field_media_az_oembed_video
+    - media.type.az_remote_video
+  module:
+    - field_group
+    - media
+third_party_settings:
+  field_group:
+    group_16x9:
+      children:
+        - field_media_az_oembed_video
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: 'style="max-width: 760px;"'
+        effect: none
+        speed: fast
+        id: ''
+        classes: 'embed-responsive embed-responsive-16by9'
+      label: '16:9 Responsive'
+id: media.az_remote_video.az_medium
+targetEntityType: media
+bundle: az_remote_video
+mode: az_medium
+content:
+  field_media_az_oembed_video:
+    type: oembed
+    weight: 1
+    label: hidden
+    settings:
+      max_width: 0
+      max_height: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_remote_video.az_natural_size.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_remote_video.az_natural_size.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.az_natural_size
+    - field.field.media.az_remote_video.field_media_az_oembed_video
+    - media.type.az_remote_video
+  module:
+    - field_group
+    - media
+third_party_settings:
+  field_group:
+    group_16x9:
+      children:
+        - field_media_az_oembed_video
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        id: ''
+        classes: 'embed-responsive embed-responsive-16by9'
+      label: '16:9 Responsive'
+id: media.az_remote_video.az_natural_size
+targetEntityType: media
+bundle: az_remote_video
+mode: az_natural_size
+content:
+  field_media_az_oembed_video:
+    type: oembed
+    weight: 1
+    label: hidden
+    settings:
+      max_width: 0
+      max_height: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_remote_video.az_small.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_remote_video.az_small.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.az_small
+    - field.field.media.az_remote_video.field_media_az_oembed_video
+    - media.type.az_remote_video
+  module:
+    - field_group
+    - media
+third_party_settings:
+  field_group:
+    group_16x9:
+      children:
+        - field_media_az_oembed_video
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: 'style="max-width: 360px;"'
+        effect: none
+        speed: fast
+        id: ''
+        classes: 'embed-responsive embed-responsive-16by9'
+      label: '16:9 Responsive'
+id: media.az_remote_video.az_small
+targetEntityType: media
+bundle: az_remote_video
+mode: az_small
+content:
+  field_media_az_oembed_video:
+    type: oembed
+    weight: 1
+    label: hidden
+    settings:
+      max_width: 0
+      max_height: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_remote_video.az_square.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_remote_video.az_square.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.az_square
+    - field.field.media.az_remote_video.field_media_az_oembed_video
+    - media.type.az_remote_video
+  module:
+    - field_group
+    - media
+third_party_settings:
+  field_group:
+    group_16x9:
+      children:
+        - field_media_az_oembed_video
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: 'style="max-width: 220px;"'
+        effect: none
+        speed: fast
+        id: ''
+        classes: 'embed-responsive embed-responsive-4by3'
+      label: '4:3 Responsive'
+id: media.az_remote_video.az_square
+targetEntityType: media
+bundle: az_remote_video
+mode: az_square
+content:
+  field_media_az_oembed_video:
+    type: oembed
+    weight: 1
+    label: hidden
+    settings:
+      max_width: 0
+      max_height: 0
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  name: true
+  thumbnail: true
+  uid: true


### PR DESCRIPTION
This PR creates display modes for remote videos similar to images and with the same sizing.

## Description
Content editors in QS 2 currently can select the same sizes when adding a remote video as they do for images, but these sizes do not do anything because the Remote video view modes are not set.

This PR adds view modes for small, medium, large, natural size, and square and also set a max-width for some sizes (to match what we did for images):
- small: max-width 360px
- medium: max-width 760 px
- square: max-width 220 px (and also 4:30 ratio matching QS1)
- default: no sizing
- large: no sizing
- natural size: no sizing

## Related Issue
#748 

## How Has This Been Tested?
Tested locally and in Probo.
Review site: https://a2169b16-8bb1-49a6-802a-1096efb6c13b.probo.build/video-display-modes

To test:
1. Add video to page
2. Edit media and select size
3. Verify that the video appears at correct size
4. View video at different screen sizes (small/square should stay the same, medium, large should scale responsively on smaller screens

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
