### PR TITLE
Add Content Moderation to install profile

### DIFF
--- a/az_quickstart.info.yml
+++ b/az_quickstart.info.yml
@@ -31,6 +31,7 @@ install:
   - drupal:ckeditor
   - drupal:color
   - drupal:config
+  - drupal:content_moderation
   - drupal:contextual
   - drupal:menu_link_content
   - drupal:datetime


### PR DESCRIPTION
## Description
Adds the Content Moderation (in core) module to the install profile in order to address content permissions issue. By enabling the module, you grant "view unpublished" permissions to editors without modifying permissions to a per node basis. This method keeps permissions on a per node type basis. Enabling the module does not enable content workflows--you must manually enable workflows to specific content types.

## Related Issue
Closes #844 

## How Has This Been Tested?
Locally and on Probo

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
