### PR TITLE
Closes #651 Show full paragraph type labels in the editor experience

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
@@ -50,6 +50,7 @@ az_paragraphs.preview:
   css:
     theme:
       css/az_paragraphs_preview.css: {}
+      css/az_paragraphs_widget.css: {}
   dependencies:
     - az_barrio/global-styling
     - az_barrio/arizona-bootstrap

--- a/modules/custom/az_paragraphs/css/az_paragraphs_widget.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_widget.css
@@ -1,0 +1,3 @@
+.js .paragraph-type{
+  overflow:unset;
+}


### PR DESCRIPTION
## Description
This was being caused by the overflow attribute shown here. Removing that attribute resolves this issue, but may have other implications depending on where else these classes are used.

```
.js .paragraph-type {
    text-overflow: ellipsis;
    overflow: hidden;
    white-space: nowrap;
}
```
This CSS was provided by the contrib module in this file: /modules/contrib/paragraphs/css/paragraphs.widget.css

I created a new css file that we will be able to use for any future style changes to the widgets.

## Related Issue
https://github.com/az-digital/az_quickstart/issues/651

## How Has This Been Tested?
Locally with Lando

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
