### PR TITLE
Closes #907: Point Quickstart indicator to quickstart.arizona.edu

### DIFF
--- a/config/install/user.role.az_content_editor.yml
+++ b/config/install/user.role.az_content_editor.yml
@@ -23,7 +23,6 @@ permissions:
   - 'access webform help'
   - 'access webform overview'
   - 'add content to books'
-  - 'administer nodes'
   - 'administer webform'
   - 'administer webform element access'
   - 'administer webform submission'

--- a/config/install/user.role.az_content_editor.yml
+++ b/config/install/user.role.az_content_editor.yml
@@ -23,6 +23,7 @@ permissions:
   - 'access webform help'
   - 'access webform overview'
   - 'add content to books'
+  - 'administer nodes'
   - 'administer webform'
   - 'administer webform element access'
   - 'administer webform submission'

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -38,7 +38,7 @@ function az_core_toolbar() {
     '#type' => 'toolbar_item',
     'tab' => [
       '#type' => 'link',
-      '#title' => t('Quickstart'),
+      '#title' => t('Quickstart 2'),
       '#url' => Url::fromUri('https://quickstart.arizona.edu'),
       '#attributes' => [
         'target' => t('_blank'),

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -38,7 +38,7 @@ function az_core_toolbar() {
     '#type' => 'toolbar_item',
     'tab' => [
       '#type' => 'link',
-      '#title' => t('Quickstart 2'),
+      '#title' => t('Quickstart'),
       '#url' => Url::fromUri('https://quickstart.arizona.edu'),
       '#attributes' => [
         'target' => t('_blank'),

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -39,8 +39,9 @@ function az_core_toolbar() {
     'tab' => [
       '#type' => 'link',
       '#title' => t('Quickstart 2'),
-      '#url' => Url::fromRoute('az_core.az_quickstart'),
+      '#url' => Url::fromUri('https://quickstart.arizona.edu'),
       '#attributes' => [
+        'target' => t('_blank'),
         'title' => t('AZ Quickstart 2'),
         'class' => [
           'toolbar-item',


### PR DESCRIPTION
This PR changes the 'Quickstart 2' link in the admin toolbar to point to the documentation site quickstart.arizona.edu

## Related Issue
#907 

## How Has This Been Tested?
Tested locally and in Probo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
