### PR TITLE
Closes #916 — Restore the Barrio node__content margin-top, override it on az_flexible_page.

### DIFF
--- a/modules/custom/az_flexible_page/az_flexible_page.libraries.yml
+++ b/modules/custom/az_flexible_page/az_flexible_page.libraries.yml
@@ -2,3 +2,7 @@ az_flexible_page_form:
   css:
     base:
       css/az-flexible-page-edit-form.css: {}
+az_flexible_page_theme:
+  css:
+    layout:
+      css/az_flexible_page.theme.css: {}

--- a/modules/custom/az_flexible_page/az_flexible_page.module
+++ b/modules/custom/az_flexible_page/az_flexible_page.module
@@ -9,6 +9,13 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityFormInterface;
 
 /**
+ * Implements hook_preprocess_node().
+ */
+function az_flexible_page_preprocess_node__az_flexible_page(&$variables) {
+  $variables['#attached']['library'][] = 'az_flexible_page/az_flexible_page_theme';
+}
+
+/**
  * Implements hook_form_alter().
  */
 function az_flexible_page_form_alter(&$form, FormStateInterface $form_state, $form_id) {

--- a/modules/custom/az_flexible_page/css/az_flexible_page.theme.css
+++ b/modules/custom/az_flexible_page/css/az_flexible_page.theme.css
@@ -1,0 +1,9 @@
+/*
+*  Page-specific overrides to the theme defaults.
+*/
+
+.node__content {
+  /* Remove extra space at the top of content. */
+  margin-top: 0;
+}
+  

--- a/themes/custom/az_barrio/css/style.css
+++ b/themes/custom/az_barrio/css/style.css
@@ -200,6 +200,13 @@ span.field-label {
 }
 
 /**
+ * General node styles (replacing Bootstrap Barrio node.css).
+ */
+.node__content {
+  margin-top: 10px;
+}
+
+/**
  * Unpublished note.
  */
 /* The word "Unpublished" displayed underneath the content. */


### PR DESCRIPTION
## Description
Apply the Barrio theme's `margin-top: 10px;` from the `.node__content` rule in node.css (now ignored), but add an override on az_flexible_page nodes, following the pattern used by az_person.

## Related Issue
Repairs a regression introduced by the fix for Issue #852.
