### PR TITLE
Closes #852: Restore the original fix, broken when re-introducing default margins.

### DIFF
--- a/modules/custom/az_flexible_page/css/az_flexible_page.theme.css
+++ b/modules/custom/az_flexible_page/css/az_flexible_page.theme.css
@@ -2,8 +2,7 @@
 *  Page-specific overrides to the theme defaults.
 */
 
-.node__content {
+.node--type-az-flexible-page .node__content {
   /* Remove extra space at the top of content. */
   margin-top: 0;
 }
-  


### PR DESCRIPTION
## Description
The fix re-introducing `margin-top: 10px` failed to complete the module-specific override for az_flexible_page.

## Related Issue
Closes #916 — Restore the Barrio node__content margin-top, override it on az_flexible_page. (PR #921)

## How Has This Been Tested?
Verified that the override works on a local Lando build.
