### PR TITLE
Closes #939: Fix install time footer menu-block config warnings.

### DIFF
--- a/themes/custom/az_barrio/config/optional/block.block.az_barrio_footer_menu_info.yml
+++ b/themes/custom/az_barrio/config/optional/block.block.az_barrio_footer_menu_info.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - system.menu.main
+    - system.menu.az-footer-information-for
   module:
     - menu_block
   theme:

--- a/themes/custom/az_barrio/config/optional/block.block.az_barrio_footer_menu_main.yml
+++ b/themes/custom/az_barrio/config/optional/block.block.az_barrio_footer_menu_main.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - system.menu.main
+    - system.menu.az-footer-main
   module:
     - menu_block
   theme:

--- a/themes/custom/az_barrio/config/optional/block.block.az_barrio_footer_menu_resources.yml
+++ b/themes/custom/az_barrio/config/optional/block.block.az_barrio_footer_menu_resources.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - system.menu.main
+    - system.menu.az-footer-resources
   module:
     - menu_block
   theme:

--- a/themes/custom/az_barrio/config/optional/block.block.az_barrio_footer_menu_topics.yml
+++ b/themes/custom/az_barrio/config/optional/block.block.az_barrio_footer_menu_topics.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - system.menu.main
+    - system.menu.az-footer-topics
   module:
     - menu_block
   theme:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This removes the warnings during install time.  We may also want to look into moving the menu configs out of the profile (as a follow-up issue/PR) in order for these blocks to actually get properly placed during install since the install profile config is installed _after_ the theme config.

## Related Issue
#939 

## How Has This Been Tested?
Locally with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
