### PR TITLE
Closes #964: Fix drush site:install command used on kitten.

### DIFF
--- a/.github/workflows/review-site.yml
+++ b/.github/workflows/review-site.yml
@@ -110,12 +110,13 @@ jobs:
         run: |
           terminus -y -n connection:set ${{ secrets.DEMO_SITE_NAME }}.dev sftp
           terminus -y -n drush ${{ secrets.DEMO_SITE_NAME }}.dev -- \
-          site-install az_quickstart install_configure_form.update_status_module='array(FALSE,FALSE)' \
+          site:install az_quickstart install_configure_form.enable_update_status_module=NULL \
           --account-name="azadmin" \
           --account-mail="noreply@email.arizona.edu" \
           --site-mail="noreply@email.arizona.edu" \
           --site-name="Kitten" \
           --yes
+          --verbose
           terminus -y -n drush ${{ secrets.DEMO_SITE_NAME }}.dev -- pm:enable -n -y az_demo
           terminus -y -n connection:set ${{ secrets.DEMO_SITE_NAME }}.dev git
 


### PR DESCRIPTION
## Description
Fixes issue with drush site:install command used in GitHub actions workflow for updating kitten review site.

## Related Issue
#964 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with terminus and drush (using a Pantheon sandbox site)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
