### PR TITLE
#964: Fix broken drush site:install command (again).

### DIFF
--- a/.github/workflows/review-site.yml
+++ b/.github/workflows/review-site.yml
@@ -115,7 +115,7 @@ jobs:
           --account-mail="noreply@email.arizona.edu" \
           --site-mail="noreply@email.arizona.edu" \
           --site-name="Kitten" \
-          --yes
+          --yes \
           --verbose
           terminus -y -n drush ${{ secrets.DEMO_SITE_NAME }}.dev -- pm:enable -n -y az_demo
           terminus -y -n connection:set ${{ secrets.DEMO_SITE_NAME }}.dev git


### PR DESCRIPTION
## Description
The fix for #964 that we merged this morning added an extra line to the multi-line shell command without adding the necessary `\` to the preceding line so now the `drush site:install` command is totally broken 🤦🏻 .

## Related Issue
#964 
