### PR TITLE
Fixes column sizes for calendar view on small screens

### DIFF
--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
@@ -64,7 +64,7 @@ third_party_settings:
       region: content
       format_settings:
         id: ''
-        classes: 'col-xs-4 col-md-2'
+        classes: 'col-4 col-lg-2'
         element: div
         show_label: false
         label_element: h3
@@ -82,7 +82,7 @@ third_party_settings:
       region: content
       format_settings:
         id: ''
-        classes: 'col-xs-8 col-md-10'
+        classes: 'col-8 col-lg-10'
         element: div
         show_label: false
         label_element: h3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There is a bug on small screens for the calendar view on events with the short date (column 1) and event summary info (column 2) stack on mobile rather than appearing side by side as the did in Quickstart 1. 

To fix this, I updated the col classes to match bootstrap 4 (e.g. removing xs).

Before:
![image](https://user-images.githubusercontent.com/10873398/129270614-cbde9bb7-adbc-4fd1-a015-e70be15aa6c2.png)

After:
![image](https://user-images.githubusercontent.com/10873398/129270888-d74f72c0-f4c5-4351-a038-cc6791e69dc5.png)


## Related Issue
#722

## How Has This Been Tested?
Tested locally and in Probo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
