### PR TITLE
Blocked: Use full pager on events

### DIFF
--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
@@ -64,7 +64,7 @@ third_party_settings:
       region: content
       format_settings:
         id: ''
-        classes: 'col-4 col-lg-2'
+        classes: 'col-xs-4 col-md-2'
         element: div
         show_label: false
         label_element: h3
@@ -82,7 +82,7 @@ third_party_settings:
       region: content
       format_settings:
         id: ''
-        classes: 'col-8 col-lg-10'
+        classes: 'col-xs-8 col-md-10'
         element: div
         show_label: false
         label_element: h3

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
@@ -64,7 +64,7 @@ third_party_settings:
       region: content
       format_settings:
         id: ''
-        classes: 'col-xs-4 col-md-2'
+        classes: 'col-4 col-lg-2'
         element: div
         show_label: false
         label_element: h3
@@ -82,7 +82,7 @@ third_party_settings:
       region: content
       format_settings:
         id: ''
-        classes: 'col-xs-8 col-md-10'
+        classes: 'col-8 col-lg-10'
         element: div
         show_label: false
         label_element: h3

--- a/modules/custom/az_event/config/install/views.view.az_events.yml
+++ b/modules/custom/az_event/config/install/views.view.az_events.yml
@@ -51,7 +51,7 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: mini
+        type: full
         options:
           items_per_page: 10
           offset: 0


### PR DESCRIPTION
Events has been using the mini-pager, but our other content types use the full pager. This PR makes things consistent by using the full pager on events

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

## Related Issue
#726 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
