### PR TITLE
Closes #1028: Update text on media title text on dark background to be white.

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/templates/paragraph--az-text-media--default.html.twig
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/templates/paragraph--az-text-media--default.html.twig
@@ -70,6 +70,14 @@
 
   ]
 %}
+{% set title_attributes = create_attribute() %}
+{%
+  set title_classes = [
+    'mt-0',
+    'bold',
+    text_on_media.bg_color != 'dark' ? 'text-blue'
+  ]
+%}
 {% block paragraph %}
   <div{{ attributes.addClass(classes).setAttribute('id', paragraph.bundle() ~ '-' ~ paragraph.id()) }}>
     {% block content %}
@@ -84,7 +92,7 @@
         <div class="az-full-width-row">
           <div{{ col_attributes.addClass(col_classes) }}>
             <div{{ content_attributes.addClass(content_classes).addClass('az-full-width-column-content') }}>
-              <h2 class="mt-0 text-blue bold">{{ paragraph.field_az_title.value }}</h2>
+              <h2{{ title_attributes.addClass(title_classes) }}>{{ paragraph.field_az_title.value }}</h2>
               {{ content }}
             </div>
           </div>


### PR DESCRIPTION
## Description
This updates the title text on dark background to be white (completes one of the remaining tasks for #656).  If it would be better to merge this into [@trackleft's existing Issue #656 branch](https://github.com/az-digital/az_quickstart/compare/issue/656-text-media-updates), I'd be fine with that.

Before:
![446-titles-before](https://user-images.githubusercontent.com/471936/132927305-073d66ef-8fd1-4755-baf6-d8259257d8d7.png)

After:
![446-titles-after](https://user-images.githubusercontent.com/471936/132927311-49dc708a-0671-4d39-afea-f6b0351d9c3a.png)


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1028 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
