### PR TITLE
#360: Limiting the Views options to AZ Events, AZ News and AZ Person.

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_view_reference.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_view_reference.yml
@@ -28,9 +28,9 @@ settings:
     attachment: 0
     feed: 0
   preselect_views:
-    az_events: 0
-    az_news: 0
-    az_person: 0
+    az_events: 1 
+    az_news: 1
+    az_person: 1
     az_reorder: 0
     block_content: 0
     content: 0

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_view_reference.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_view_reference.yml
@@ -23,14 +23,15 @@ settings:
     auto_create: 0
   plugin_types:
     default: default
-    page: page
     block: block
+    page: page
     attachment: 0
     feed: 0
   preselect_views:
-    az_events: 1 
-    az_news: 1
-    az_person: 1
+    az_events: az_events
+    az_news: az_news
+    az_page_by_category: az_page_by_category
+    az_person: az_person
     az_reorder: 0
     block_content: 0
     content: 0
@@ -39,6 +40,7 @@ settings:
     frontpage: 0
     media: 0
     media_library: 0
+    moderated_content: 0
     redirect: 0
     taxonomy_term: 0
     user_admin_people: 0
@@ -46,9 +48,9 @@ settings:
     who_s_new: 0
     who_s_online: 0
   enabled_settings:
-    title: title
-    argument: argument
     limit: limit
+    argument: argument
+    title: title
     pager: 0
     offset: 0
 field_type: viewsreference


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR sets the install config for the Views paragraph item to only display the intended, front-end views.

This both simplifies the View paragraph type, but also prevents users from selecting potentially harmful views that have been shown to crash sites. 

~~This _does not_ include AZ Page, since that view was not included in this configuration file.~~
After merging in Joe's suggestions it does include AZ Page.

## Related Issue
#360 
This is only completing one of the tasks on that ticket, so it should not close it. 

## How Has This Been Tested?
Locally with a new build.
I have not tested this on an existing site.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
