### PR TITLE
Closes #446: Summary link field(s) cannot use tokens.

### DIFF
--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -5,6 +5,7 @@
  * Contains az_core.module.
  */
 
+use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
 use Drupal\pathauto\PathautoPatternInterface;
@@ -109,8 +110,8 @@ function az_core_token_info() {
     'tokens' => [
       'node' => [
         'az-canonical-url' => [
-          'name' => t("Canonical URL"),
-          'description' => t("Switches between field_az_link and node:url."),
+          'name' => t("AZ Canonical URL"),
+          'description' => t("Returns the URI value of field_az_link if present on the node or the default node URI if not."),
         ],
       ],
     ],
@@ -120,9 +121,9 @@ function az_core_token_info() {
 /**
  * Implements hook_token().
  */
-function az_core_tokens($type, $tokens, array $data, array $options, \Drupal\Core\Render\BubbleableMetadata $bubbleable_metadata) {
+function az_core_tokens($type, $tokens, array $data, array $options, BubbleableMetadata $bubbleable_metadata) {
   $replacements = [];
-  if ($type == 'node') {
+  if ($type === 'node') {
     foreach ($tokens as $name => $original) {
       // Find the desired token by name.
       switch ($name) {
@@ -137,13 +138,23 @@ function az_core_tokens($type, $tokens, array $data, array $options, \Drupal\Cor
 }
 
 /**
- * @TODO internal paths don't work.
+ * Token replacement callback providing the canonical URI for a node.
+ *
+ * Returns the URI value of field_az_link if present on the node or the default
+ * node URI if not.
+ *
+ * @param array $data
+ *   Node data from hook_tokens().
+ *
+ * @return string
+ *   The node's canononical URI.
  */
-function az_core_canonical_url($data) {
+function az_core_canonical_url(array $data) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $data['node'];
-  $url = \Drupal\Core\Url::fromRoute('entity.node.canonical', ['node' => $node->id()]);
-  $uri = $url->getUri();
+  /** @var \Drupal\Core\Url $url */
+  $url = $node->toUrl();
+  $uri = $url->toUriString();
 
   if (!empty($node->field_az_link[0]->uri)) {
     $uri = $node->field_az_link[0]->uri;

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -100,3 +100,64 @@ function az_core_block_access(Block $block, $operation, AccountInterface $accoun
   }
   return AccessResult::neutral();
 }
+
+
+/**
+ * Implements hook_token_info().
+ */
+
+function az_core_token_info() {
+  return [
+    'tokens' => [
+      'node' => [
+        'az-canonical-url' => [
+          'name' => t("Canonical URL"),
+          'description' => t("Switches between field_az_link and node:url."),
+        ],
+      ],
+    ],
+  ];
+}
+
+/**
+ * Implements hook_token().
+ */
+
+function az_core_tokens($type, $tokens, array $data, array $options, \Drupal\Core\Render\BubbleableMetadata $bubbleable_metadata) {
+  $replacements = [];
+  if ($type == 'node') {
+
+    foreach ($tokens as $name => $original) {
+      // Find the desired token by name.
+      switch ($name) {
+        case 'az-canonical-url':
+          $replacements[$original] = az_core_canonical_url($data);
+          break;
+      }
+    }
+  }
+  return $replacements;
+
+}
+/**
+ * @TODO internal paths don't work.
+ */
+function az_core_canonical_url($data) {
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = $data['node'];
+  $options = ['absolute' => TRUE];
+  $url = \Drupal\Core\Url::fromRoute('entity.node.canonical', ['node' => $node->id()], $options);
+  $default_url = $url->toString();
+  $url = $default_url;
+
+  if (!empty($node->field_az_link[0]->uri)){
+    try {
+      $url = Url::fromUri($node->field_az_link[0]->uri);
+      $url = $url->toString();
+      } catch (\InvalidArgumentException $e) {
+        $url = $default_url;
+      }
+  }
+
+  return $url;
+}

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -101,11 +101,9 @@ function az_core_block_access(Block $block, $operation, AccountInterface $accoun
   return AccessResult::neutral();
 }
 
-
 /**
  * Implements hook_token_info().
  */
-
 function az_core_token_info() {
   return [
     'tokens' => [
@@ -122,11 +120,9 @@ function az_core_token_info() {
 /**
  * Implements hook_token().
  */
-
 function az_core_tokens($type, $tokens, array $data, array $options, \Drupal\Core\Render\BubbleableMetadata $bubbleable_metadata) {
   $replacements = [];
   if ($type == 'node') {
-
     foreach ($tokens as $name => $original) {
       // Find the desired token by name.
       switch ($name) {
@@ -136,9 +132,10 @@ function az_core_tokens($type, $tokens, array $data, array $options, \Drupal\Cor
       }
     }
   }
-  return $replacements;
 
+    return $replacements;
 }
+
 /**
  * @TODO internal paths don't work.
  */
@@ -154,9 +151,9 @@ function az_core_canonical_url($data) {
     try {
       $url = Url::fromUri($node->field_az_link[0]->uri);
       $url = $url->toString();
-      } catch (\InvalidArgumentException $e) {
-        $url = $default_url;
-      }
+    } catch (\InvalidArgumentException $e) {
+      $url = $default_url;
+    }
   }
 
   return $url;

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -133,7 +133,7 @@ function az_core_tokens($type, $tokens, array $data, array $options, \Drupal\Cor
     }
   }
 
-    return $replacements;
+  return $replacements;
 }
 
 /**
@@ -142,19 +142,12 @@ function az_core_tokens($type, $tokens, array $data, array $options, \Drupal\Cor
 function az_core_canonical_url($data) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $data['node'];
-  $options = ['absolute' => TRUE];
-  $url = \Drupal\Core\Url::fromRoute('entity.node.canonical', ['node' => $node->id()], $options);
-  $default_url = $url->toString();
-  $url = $default_url;
+  $url = \Drupal\Core\Url::fromRoute('entity.node.canonical', ['node' => $node->id()]);
+  $uri = $url->getUri();
 
-  if (!empty($node->field_az_link[0]->uri)){
-    try {
-      $url = Url::fromUri($node->field_az_link[0]->uri);
-      $url = $url->toString();
-    } catch (\InvalidArgumentException $e) {
-      $url = $default_url;
-    }
+  if (!empty($node->field_az_link[0]->uri)) {
+    $uri = $node->field_az_link[0]->uri;
   }
 
-  return $url;
+  return $uri;
 }

--- a/modules/custom/az_demo/data/az_demo_event_node.json
+++ b/modules/custom/az_demo/data/az_demo_event_node.json
@@ -16,12 +16,6 @@
         "title": "Death Valley"
       }
     ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
-      }
-    ],
     "az_photos" : "badwater_panorama.jpg",
     "az_attachments" : "",
     "az_attachments_description" : ""
@@ -42,12 +36,6 @@
       {
         "url": "http://uanow.org/3EW",
         "title": "Math"
-      }
-    ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
       }
     ],
     "uaqs_link_info" : "https://en.wikipedia.org/wiki/Pi_Day",
@@ -73,12 +61,6 @@
         "title": "Museum of Art"
       }
     ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
-      }
-    ],
     "az_photos" : "",
     "az_attachments" : "",
     "az_attachments_description" : ""
@@ -99,12 +81,6 @@
       {
         "url": "",
         "title": ""
-      }
-    ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
       }
     ],
     "az_photos" : "",
@@ -129,12 +105,6 @@
         "title": ""
       }
     ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
-      }
-    ],
     "az_photos" : "",
     "az_attachments" : "",
     "az_attachments_description" : ""
@@ -153,12 +123,6 @@
       {
         "url": "",
         "title": ""
-      }
-    ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
       }
     ],
     "az_photos" : "",
@@ -181,12 +145,6 @@
         "title": ""
       }
     ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
-      }
-    ],
     "az_photos" : "",
     "az_attachments" : "",
     "az_attachments_description" : ""
@@ -205,12 +163,6 @@
       {
         "url": "",
         "title": ""
-      }
-    ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
       }
     ],
     "az_photos" : "",
@@ -233,12 +185,6 @@
         "title": "Gallagher Theater"
       }
     ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
-      }
-    ],
     "az_photos" : "",
     "az_attachments" : "",
     "az_attachments_description" : ""
@@ -257,12 +203,6 @@
       {
         "url": "https://union.arizona.edu/involvement/gallagher/",
         "title": "Gallagher Theater"
-      }
-    ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
       }
     ],
     "az_photos" : "",
@@ -285,12 +225,6 @@
         "title": "Gallagher Theater"
       }
     ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
-      }
-    ],
     "az_photos" : "",
     "az_attachments" : "",
     "az_attachments_description" : ""
@@ -309,12 +243,6 @@
       {
         "url": "",
         "title": ""
-      }
-    ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
       }
     ],
     "az_photos" : "",
@@ -337,12 +265,6 @@
         "title": ""
       }
     ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
-      }
-    ],
     "az_photos" : "",
     "az_attachments" : "",
     "az_attachments_description" : ""
@@ -361,12 +283,6 @@
       {
         "url": "",
         "title": ""
-      }
-    ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
       }
     ],
     "az_photos" : "",
@@ -389,12 +305,6 @@
         "title": ""
       }
     ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
-      }
-    ],
     "az_photos" : "",
     "az_attachments" : "",
     "az_attachments_description" : ""
@@ -415,12 +325,6 @@
         "title": ""
       }
     ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
-      }
-    ],
     "az_photos" : "",
     "az_attachments" : "",
     "az_attachments_description" : ""
@@ -439,12 +343,6 @@
       {
         "url": "",
         "title": ""
-      }
-    ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
       }
     ],
     "az_photos" : "",
@@ -487,12 +385,6 @@
         "title": "Holsclaw Hall"
       }
     ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
-      }
-    ],
     "az_photos" : "",
     "az_attachments" : "",
     "az_attachments_description" : ""
@@ -511,12 +403,6 @@
       {
         "url": "",
         "title": ""
-      }
-    ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
       }
     ],
     "az_photos" : "",
@@ -539,12 +425,6 @@
         "title": ""
       }
     ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
-      }
-    ],
     "az_photos" : "",
     "az_attachments" : "",
     "az_attachments_description" : ""
@@ -563,12 +443,6 @@
       {
         "url": "",
         "title": ""
-      }
-    ],
-    "az_link": [
-      {
-        "url": "[node:url]",
-        "title": "View Event"
       }
     ],
     "az_photos" : "",

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_card.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_card.yml
@@ -194,11 +194,12 @@ third_party_settings:
       format_type: link
       region: content
       format_settings:
-        target: entity
-        custom_uri: ''
+        target: custom_uri
+        custom_uri: '[node:az-canonical-url]'
         target_attribute: default
         id: ''
         classes: 'card-body p-4'
+        show_empty_fields: false
       label: Link
     group_date:
       children:

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
@@ -30,11 +30,12 @@ third_party_settings:
       format_type: link
       region: content
       format_settings:
-        target: entity
-        custom_uri: ''
+        target: custom_uri
+        custom_uri: '[node:az-canonical-url]'
         target_attribute: default
         id: ''
         classes: text-decoration-none
+        show_empty_fields: false
       label: Link
     group_row:
       children:


### PR DESCRIPTION
## Description
This PR is the result of a group workshop on Wednesday Sept 22 2021

Bypass need for using tokens in summary link field in favor of adding our own token `[az-canonical-url]` that checks if the field is empty, and if it is use the node url, otherwise use the field value.  This token is then used in the Field Group Link formatter (custom url setting) on each display mode for each content type that needs to house internal/external content.


Still need to reexport all the display modes and add the field_az_link field to each content type that needs it.

Relevant links https://git.drupalcode.org/project/field_group_link/-/blob/8.x-3.x/src/Plugin/field_group/FieldGroupFormatter/Link.php#L203-213

## Related Issue
#446

## How Has This Been Tested?
Locally

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
