### PR TITLE
Closes #1061: Remove slogan from site branding block.

### DIFF
--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -184,16 +184,18 @@ function az_core_form_block_form_alter(&$form, &$form_state, $form_id) {
 
       // Provide link to Quickstart settings page if the user has access.
       $site_name_description = t('Defined on the <a href=":information">Quickstart settings</a> page.', [':information' => $quickstart_settings_url]);
-      $site_slogan_description = t('Defined on the <a href=":information">Quickstart settings</a> page.', [':information' => $quickstart_settings_url]);
     }
     else {
       // Explain that the user does not have access to the Quickstart settings
       // page.
       $site_name_description = t('Defined on the Quickstart settings page. You do not have the appropriate permissions to change the site name.');
-      $site_slogan_description = t('Defined on the Quickstart settings page. You do not have the appropriate permissions to change the site slogan.');
     }
-
     $form['settings']['block_branding']['use_site_name']['#description'] = $site_name_description;
-    $form['settings']['block_branding']['use_site_slogan']['#description'] = $site_slogan_description;
+
+    // Suppress site slogan toggle.
+    $form['settings']['block_branding']['use_site_slogan']['#access'] = FALSE;
+
+    // Modify help text.
+    $form['settings']['block_branding']['#description'] = t('Choose which branding elements you want to show in this block instance.  Enabling both the Site logo and the Site name is <strong><em>not recommended</em></strong> per UArizona brand guidelines.');
   }
 }

--- a/modules/custom/az_core/src/Form/QuickstartCoreSettingsForm.php
+++ b/modules/custom/az_core/src/Form/QuickstartCoreSettingsForm.php
@@ -96,13 +96,6 @@ class QuickstartCoreSettingsForm extends ConfigFormBase {
       '#required' => TRUE,
     ];
 
-    $form['site_slogan'] = [
-      '#type' => 'textfield',
-      '#title' => t('Site slogan'),
-      '#default_value' => $site_config->get('slogan'),
-      '#required' => FALSE,
-    ];
-
     $form['monitoring_page'] = [
       '#type' => 'details',
       '#title' => t('Monitoring page'),
@@ -166,7 +159,6 @@ class QuickstartCoreSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->config('system.site')
       ->set('name', $form_state->getValue('site_name'))
-      ->set('slogan', $form_state->getValue('site_slogan'))
       ->save();
 
     $this->config('az_core.settings')

--- a/themes/custom/az_barrio/templates/blocks/block--system-branding-block.html.twig
+++ b/themes/custom/az_barrio/templates/blocks/block--system-branding-block.html.twig
@@ -22,9 +22,4 @@
       <span class="d-inline-block h3 text-blue text-uppercase bold my-4">{{ site_name }}</span>
     </a>
   {% endif %}
-  {% if site_slogan %}
-    <div class="d-inline-block align-top site-name-slogan lead mb-4">
-      {{ site_slogan }}
-    </div>
-  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Description
Removes site slogan toggle from settings form for site branding block and omits it from the template.

## Related Issue
#1061 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
