### PR TITLE
Closes #1073: Restrict assignable roles in Add CAS User(s) admin form.

### DIFF
--- a/modules/custom/az_cas/az_cas.module
+++ b/modules/custom/az_cas/az_cas.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\user\RoleInterface;
+use Drupal\Component\Utility\Html;
 
 /**
  * Implements hook_help().
@@ -33,11 +34,11 @@ function az_cas_help($route_name, RouteMatchInterface $route_match) {
  */
 function az_cas_form_bulk_add_cas_users_alter(&$form, FormStateInterface $form_state, $form_id) {
   if (\Drupal::moduleHandler()->moduleExists('role_delegation')) {
-    $form['roles']['#options'] = array_map(
-      ['\Drupal\Component\Utility\Html', 'escape'],
-      \Drupal::service('delegatable_roles')->getAssignableRoles(\Drupal::currentUser())
-    );
-
+    $options = \Drupal::service('delegatable_roles')->getAssignableRoles(\Drupal::currentUser());
+    foreach ($options as $key => $value) {
+      $options[$key] = HTML::escape($value);
+    }
+    $form['roles']['#options'] = $options;
     $form['#validate'][] = 'az_cas_validate_roles';
   }
 }
@@ -54,14 +55,14 @@ function az_cas_validate_roles(array &$form, FormStateInterface $form_state) {
   $allowed_roles = \Drupal::service('delegatable_roles')->getAssignableRoles(\Drupal::currentUser());
   $allowed_roles = array_keys($allowed_roles);
 
-  $invalid_roles = array_filter(
-    $submitted_roles,
-    function($key) use ($allowed_roles) {
-      return !in_array($key, $allowed_roles);
+  $valid_roles = TRUE;
+  foreach ($submitted_roles as $role) {
+    if (!in_array($role, $allowed_roles)) {
+      $valid_roles = FALSE;
     }
-  );
+  }
 
-  if (!empty($invalid_roles)) {
+  if (!$valid_roles) {
     $form_state->setErrorByName(
       'roles',
       t('You do not have permission to assign all of the submitted roles.')


### PR DESCRIPTION
## Description
Modifies the assignable roles list in the `Add CAS User(s)` form provided by the CAS module when the Role Delegation module is installed using `Drupal\role_delegation\DelegatableRoles::getAssignableRoles()`.

## Related Issue
#1073 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with Lando

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
