### PR TITLE
Closes #1075: Don't hide person details if pronouns field is populated.

### DIFF
--- a/themes/custom/az_barrio/templates/content/node--az-person--full.html.twig
+++ b/themes/custom/az_barrio/templates/content/node--az-person--full.html.twig
@@ -154,7 +154,7 @@
             {{ content.field_az_address.0 }}
           </div>
           {% endif %}
-          {% if content.field_az_phones.0 or content.field_az_email.0 or content.field_az_links.0 %}
+          {% if content.field_az_phones.0 or content.field_az_email.0 or content.field_az_links.0 or content.field_az_pronouns.0 %}
           <ul class="list-group list-group-flush border-0 py-3">
           {% if content.field_az_phones %}
             {% for key, item in content.field_az_phones if key|first != '#' %}


### PR DESCRIPTION
## Description
Modify if statement controlling conditional display of person details list-group to include pronouns in Person template.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1075 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ProboCI FTW

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
