### PR TITLE
Closes #1089 - az_mail should depend on az_core.

### DIFF
--- a/modules/custom/az_mail/az_mail.info.yml
+++ b/modules/custom/az_mail/az_mail.info.yml
@@ -4,4 +4,5 @@ description: Send mail via SMTP using Amazon SES.
 core_version_requirement: ^8.8 || ^9
 package: The University of Arizona
 dependencies:
-  - smtp
+  - az_core
+  - smtp:smtp


### PR DESCRIPTION
## Description
The `az_mail` module should depend on `az_core` as it needs `az_core` in order to install `smtp` settings.
