### PR TITLE
Closes #1091 Using canonical url in metatags

### DIFF
--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node.yml
@@ -5,5 +5,5 @@ id: node
 label: Content
 tags:
   description: '[node:field_az_summary]'
-  canonical_url: '[node:field_az_link:url]'
+  canonical_url: '[node:field_az_link:uri]'
   title: '[node:title] | [site:name]'


### PR DESCRIPTION
## Description
Because we want external content to be marked as such for search engines we should link to it as the canonical source.

Field Az link is empty unless there is an external link in it
Default for canonical metatag is [node:field_az_link:uri]
If there is nothing in the external link field the canonical tag should point to the node
If there is something in the external link field the canonical tag should point to that value.


## Related Issue
#1091 

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
