### PR TITLE
Closes #1088: Fix composer fatal errors in lando.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -83,7 +83,7 @@ tooling:
     service: appserver
     cmd:
       # Run command against the install profile's composer.json - eg. profile dependencies.
-      - composer --working-dir=/usr/local/quickstart-install-profile --no-scripts --no-update
+      - /usr/local/bin/composer --working-dir=/usr/local/quickstart-install-profile --no-scripts --no-update
       # Now issue a composer update/install for the scaffolding folder to pull in new dependencies.
       # "true" command consumes passed Lando arguments that were only intended to be passed to the previous call.
-      - composer --working-dir=/app --no-scripts update && composer --working-dir=/app install && true
+      - /usr/local/bin/composer --working-dir=/app --no-scripts update && /usr/local/bin/composer --working-dir=/app install && true


### PR DESCRIPTION
## Description
This forces `lando composer` to use the globally installed composer binary instead of the one installed in `/app/vendor/bin/composer` by the `drupal/core-dev-pinned` package which was causing fatal errors.
 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1088

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with lando

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
