### PR TITLE
Closes #880: Add new ViewsReferenceMapping process plugin with views argument lookup handling.

### DIFF
--- a/modules/custom/az_migration/README.md
+++ b/modules/custom/az_migration/README.md
@@ -531,7 +531,8 @@ These plugins are designed to be reusable in custom migrations.
 - [ParagraphsMappingFlexiblePage (paragraphs_mapping_flexible_page)](https://github.com/az-digital/az_quickstart/blob/main/modules/custom/az_migration/src/Plugin/migrate/process/ParagraphMappingFlexiblePage.php)
 - [ParagraphsBehavior (paragraphs_behavior_settings)](https://github.com/az-digital/az_quickstart/blob/main/modules/custom/az_paragraphs/src/Plugin/migrate/process/ParagraphsBehavior.php) (Deprecated: use `az_paragraphs_behavior_settings`)
 - [ParagraphsBehaviorSettings (az_paragraphs_behavior_settings)](https://github.com/az-digital/az_quickstart/blob/main/modules/custom/az_paragraphs/src/Plugin/migrate/process/ParagraphsBehaviorSettings.php)
-  
+- [ViewsReferenceMapping (az_views_reference_mapping)](https://github.com/az-digital/az_quickstart/blob/main/modules/custom/az_migration/src/Plugin/migrate/process/ViewsReferenceMapping.php)
+
 ### Source plugins
 
 - [AZFileHandle (az_file_migration)](https://github.com/az-digital/az_quickstart/blob/main/modules/custom/az_migration/src/Plugin/migrate/source/AZFileHandle.php)
@@ -544,7 +545,7 @@ These plugins are designed to be reusable in custom migrations.
 These plugins are used in various built-in Quickstart migrations but were not designed with reusability in mind.
 
 - `paragraphs_callout_field_merge`
-- `paragraphs_chunks_view_display_mapping`
+- `paragraphs_chunks_view_display_mapping` (Deprecated: use `az_views_reference_mapping`)
 - `paragraphs_column_image_field_merge`
 - `paragraphs_extra_info_field_merge`
 - `paragraphs_file_download_field_merge`

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_chucks_view.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_chucks_view.yml
@@ -16,7 +16,7 @@ destination:
 process:
 
   field_az_view_reference:
-    plugin: paragraphs_chunks_view_display_mapping
+    plugin: az_views_reference_mapping
     source: field_uaqs_view
 
   behavior_settings:

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_chucks_view.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_chucks_view.yml
@@ -27,6 +27,16 @@ process:
           bottom_spacing: bottom_spacing
 
 dependencies:
+  module:
+    az_paragraphs_view
   enforced:
     module:
       - az_migration
+
+migration_dependencies:
+  optional:
+    - az_event_categories
+    - az_flexible_page_categories
+    - az_news_tags
+    - az_person_categories
+    - az_person_categories_secondary

--- a/modules/custom/az_migration/src/Plugin/migrate/process/ParagraphsChunksViewDisplayMapping.php
+++ b/modules/custom/az_migration/src/Plugin/migrate/process/ParagraphsChunksViewDisplayMapping.php
@@ -30,6 +30,15 @@ use Drupal\migrate\Row;
  *     source: field_uaqs_view
  * @endcode
  *
+ * @deprecated in az_quickstart:2.3.0 and is removed from az_quickstart:2.4.0.
+ *   Use the
+ *   \Drupal\az_migration\Plugin\migrate\process\ViewsReferenceMapping
+ *   process plugin instead following its migration patterns.
+ * // @codingStandardsIgnoreStart
+ * @see https://github.com/az-digital/az_quickstart/pull/1109
+ * @see https://github.com/az-digital/az_quickstart/issues/880
+ * // @codingStandardsIgnoreEnd
+ *
  * @MigrateProcessPlugin(
  *   id = "paragraphs_chunks_view_display_mapping"
  * )

--- a/modules/custom/az_migration/src/Plugin/migrate/process/ViewsReferenceMapping.php
+++ b/modules/custom/az_migration/src/Plugin/migrate/process/ViewsReferenceMapping.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Drupal\az_migration\Plugin\migrate\process;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Drupal\views\Plugin\views\HandlerBase as ViewsHandler;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Process plugin that maps QS1 viewfield fields QS2 viewsreference fields.
+ *
+ * Used to map view and display names referenced in QS1 field_uaqs_view source
+ * field values into viewsreference field values suitable for use in
+ * field_az_view_reference destination fields in QS2.  Also handles migrating
+ * viewsfield argument values using a the specified taxonomy term migrations.
+ *
+ * Expects a field_uaqs_view source field value.
+ *
+ * Available configuration keys (optional):
+ * - views_mapping : May be used to specify how custom source view and display
+ *   names are mapped to destination views as well as configure which migrations
+ *   are used to perform argument ID migration lookups on.  Default mappings for
+ *   QS1 views and displays are built-in but can be overridden using this
+ *   configuration key.
+ *
+ * Examples:
+ *
+ * Consider a paragraph item migration, where you want to map the views
+ * references in the source field_uaqs_view to QS2 view and display names and
+ * also map additional custom source view and display names to the proper
+ * destination view and display names and also migrate the argument values using
+ * a custom taxonomy term migration.
+ * @code
+ * process:
+ *   field_az_view_reference:
+ *     source: field_uaqs_view
+ *     plugin: az_views_reference_mapping
+ *     view_mapping:
+ *       neuroscience_faculty_directory:
+ *         view: neuroscience_faculty_directory
+ *         display:
+ *           page: page
+ *         argument_migrations:
+ *           - az_person_categories
+ *           - neuroscience_person_categories
+ * @endcode
+ *
+ * @MigrateProcessPlugin(
+ *   id = "az_views_reference_mapping"
+ * )
+ */
+class ViewsReferenceMapping extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The migrate lookup service.
+   *
+   * @var \Drupal\migrate\MigrateLookupInterface
+   */
+  protected $migrateLookup;
+
+  /**
+   * Provides Quickstart 1 to Quickstart 2 view mapping data.
+   *
+   * @var array
+   */
+  const VIEW_MAPPING = [
+    'uaqs_events' => [
+      'view' => 'az_events',
+      'display' => [
+        'default' => 'page_1',
+        'page' => 'page_1',
+        'list_block' => 'page_1',
+        'card_group_block' => 'az_grid',
+        'block_1' => 'az_sidebar',
+      ],
+      'argument_migrations' => [
+        'az_event_categories',
+      ],
+    ],
+    'uaqs_news' => [
+      'view' => 'az_news',
+      'display' => [
+        'default' => 'az_grid',
+        'three_col_news_block_3' => 'az_grid',
+        'three_col_news_block' => 'az_grid',
+        'sidebar_promoted_news' => 'az_sidebar',
+        'uaqs_teaser_list_page' => 'az_teaser_grid',
+        'uaqs_media_list_page' => 'az_paged_row',
+        'recent_news_marquee' => 'marquee',
+        'recent_news_medium_media_list' => 'az_paged_row',
+      ],
+      'argument_migrations' => [
+        'az_news_tags',
+      ],
+    ],
+    'uaqs_person_directory' => [
+      'view' => 'az_person',
+      'display' => [
+        'default' => 'grid',
+        'page' => 'grid',
+        'page_1' => 'row',
+      ],
+      'argument_migrations' => [
+        'az_person_categories',
+        'az_person_categories_secondary',
+      ],
+    ],
+    'uaqs_content_chunks_views_page_by_category' => [
+      'view' => 'az_page_by_category',
+      'display' => [
+        'default' => 'row',
+        'page' => 'row',
+        'page_1' => 'grid',
+      ],
+      'argument_migrations' => [
+        'az_flexible_page_categories',
+      ],
+    ],
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+    );
+
+    $instance->migrateLookup = $container->get('migrate.lookup');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $transformedValue = [];
+    $viewData = [];
+    $viewMapping = self::VIEW_MAPPING;
+
+    if (!empty($this->configuration['view_mapping']) && is_array($this->configuration['view_mapping'])) {
+      $viewMapping = array_merge($viewMapping, $this->configuration['view_mapping']);
+    }
+
+    // Get view and display name.
+    $viewDisplay = explode("|", $value['vname']);
+    $view = $viewDisplay[0];
+    $display = $viewDisplay[1];
+
+    if (isset($viewMapping[$view])) {
+      $transformedValue['target_id'] = $viewMapping[$view]['view'];
+      $transformedValue['display_id'] = $viewMapping[$view]['display'][$display];
+      $argumentMigrations = $viewMapping[$view]['argument_migrations'];
+    }
+    else {
+      $transformedValue['target_id'] = $view;
+      $transformedValue['display_id'] = $display;
+      $argumentMigrations = NULL;
+    }
+
+    if (!empty($value['vargs']) && !empty($argumentMigrations)) {
+      // Parse view arguments.
+      $arguments = [];
+      $rawArguments = explode('/', $value['vargs']);
+      foreach ($rawArguments as $rawArgument) {
+        /** @var stdClass $parsed */
+        $parsedArgument = ViewsHandler::breakString($rawArgument);
+        $arguments[] = $parsedArgument;
+      }
+
+      $migratedArguments = [];
+      foreach ($arguments as &$argument) {
+        foreach ($argument->value as $i => $argValue) {
+          $ids = $this->migrateLookup->lookup($argumentMigrations, [$argValue]);
+          $id = reset($ids);
+          // TODO: Create stub if no matching ID found?
+          if (!empty($id)) {
+            $migratedId = reset($id);
+            $argument->value[$i] = $migratedId;
+          }
+        }
+        $migratedArguments[] = $argument;
+      }
+      if (!empty($migratedArguments)) {
+        $transformedArguments = [];
+        foreach ($migratedArguments as $argument) {
+          if (!empty($argument->operator) && count($argument->value) > 1) {
+            $separator = ($argument->operator == 'and') ? ',' : '+';
+            $transformedArguments[] = implode($separator, $argument->value);
+          }
+          else {
+            $transformedArguments[] = reset($argument->value);
+          }
+        }
+        $viewData['argument'] = implode('/', $transformedArguments);
+      }
+    }
+    $transformedValue['data'] = serialize($viewData);
+
+    return $transformedValue;
+  }
+
+}


### PR DESCRIPTION
## Description
Adds new ViewsReferenceMapping migrate process plugin and deprecates old ParagraphsChunksViewDisplayMapping plugin.

New plugin performs migrate lookups on source viewsfield argument values if present.  Provides built-in mappings for default QS1 views but custom views can be used via `view_mapping` migration configuration key.


## Related Issue
Closes #880 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Pretty extensive local testing with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
**Arizona Quickstart** (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [x] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [x] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

**Drupal core**
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

**Drupal contrib projects**
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
