### PR TITLE
Closes #805: Fix button classes and path in carousel migration.

### DIFF
--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_node_carousel.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_node_carousel.yml
@@ -6,10 +6,8 @@ migration_tags:
 status: true
 
 source:
-  plugin: d7_node
+  plugin: az_node
   node_type: uaqs_carousel_item
-  constants:
-    slash: '/'
 
 destination:
   plugin: entity:node
@@ -91,13 +89,10 @@ process:
   promote: promote
   sticky: sticky
 
-  path/pathauto: pathauto
-  path/alias:
-    plugin: concat
-    source:
-      - constants/slash
-      - path
-
+  path/pathauto:
+    plugin: default_value
+    default_value: 0
+  path/alias: alias
 
 migration_dependencies:
   required:


### PR DESCRIPTION
Update migration to include default class.

In this case the options field will look like this in the database

`a:1:{s:10:"attributes";a:1:{s:5:"class";s:28:"btn btn-outline-white btn-sm";}}`


check it out: https://036ad99f-b8ed-4d8f-8ac4-b265be91c27b--site-migration.probo.build/