### PR TITLE
Closes #1064 - Fix reorder people

### DIFF
--- a/modules/custom/az_person/config/install/views.view.az_person.yml
+++ b/modules/custom/az_person/config/install/views.view.az_person.yml
@@ -289,6 +289,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags:
@@ -384,8 +385,9 @@ display:
           exposed: false
           expose:
             label: ''
-          draggable_views_reference: 'azqs_reorder:page_1'
+          draggable_views_reference: 'az_reorder:reorder_people'
           draggable_views_null_order: after
+          draggable_views_pass_arguments: 0
           plugin_id: standard
         field_az_lname_value:
           id: field_az_lname_value
@@ -417,6 +419,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags:
@@ -460,8 +463,9 @@ display:
           exposed: false
           expose:
             label: ''
-          draggable_views_reference: 'azqs_reorder:page_1'
+          draggable_views_reference: 'az_reorder:reorder_people'
           draggable_views_null_order: after
+          draggable_views_pass_arguments: 0
           plugin_id: standard
         field_az_lname_value:
           id: field_az_lname_value
@@ -495,6 +499,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags:

--- a/modules/custom/az_person/config/install/views.view.az_reorder.yml
+++ b/modules/custom/az_person/config/install/views.view.az_reorder.yml
@@ -8,6 +8,7 @@ dependencies:
     - draggableviews
     - node
     - user
+_core:
 id: az_reorder
 label: 'AZ Reorder'
 module: views
@@ -27,13 +28,13 @@ display:
         options:
           perm: 'access administration pages'
       cache:
-        type: tag
+        type: none
         options: {  }
       query:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }

--- a/modules/custom/az_person/config/install/views.view.az_reorder.yml
+++ b/modules/custom/az_person/config/install/views.view.az_reorder.yml
@@ -8,7 +8,6 @@ dependencies:
     - draggableviews
     - node
     - user
-_core:
 id: az_reorder
 label: 'AZ Reorder'
 module: views

--- a/modules/custom/az_person/config/install/views.view.az_reorder.yml
+++ b/modules/custom/az_person/config/install/views.view.az_reorder.yml
@@ -336,10 +336,10 @@ display:
           entity_field: type
           plugin_id: bundle
       sorts:
-        field_az_person_category_target_id:
-          id: field_az_person_category_target_id
-          table: node__field_az_person_category
-          field: field_az_person_category_target_id
+        weight:
+          id: weight
+          table: draggableviews_structure
+          field: weight
           relationship: none
           group_type: group
           admin_label: ''
@@ -348,10 +348,10 @@ display:
           expose:
             label: ''
           plugin_id: standard
-        weight:
-          id: weight
-          table: draggableviews_structure
-          field: weight
+        field_az_person_category_target_id:
+          id: field_az_person_category_target_id
+          table: node__field_az_person_category
+          field: field_az_person_category_target_id
           relationship: none
           group_type: group
           admin_label: ''


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Updates the AZ Person view so that both `grid` and `row` view displays are referencing the correct "reorder" view, rather than "this view/display".
- Updated the AZ Reorder view so "distinct" is checked and caching is turned off.

Review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-1115.probo.build/

## Related Issue
Closes #1064 

## How Has This Been Tested?
- Tested locally with demo content
- Pending Probo test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
