### PR TITLE
Closes #1122 Updates editorial workflow to allow published to published

### DIFF
--- a/config/optional/workflows.workflow.editorial.yml
+++ b/config/optional/workflows.workflow.editorial.yml
@@ -23,6 +23,7 @@ type_settings:
       label: Publish
       from:
         - draft
+        - published
       to: published
       weight: 0
     create_new_draft:

--- a/config/optional/workflows.workflow.editorial.yml
+++ b/config/optional/workflows.workflow.editorial.yml
@@ -11,12 +11,12 @@ type_settings:
     draft:
       label: Draft
       published: false
-      default_revision: false
+      default_revision: true
       weight: -2
     published:
       label: Published
       published: true
-      default_revision: true
+      default_revision: false
       weight: 0
   transitions:
     az_publish:


### PR DESCRIPTION
## Description
On the COVID-19 and Quickstart sites I noticed that the default editorial workflow for content moderation makes small edits more difficult because you have to save as a draft and then go back and save as published (no way to move from published state to published state like you can in QS1). This PR adds published state for "From" for the Published transition.

Before:
![image](https://user-images.githubusercontent.com/10873398/140970075-96043ebf-929d-4b7d-b5f9-c3bd0dce75d3.png)

After:
![image](https://user-images.githubusercontent.com/10873398/140970522-5b82065d-154b-4a57-9415-5e0a700b41ff.png)

## Related Issue
#1122 

## How Has This Been Tested?
Locally and in Probo
https://a24a042a-fb91-4897-a080-806c4265ea93.probo.build/

Note: you may need to turn the workflow on for a particular content type you are testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
