### PR TITLE
Closes #1146 Migrate basic page content type (to az_page)

### DIFF
--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_node_uaqs_basic_page_to_az_page.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_node_uaqs_basic_page_to_az_page.yml
@@ -1,0 +1,88 @@
+id: az_node_uaqs_basic_page_to_az_page
+label: AZ Flexible Page from UAQS Basic Page
+migration_group: az_migration
+migration_tags:
+  - Quickstart Content Migration
+status: true
+
+source:
+  plugin: az_node
+  node_type: uaqs_page
+
+destination:
+  plugin: entity:node
+  bundle: az_flexible_page
+
+process:
+  type: 
+    plugin: default_value
+    default_value: az_flexible_page
+  langcode:
+    plugin: static_map
+    bypass: true
+    source: language
+    map:
+      und: en
+  
+  title: title
+  uid:
+    -
+      plugin: migration_lookup
+      migration: az_user
+      no_stub: true
+      source: node_uid
+    -
+      plugin: default_value
+      default_value: 0
+
+  status: status
+  created: created
+  changed: changed
+  promote: promote
+  sticky: sticky
+
+  path/pathauto:
+    - 
+      plugin: skip_on_empty
+      source: alias
+      method: process
+    -
+      plugin: default_value
+      default_value: 0
+
+  path/alias:
+    - 
+      plugin: skip_on_empty
+      source: alias
+      method: process
+
+  field_az_main_content/target_id:
+    -
+      plugin: migration_lookup
+      migration: az_paragraph_uaqs_basic_page_to_az_page
+      source: nid
+      no_stub: true
+    -
+      plugin: extract
+      index:
+        - 0
+  field_az_main_content/target_revision_id:
+    -
+      plugin: migration_lookup
+      migration: az_paragraph_uaqs_basic_page_to_az_page
+      source: nid
+      no_stub: true
+    -
+      plugin: extract
+      index:
+        - 1
+
+dependencies:
+  enforced:
+    module:
+      - az_migration
+
+migration_dependencies:
+  required:
+    - az_user
+    - az_paragraph_uaqs_basic_page_to_az_page

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_uaqs_basic_page_to_az_page.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_uaqs_basic_page_to_az_page.yml
@@ -1,0 +1,56 @@
+id: az_paragraph_uaqs_basic_page_to_az_page
+label: Convert basic page body field to a paragraph.
+migration_group: az_migration
+migration_tags:
+  - Quickstart Content Migration
+status: true
+
+source:
+  plugin: d7_node
+  node_type: uaqs_page
+
+process:
+  destination_bundle:
+    plugin: text_format_recognizer
+    format: 'az_standard'
+    source: field_uaqs_body
+    required_module: 'az_paragraphs_html'
+    passed: 'az_text'
+    failed: 'az_html'
+    module_missing: 'az_text'
+
+  type:
+    -
+      plugin: array_shift
+      source: '@destination_bundle'
+    -
+      plugin: default_value
+      default_value: 'az_text'
+
+  field_az_full_html:
+    plugin: sub_process
+    source: field_uaqs_body
+    process:
+      delta: delta
+      value: value
+      format:
+        plugin: default_value
+        default_value: full_html
+
+  field_az_text_area:
+    plugin: sub_process
+    source: field_uaqs_body
+    process:
+      delta: delta
+      value: value
+      format:
+        plugin: default_value
+        default_value: az_standard
+
+destination:
+  plugin: 'entity_reference_revisions:paragraph'
+
+dependencies:
+  enforced:
+    module:
+      - az_migration


### PR DESCRIPTION
Add two new migrations, one for body field, and one for node.
body field migration creates either a text or html paragraph type
node creates the flexible page and attaches the new paragraph

## Related Issue
Closes #1146 

## How Has This Been Tested?
Locally

### Source
![image](https://user-images.githubusercontent.com/1023167/142494345-04b87e70-e56b-4e96-82d8-48a9214c5f1e.png)
### Destination
![image](https://user-images.githubusercontent.com/1023167/142494564-f2d422f6-9312-4082-8db2-e2543aa2e6a8.png)

![image](https://user-images.githubusercontent.com/1023167/142495210-baae26ef-f06e-4efb-be6f-5f7da33e536b.png)
![image](https://user-images.githubusercontent.com/1023167/142497031-1e86dba7-6829-4340-b512-8ac4d83e59ee.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
