### PR TITLE
Closes #1154: Remove problematic role mapping from az_user migration.

### DIFF
--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_user.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_user.yml
@@ -19,11 +19,9 @@ process:
   pass: pass
   mail: mail
   created: created
-  access:
-    plugin: skip_on_empty
-    source: access
-    method: process
+  access: access
   login: login
+  # Skip blocked users.
   status:
     plugin: skip_on_value
     equals: true

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_user.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_user.yml
@@ -19,17 +19,18 @@ process:
   pass: pass
   mail: mail
   created: created
-  access: access
+  access:
+    plugin: skip_on_empty
+    source: access
+    method: process
   login: login
-  status: 
-    -
-      plugin: skip_on_value
-      equals: true
-      method: row
-      source: status
-      value: 
-        - 0
-
+  status:
+    plugin: skip_on_value
+    equals: true
+    method: row
+    source: status
+    value:
+      - 0
   timezone: timezone
   langcode:
     plugin: user_langcode
@@ -44,15 +45,6 @@ process:
     source: language
     fallback_to_site_default: true
   init: init
-  roles:
-    plugin: static_map
-    bypass: true
-    source: roles
-    map:
-      3: authenticated
-      2: authenticated
-      4: authenticated
-      5: authenticated
   user_picture:
     -
       plugin: default_value

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_user.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_user.yml
@@ -21,7 +21,7 @@ process:
   created: created
   access: access
   login: login
-  # Skip blocked users.
+  # Skip blocked users.  If you want to maintain a blocked user's history, you should not use this approach.
   status:
     plugin: skip_on_value
     equals: true


### PR DESCRIPTION
## Description
The `authenticated user` role is automatically added to all users and not explicitly assignable.  Since we are want all migrated users to only have the `authenticated user` role, we can simply omit our existing (problematic) role mapping which is causing migration failures for source sites having users with no assigned roles.

This also includes some minor cleanup changes and makes the `access` (last access) field value optional (since it isn't populated on the source site if a user has never logged in). 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1154 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with lando

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
