### PR TITLE
Closes #1164: Add ProboCI step to check for PHP error/notice logs.

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -74,8 +74,7 @@ steps:
       - curl -I http://localhost/calendar
       - curl -I http://localhost/pages/annual-events
       # Check for PHP watchdog entries
-      - messages=$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php)
-      - if [ -z "$messages" ]; then echo "No PHP notices/errors logged."; else $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php && echo "PHP notices/errors found in log. >&2 && exit 1; fi
+      - if [ -z $($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php) ]; then echo "No PHP notices/errors logged."; else $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php && echo "PHP notices/errors found in log. >&2 && exit 1; fi
   - name: Run PHPUnit Tests
     plugin: Script
     script:

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -74,7 +74,7 @@ steps:
       - curl -I http://localhost/calendar
       - curl -I http://localhost/pages/annual-events
       # Check for PHP watchdog entries
-      - if [ -z $($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php) ]; then echo "No PHP notices/errors logged."; else $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php && echo "PHP notices/errors found in log. >&2 && exit 1; fi
+      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php)" ]; then echo "No PHP notices/errors logged."; else $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php && echo "PHP notices/errors found in log." >&2 && exit 1; fi
   - name: Run PHPUnit Tests
     plugin: Script
     script:

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -54,6 +54,28 @@ steps:
       - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush user:role:add az_content_admin azuseradmin
       - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush user:role:add az_user_admin azuseradmin
       - chown www-data:www-data -R /var/www/html/sites/default/files
+  - name: Check for PHP errors and notices
+    plugin: Script
+    script:
+      # Load some known demo URL paths
+      - curl -I http://localhost
+      - curl -I http://localhost/user
+      - curl -I http://localhost/people
+      - curl -I http://localhost/people-list
+      - curl -I http://localhost/pages/text
+      - curl -I http://localhost/pages/text-background
+      - curl -I http://localhost/pages/text-media
+      - curl -I http://localhost/pages/card-decks
+      - curl -I http://localhost/pages/accordions
+      - curl -I http://localhost/pages/photo-galleries
+      - curl -I http://localhost/page-grid
+      - curl -I http://localhost/page-list
+      - curl -I http://localhost/news
+      - curl -I http://localhost/calendar
+      - curl -I http://localhost/pages/annual-events
+      # Check for PHP watchdog entries
+      - messages=$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php)
+      - if [ -z "$messages" ]; then echo "No PHP notices/errors logged."; else $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php && echo "PHP notices/errors found in log. >&2 && exit 1; fi
   - name: Run PHPUnit Tests
     plugin: Script
     script:

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -58,23 +58,23 @@ steps:
     plugin: Script
     script:
       # Load some known demo URL paths
-      - curl -I http://localhost
-      - curl -I http://localhost/user
-      - curl -I http://localhost/people
-      - curl -I http://localhost/people-list
-      - curl -I http://localhost/pages/text
-      - curl -I http://localhost/pages/text-background
-      - curl -I http://localhost/pages/text-media
-      - curl -I http://localhost/pages/card-decks
-      - curl -I http://localhost/pages/accordions
-      - curl -I http://localhost/pages/photo-galleries
-      - curl -I http://localhost/page-grid
-      - curl -I http://localhost/page-list
-      - curl -I http://localhost/news
-      - curl -I http://localhost/calendar
-      - curl -I http://localhost/pages/annual-events
+      - curl -sS -o /dev/null http://localhost
+      - curl -sS -o /dev/null http://localhost/user
+      - curl -sS -o /dev/null http://localhost/people
+      - curl -sS -o /dev/null http://localhost/people-list
+      - curl -sS -o /dev/null http://localhost/pages/text
+      - curl -sS -o /dev/null http://localhost/pages/text-background
+      - curl -sS -o /dev/null http://localhost/pages/text-media
+      - curl -sS -o /dev/null http://localhost/pages/card-decks
+      - curl -sS -o /dev/null http://localhost/pages/accordions
+      - curl -sS -o /dev/null http://localhost/pages/photo-galleries
+      - curl -sS -o /dev/null http://localhost/page-grid
+      - curl -sS -o /dev/null http://localhost/page-list
+      - curl -sS -o /dev/null http://localhost/news
+      - curl -sS -o /dev/null http://localhost/calendar
+      - curl -sS -o /dev/null http://localhost/pages/annual-events
       # Check for PHP watchdog entries
-      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php)" ]; then echo "No PHP notices/errors logged."; else $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php && echo "PHP notices/errors found in log." >&2 && exit 1; fi
+      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php)" ]; then echo "No PHP notices/errors logged."; else echo "PHP notices/errors found in log." >&2 && exit 1; fi
   - name: Run PHPUnit Tests
     plugin: Script
     script:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds step to check for PHP entries in the watchdog logs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1164 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
