### PR TITLE
Fixes #1184 Regression: Bottom margin on text on media paragraphs no longer works.

### DIFF
--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -257,7 +257,7 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
     $config = $this->getSettings($paragraph);
     // Apply bottom spacing if set.
     if (!empty($config['az_display_settings']['bottom_spacing'])) {
-      $build['#attributes']['class'] = $config['az_display_settings']['bottom_spacing'];
+      $build['#attributes']['class'][] = $config['az_display_settings']['bottom_spacing'];
     }
   }
 


### PR DESCRIPTION
## Description
See #1184 

## Related Issue
#1184 

## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
