### PR TITLE
Closes #1166 Changes Content position 'none' option to say 'full-width'

### DIFF
--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -97,7 +97,7 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
         'col-md-8 col-lg-6' => $this->t('Position left'),
         'col-md-8 col-lg-6 col-md-offset-2 col-lg-offset-3' => $this->t('Position center'),
         'col-md-8 col-lg-6 col-md-offset-4 col-lg-offset-6' => $this->t('Position right'),
-        'col-xs-12' => $this->t('None'),
+        'col-xs-12' => $this->t('Full-width'),
       ],
       '#default_value' => $config['position'],
       '#description' => $this->t('The position of the content on the media.'),


### PR DESCRIPTION
## Description
Content editors (me and Catherine) have been confused about the "none" option for Content position on Text on Media. Neither of us realized that this option would make the box larger than the other positions.

Changing the language to say "Full-width" will be more understandable to content editors.

![image](https://user-images.githubusercontent.com/10873398/145302328-62cc7208-1acf-4a69-b602-43f97f092271.png)


## Related Issue
#1166 

## How Has This Been Tested?
Tested in locally and in Probo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
