### PR TITLE
 Closes #1150: Fix issues with Single Card paragraph migration.

### DIFF
--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_single_card.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_single_card.yml
@@ -15,43 +15,60 @@ destination:
 
 process:
 
-  field_az_cards/title: 
-    plugin: extract
-    source: field_uaqs_short_title
-    index:
-      - 0
-      - value
+  field_az_cards/title:
+    -
+      plugin: skip_on_empty
+      source: field_uaqs_short_title
+      method: process
+    -
+      plugin: extract
+      index:
+        - 0
+        - value
 
   field_az_cards/body:
-    plugin: extract
-    source: field_uaqs_summary
-    index:
-      - 0
-      - value
+    -
+      plugin: skip_on_empty
+      source: field_uaqs_summary
+      method: process
+    -
+      plugin: extract
+      index:
+        - 0
+        - value
 
   field_az_cards/link_title:
-    plugin: extract
-    source: field_uaqs_links
-    index:
-      - 0
-      - title
+    -
+      plugin: skip_on_empty
+      source: field_uaqs_links
+      method: process
+    -
+      plugin: extract
+      source: field_uaqs_links
+      index:
+        - 0
+        - title
 
   field_az_cards/link_uri:
-    plugin: extract
-    source: field_uaqs_links
-    index:
-      - 0
-      - url
+    -
+      plugin: skip_on_empty
+      source: field_uaqs_links
+      method: process
+    -
+      plugin: extract
+      index:
+        - 0
+        - url
 
-  field_az_cards/body_format:  
+  field_az_cards/body_format:
     plugin: default_value
     default_value: az_standard
-  
+
   field_az_cards/options:
     plugin: default_value
-    default_value: 
+    default_value:
       class: 'bg-white'
-    
+
   behavior_settings:
     plugin: paragraphs_behavior_settings
     card_width: 'col-md-12 col-lg-12'

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_single_card.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_single_card.yml
@@ -60,20 +60,6 @@ process:
       index:
         - 0
         - url
-    -
-      plugin: az_migrated_path_lookup
-      term_migration:
-        - az_event_categories
-        - az_flexible_page_categories
-        - az_news_tags
-        - az_person_categories_secondary
-        - az_person_categories
-      node_migration:
-        - az_node_carousel
-        - az_node_event
-        - az_node_flexible_page
-        - az_node_news
-        - az_node_person
 
   field_az_cards/body_format:
     plugin: default_value
@@ -90,19 +76,6 @@ process:
     card_style: 'card'
     card_width_sm: 'col-sm-12'
     card_width_xs: 'col-12'
-
-migration_dependencies:
-  optional:
-    - az_event_categories
-    - az_flexible_page_categories
-    - az_news_tags
-    - az_person_categories_secondary
-    - az_person_categories
-    - az_node_carousel
-    - az_node_event
-    - az_node_flexible_page
-    - az_node_news
-    - az_node_person
 
 dependencies:
   enforced:

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_single_card.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_single_card.yml
@@ -44,7 +44,7 @@ process:
       method: process
     -
       plugin: extract
-      source: field_uaqs_links
+      default: null
       index:
         - 0
         - title
@@ -56,9 +56,24 @@ process:
       method: process
     -
       plugin: extract
+      default: null
       index:
         - 0
         - url
+    -
+      plugin: az_migrated_path_lookup
+      term_migration:
+        - az_event_categories
+        - az_flexible_page_categories
+        - az_news_tags
+        - az_person_categories_secondary
+        - az_person_categories
+      node_migration:
+        - az_node_carousel
+        - az_node_event
+        - az_node_flexible_page
+        - az_node_news
+        - az_node_person
 
   field_az_cards/body_format:
     plugin: default_value
@@ -75,6 +90,19 @@ process:
     card_style: 'card'
     card_width_sm: 'col-sm-12'
     card_width_xs: 'col-12'
+
+migration_dependencies:
+  optional:
+    - az_event_categories
+    - az_flexible_page_categories
+    - az_news_tags
+    - az_person_categories_secondary
+    - az_person_categories
+    - az_node_carousel
+    - az_node_event
+    - az_node_flexible_page
+    - az_node_news
+    - az_node_person
 
 dependencies:
   enforced:

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_user.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_user.yml
@@ -19,10 +19,7 @@ process:
   pass: pass
   mail: mail
   created: created
-  access:
-    plugin: skip_on_empty
-    source: access
-    method: process
+  access: access
   login: login
   # Skip blocked users.  If you want to maintain a blocked user's history, you should not use this approach.
   status:

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_user.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_user.yml
@@ -19,7 +19,10 @@ process:
   pass: pass
   mail: mail
   created: created
-  access: access
+  access:
+    plugin: skip_on_empty
+    source: access
+    method: process
   login: login
   # Skip blocked users.  If you want to maintain a blocked user's history, you should not use this approach.
   status:


### PR DESCRIPTION
## Description
Fixes issues that were preventing the Single Card paragraph migration from working correctly.


### _Removed (will be addressed in #1201)_:
Note: this adds a migrated path lookup step to the link field on Single cards which means that the Single Card migration needs to be ran a second time (in update mode) after the node and term migrations have been run to update the migration lookup stubs:

```
$ drush mim --group az_migration
...
(lots of progress messages)
...

$ drush mim az_paragraph_single_card --update
  [notice] Processed 17 items (0 created, 17 updated, 0 failed, 0 ignored) - done with 'az_paragraph_single_card'
```

The term and node migrations used in the migrated path lookup step are added as optional dependencies because the single card migration is a dependency for the flexible page migration and so it can't be added as a required dependency to this migration. 

## Related Issue
#1150 

## How Has This Been Tested?
Locally with lando using a dev copy of the quickstart1.arizona.edu site as the source.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
