### PR TITLE
Closes #1192: Use correct field name from AzParagraphsItem source plugin in card deck migration.

### DIFF
--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_card_deck.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_card_deck.yml
@@ -90,7 +90,7 @@ process:
     card_width_sm: 'col-sm-6'
     card_width_xs: 'col-12'
     card_width_field: field_uaqs_setting_deck_width
-    card_count_field: field_uaqs_photo
+    card_count_field: field_uaqs_cards_values
 
 dependencies:
   enforced:


### PR DESCRIPTION
## Description
Updates card deck paragraph migration to use correct field name for card count since changes made to `AzParagraphsItem` source plugin made in #1130.

## Related Issue
#1192 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
