### PR TITLE
Closes #1197 Fixes content moderation workflow problem

### DIFF
--- a/config/optional/workflows.workflow.editorial.yml
+++ b/config/optional/workflows.workflow.editorial.yml
@@ -11,12 +11,12 @@ type_settings:
     draft:
       label: Draft
       published: false
-      default_revision: true
+      default_revision: false
       weight: -2
     published:
       label: Published
       published: true
-      default_revision: false
+      default_revision: true
       weight: 0
   transitions:
     az_publish:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the content moderation workflow issue described in #1197 where you cannot go from Published > Published.

## Related Issue
#1197

## How Has This Been Tested?
Locally and in Probo

To test:

1. Create a page and save as Published
2. Edit that same page and make a change
3. Save as published again
4. Verify that the change appears on the live page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
