### PR TITLE
#1150: Fixes additional single card migration issues.

### DIFF
--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_single_card.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_single_card.yml
@@ -22,6 +22,7 @@ process:
       method: process
     -
       plugin: extract
+      default: null
       index:
         - 0
         - value
@@ -33,6 +34,7 @@ process:
       method: process
     -
       plugin: extract
+      default: null
       index:
         - 0
         - value

--- a/modules/custom/az_migration/src/Plugin/migrate/source/AZParagraphsItem.php
+++ b/modules/custom/az_migration/src/Plugin/migrate/source/AZParagraphsItem.php
@@ -29,6 +29,8 @@ class AZParagraphsItem extends ParagraphsItem {
         ])
       ->fields('pr', ['revision_id']);
     $query->innerJoin('paragraphs_item_revision', 'pr', static::JOIN);
+    // Omit archived (deleted) paragraphs.
+    $query->condition('p.archived', 0);
     // This configuration item may be set by a deriver to restrict the
     // bundles retrieved.
     if ($this->configuration['bundle']) {


### PR DESCRIPTION
## Description
Still seeing issues with single card migration (since all the fields are optional and not always populated).  This should resolve remaining issues.

This PR also adds a condition to the query used in the AZ Paragraphs Item migration source plugin to omit archived (deleted) paragraph items.  We'll probably want to discuss that bit.


## Related Issue
#1150 

## How Has This Been Tested?
Locally with lando using a Pantheon site as the source.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
