### PR TITLE
Closes #737 Clickable Card

### DIFF
--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -119,7 +119,6 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
           '#title' => $item->link_title ?? '',
           '#url' => $link_url ? $link_url : '#',
           '#attributes' => ['class' => ['btn', 'btn-default', 'w-100']],
-          '#link_attributes' => ['class' => ['']],
         ];
       }
 
@@ -179,6 +178,7 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
       $element['#attributes']['class'][] = 'row';
       $element['#attributes']['class'][] = 'd-flex';
       $element['#attributes']['class'][] = 'flex-wrap';
+      $element['#link_attributes']['class'][] = 'stretched-link';
     }
 
     return $element;

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -180,7 +180,6 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
       $element['#attributes']['class'][] = 'row';
       $element['#attributes']['class'][] = 'd-flex';
       $element['#attributes']['class'][] = 'flex-wrap';
-      $element['#link_attributes']['class'][] = 'stretched-link';
     }
 
     return $element;

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -132,10 +132,13 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
         if ($parent instanceof ParagraphInterface) {
           // Get the behavior settings for the parent.
           $parent_config = $parent->getAllBehaviorSettings();
-
           // See if the parent behavior defines some card-specific settings.
           if (!empty($parent_config['az_cards_paragraph_behavior'])) {
             $card_defaults = $parent_config['az_cards_paragraph_behavior'];
+            // Is the card clickable?
+            if (!empty($card_defaults['card_clickable'])) {
+              $link_render_array['#attributes']['class'][] = 'stretched-link';
+            }
 
             // Set card classes according to behavior settings.
             $column_classes = [];
@@ -165,7 +168,6 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
         '#body' => check_markup($item->body, $item->body_format),
         '#link' => $link_render_array,
         '#attributes' => ['class' => $card_classes],
-        '#link_attributes' => ['class' => $card_clickable],
       ];
 
       $element['#items'][$delta] = new \stdClass();

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -165,6 +165,7 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
         '#body' => check_markup($item->body, $item->body_format),
         '#link' => $link_render_array,
         '#attributes' => ['class' => $card_classes],
+        '#link_attributes' => ['class' => $card_clickable],
       ];
 
       $element['#items'][$delta] = new \stdClass();

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -119,6 +119,7 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
           '#title' => $item->link_title ?? '',
           '#url' => $link_url ? $link_url : '#',
           '#attributes' => ['class' => ['btn', 'btn-default', 'w-100']],
+          '#link_attributes' => ['class' => ['']],
         ];
       }
 

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -136,7 +136,7 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
           if (!empty($parent_config['az_cards_paragraph_behavior'])) {
             $card_defaults = $parent_config['az_cards_paragraph_behavior'];
             // Is the card clickable?
-            if (!empty($card_defaults['card_clickable'])) {
+            if ($card_defaults['card_clickable']) {
               $link_render_array['#attributes']['class'][] = 'stretched-link';
             }
 

--- a/modules/custom/az_card/templates/az-card.html.twig
+++ b/modules/custom/az_card/templates/az-card.html.twig
@@ -28,7 +28,7 @@
       <div class="card-text">{{ body }}</div>
     {% endif %}
     {% if link %}
-      <div class="mt-auto {{ link_attributes }}">{{ link }}</div>
+      <div class="mt-auto">{{ link }} {{ link_attributes }}</div>
     {% endif %}
   </div>
 </div>

--- a/modules/custom/az_card/templates/az-card.html.twig
+++ b/modules/custom/az_card/templates/az-card.html.twig
@@ -28,7 +28,7 @@
       <div class="card-text">{{ body }}</div>
     {% endif %}
     {% if link %}
-      <div class="mt-auto">{{ link }} {{ link_attributes }}</div>
+      <div class="mt-auto">{{ link }}</div>
     {% endif %}
   </div>
 </div>

--- a/modules/custom/az_card/templates/az-card.html.twig
+++ b/modules/custom/az_card/templates/az-card.html.twig
@@ -28,7 +28,7 @@
       <div class="card-text">{{ body }}</div>
     {% endif %}
     {% if link %}
-      <div class="mt-auto">{{ link }}</div>
+      <div class="mt-auto {{ link_attributes }}">{{ link }}</div>
     {% endif %}
   </div>
 </div>

--- a/modules/custom/az_paragraphs/src/Plugin/migrate/process/ParagraphsBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/migrate/process/ParagraphsBehavior.php
@@ -116,7 +116,7 @@ class ParagraphsBehavior extends ProcessPluginBase {
     if (!empty($this->configuration['card_style'])) {
       $behavior['card_style'] = $this->configuration['card_style'];
     }
-    if (!empty($this->configuration['card_clickable'])) {
+    if (isset($this->configuration['card_clickable'])) {
       $behavior['card_clickable'] = $this->configuration['card_clickable'];
     }
     if (!empty($this->configuration['card_width_sm'])) {

--- a/modules/custom/az_paragraphs/src/Plugin/migrate/process/ParagraphsBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/migrate/process/ParagraphsBehavior.php
@@ -116,6 +116,9 @@ class ParagraphsBehavior extends ProcessPluginBase {
     if (!empty($this->configuration['card_style'])) {
       $behavior['card_style'] = $this->configuration['card_style'];
     }
+    if (!empty($this->configuration['card_clickable'])) {
+      $behavior['card_clickable'] = $this->configuration['card_clickable'];
+    }
     if (!empty($this->configuration['card_width_sm'])) {
       $behavior['az_display_settings']['card_width_sm'] = $this->configuration['card_width_sm'];
     }

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZCardsParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZCardsParagraphBehavior.php
@@ -48,6 +48,17 @@ class AZCardsParagraphBehavior extends AZDefaultParagraphsBehavior {
       '#description' => $this->t('Select a card style.'),
     ];
 
+    $form['card_clickable'] = [
+      '#title' => $this->t('Clickable cards'),
+      '#type' => 'select',
+      '#options' => [
+        '' => $this->t('Non-clickable cards'),
+        'stretched-link' => $this->t('Clickable cards'),
+      ],
+      '#default_value' => isset($config['card_clickable']) ? $config['card_clickable'] : '',
+      '#description' => $this->t('Choose if the whole card is clickable.'),
+    ];
+
     parent::buildBehaviorForm($paragraph, $form, $form_state);
 
     // Card deck width for tablets.

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZCardsParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZCardsParagraphBehavior.php
@@ -51,10 +51,6 @@ class AZCardsParagraphBehavior extends AZDefaultParagraphsBehavior {
     $form['card_clickable'] = [
       '#title' => $this->t('Clickable cards'),
       '#type' => 'checkbox',
-      '#options' => [
-        '' => $this->t('Non-clickable cards'),
-        'stretched-link' => $this->t('Clickable cards'),
-      ],
       '#default_value' => isset($config['card_clickable']) ? $config['card_clickable'] : '',
       '#description' => $this->t('Make the whole card clickable if the link fields are populated.'),
     ];

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZCardsParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZCardsParagraphBehavior.php
@@ -51,7 +51,7 @@ class AZCardsParagraphBehavior extends AZDefaultParagraphsBehavior {
     $form['card_clickable'] = [
       '#title' => $this->t('Clickable cards'),
       '#type' => 'checkbox',
-      '#default_value' => isset($config['card_clickable']) ? $config['card_clickable'] : '',
+      '#default_value' => isset($config['card_clickable']) ? $config['card_clickable'] : FALSE,
       '#description' => $this->t('Make the whole card clickable if the link fields are populated.'),
     ];
 

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZCardsParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZCardsParagraphBehavior.php
@@ -56,7 +56,7 @@ class AZCardsParagraphBehavior extends AZDefaultParagraphsBehavior {
         'stretched-link' => $this->t('Clickable cards'),
       ],
       '#default_value' => isset($config['card_clickable']) ? $config['card_clickable'] : '',
-      '#description' => $this->t('Choose if the whole card is clickable.'),
+      '#description' => $this->t('Make the whole card clickable if the link fields are populated.'),
     ];
 
     parent::buildBehaviorForm($paragraph, $form, $form_state);

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZCardsParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZCardsParagraphBehavior.php
@@ -50,7 +50,7 @@ class AZCardsParagraphBehavior extends AZDefaultParagraphsBehavior {
 
     $form['card_clickable'] = [
       '#title' => $this->t('Clickable cards'),
-      '#type' => 'select',
+      '#type' => 'checkbox',
       '#options' => [
         '' => $this->t('Non-clickable cards'),
         'stretched-link' => $this->t('Clickable cards'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a card deck paragraph-wide configuration option for clickable card.
If the option is selected all cards get the stretched-link class added.
This stretches the link over the entire card.

## Related Issue
#737 

## How Has This Been Tested?
Locally and on probo.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
