### PR TITLE
Closes #1225: Removing setting the class array as a string everywhere, and fixing bottom spacing issue.

### DIFF
--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZDefaultParagraphsBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZDefaultParagraphsBehavior.php
@@ -166,7 +166,7 @@ class AZDefaultParagraphsBehavior extends ParagraphsBehaviorBase {
 
     // Apply bottom spacing if set.
     if (!empty($config['az_display_settings']['bottom_spacing'])) {
-      $build['#attributes']['class'] = $config['az_display_settings']['bottom_spacing'];
+      $build['#attributes']['class'][] = $config['az_display_settings']['bottom_spacing'];
     }
 
   }

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -2,11 +2,9 @@
 
 namespace Drupal\az_paragraphs\Plugin\paragraphs\Behavior;
 
-use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Component\Utility\Html;
-use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\paragraphs\ParagraphInterface;
 
 /**

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -248,5 +248,4 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
     // Set title classes.
     $variables['elements']['#fieldgroups']['group_az_title']->format_settings['classes'] = implode(' ', $title_classes);
   }
-  
 }

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -248,5 +248,5 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
     // Set title classes.
     $variables['elements']['#fieldgroups']['group_az_title']->format_settings['classes'] = implode(' ', $title_classes);
   }
-  
+
 }

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -248,4 +248,5 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
     // Set title classes.
     $variables['elements']['#fieldgroups']['group_az_title']->format_settings['classes'] = implode(' ', $title_classes);
   }
+  
 }

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -177,6 +177,9 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
     }
     $paragraph_status = $paragraph->status->value ? 'published' : 'unpublished';
     $variables['attributes']['id'] = HTML::getId($paragraph->bundle() . '-' . $paragraph->id());
+    if (!empty($variables['attributes']) && !empty($variables['attributes']['class']) && !is_array($variables['attributes']['class'])) {
+      $variables['attributes']['class'] = [$variables['attributes']['class']];
+    }
     $variables['attributes']['class'][] = 'paragraph';
     $variables['attributes']['class'][] = 'position-relative';
     $variables['attributes']['class'][] = HTML::getClass('paragraph--type--' . $paragraph->bundle());

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -179,9 +179,6 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
     }
     $paragraph_status = $paragraph->status->value ? 'published' : 'unpublished';
     $variables['attributes']['id'] = HTML::getId($paragraph->bundle() . '-' . $paragraph->id());
-    if (!empty($variables['attributes']) && !empty($variables['attributes']['class']) && !is_array($variables['attributes']['class'])) {
-      $variables['attributes']['class'] = [];
-    }
     $variables['attributes']['class'][] = 'paragraph';
     $variables['attributes']['class'][] = 'position-relative';
     $variables['attributes']['class'][] = HTML::getClass('paragraph--type--' . $paragraph->bundle());
@@ -253,17 +250,5 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
     // Set title classes.
     $variables['elements']['#fieldgroups']['group_az_title']->format_settings['classes'] = implode(' ', $title_classes);
   }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function view(array &$build, Paragraph $paragraph, EntityViewDisplayInterface $display, $view_mode) {
-    // Get plugin configuration.
-    $config = $this->getSettings($paragraph);
-    // Apply bottom spacing if set.
-    if (!empty($config['az_display_settings']['bottom_spacing'])) {
-      $build['#attributes']['class'][] = $config['az_display_settings']['bottom_spacing'];
-    }
-  }
-
+  
 }

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -470,7 +470,7 @@ function az_barrio_footer_logo() {
       $svg = file_get_contents($filepath);
       $rendered_image = render($svg);
       $image_markup = Markup::create($rendered_image);
-      $attr['attributes']['class'] = 'qs-logo-svg-inline';
+      $attr['attributes']['class'][] = 'qs-logo-svg-inline';
       // Footer link destination is empty (default value)
       if ($footer_link_destination === '<front>') {
         $return = Link::fromTextAndUrl($image_markup, Url::fromRoute($footer_link_destination, [], $attr));


### PR DESCRIPTION
## Description
Attributes class arrays should always be arrays and never strings.

## Related Issue
Closes #1225 

## How Has This Been Tested?
Probo
Go to text on media page, add margin bottom to one of the paragraphs, and it still works.
Go to theme settings and upload SVG and mark that it should be rendered inline, with  `qs-logo-svg-inline` class

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
