### PR TITLE
Closes #1221: Adds classes for connect menu block

### DIFF
--- a/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_social_media.yml
+++ b/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_social_media.yml
@@ -4,9 +4,13 @@ dependencies:
   config:
     - system.menu.az-footer-social-media
   module:
+    - block_class
     - menu_block
   theme:
     - az_barrio
+third_party_settings:
+  block_class:
+    classes: 'col-12 col-sm-6 col-md-2'
 id: az_barrio_footer_menu_social_media
 theme: az_barrio
 region: footer_sub


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds classes to the block for the social media connect menu to match those that the other global footer menus have.

After this fix, the menus align properly on mobile:
![image](https://user-images.githubusercontent.com/10873398/149602931-514c3b82-7014-44cc-bf89-8743b1b37130.png)


## Related Issue
#1221 

## How Has This Been Tested?
Locally and in Probo.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
