### PR TITLE
Closes #1228, closes #1229: Added new menu-specific footer theme region.

### DIFF
--- a/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_info.yml
+++ b/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_info.yml
@@ -13,7 +13,7 @@ third_party_settings:
     classes: 'col-12 col-sm-6 col-md-3'
 id: az_barrio_footer_menu_info
 theme: az_barrio
-region: footer_sub
+region: footer_sub_menus
 weight: -11
 provider: null
 plugin: 'menu_block:az-footer-information-for'

--- a/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_resources.yml
+++ b/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_resources.yml
@@ -13,7 +13,7 @@ third_party_settings:
     classes: 'col-12 col-sm-6 col-md-2'
 id: az_barrio_footer_menu_resources
 theme: az_barrio
-region: footer_sub
+region: footer_sub_menus
 weight: -9
 provider: null
 plugin: 'menu_block:az-footer-resources'

--- a/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_social_media.yml
+++ b/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_social_media.yml
@@ -9,7 +9,7 @@ dependencies:
     - az_barrio
 id: az_barrio_footer_menu_social_media
 theme: az_barrio
-region: footer_sub
+region: footer_sub_menus
 weight: -8
 provider: null
 plugin: 'menu_block:az-footer-social-media'

--- a/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_topics.yml
+++ b/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_topics.yml
@@ -13,7 +13,7 @@ third_party_settings:
     classes: 'col-12 col-sm-6 col-md-5'
 id: az_barrio_footer_menu_topics
 theme: az_barrio
-region: footer_sub
+region: footer_sub_menus
 weight: -10
 provider: null
 plugin: 'menu_block:az-footer-topics'

--- a/themes/custom/az_barrio/az_barrio.info.yml
+++ b/themes/custom/az_barrio/az_barrio.info.yml
@@ -37,6 +37,7 @@ regions:
   content_bottom: 'Content bottom'
   footer: 'Footer'
   footer_sub: 'Footer sub'
+  footer_sub_menus: 'Footer sub menus'
   az_page_bottom: 'Page bottom'
 
 ckeditor_stylesheets:

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -567,8 +567,8 @@ function az_barrio_preprocess_block(&$variables) {
           $variables['title_attributes']['class'][] = 'text-uppercase';
         }
 
-        // Default classes for footer_sub region.
-        if ($region === 'footer_sub') {
+        // Default classes for footer_sub regions.
+        if ($region === 'footer_sub' || $region === 'footer_sub_menus') {
 
           // Footer topics menu has special split behavior.
           if (!empty($variables['derivative_plugin_id']) && $variables['derivative_plugin_id'] === 'az-footer-topics') {

--- a/themes/custom/az_barrio/config/install/az_barrio.settings.yml
+++ b/themes/custom/az_barrio/config/install/az_barrio.settings.yml
@@ -31,7 +31,8 @@ bootstrap_barrio_region_clean_content_4_col_3: false
 bootstrap_barrio_region_clean_content_4_col_4: false
 bootstrap_barrio_region_clean_content_bottom: false
 bootstrap_barrio_region_clean_footer: false
-bootstrap_barrio_region_clean_footer_sub: true
+bootstrap_barrio_region_clean_footer_sub: false
+bootstrap_barrio_region_clean_footer_sub_menus: true
 bootstrap_barrio_region_clean_az_page_bottom: false
 
 # Layout region column classes.
@@ -64,6 +65,7 @@ bootstrap_barrio_region_class_content_4_col_4: 'col-md-3'
 bootstrap_barrio_region_class_content_bottom: 'col-md'
 bootstrap_barrio_region_class_footer: 'col-12 col-sm-7 col-md-8 col-lg-8'
 bootstrap_barrio_region_class_footer_sub: 'col-md'
+bootstrap_barrio_region_class_footer_sub_menus: 'col-md'
 bootstrap_barrio_region_class_az_page_bottom: ''
 
 # Layout sidebar settings.

--- a/themes/custom/az_barrio/config/schema/az_barrio.schema.yml
+++ b/themes/custom/az_barrio/config/schema/az_barrio.schema.yml
@@ -274,6 +274,12 @@ az_barrio.settings:
     bootstrap_barrio_region_class_footer_sub:
       type: text
       label: 'Classes for footer sub region'
+    bootstrap_barrio_region_clean_footer_sub_menus:
+      type: boolean
+      label: 'Enable clean wrapper for footer sub menus region'
+    bootstrap_barrio_region_class_footer_sub_menus:
+      type: text
+      label: 'Classes for footer sub menus region'
     bootstrap_barrio_region_clean_az_page_bottom:
       type: boolean
       label: 'Enable clean wrapper for page bottom region'

--- a/themes/custom/az_barrio/templates/layout/page.html.twig
+++ b/themes/custom/az_barrio/templates/layout/page.html.twig
@@ -60,6 +60,7 @@
  * - page.content_bottom: Items for the bottom region.
  * - page.footer: Items for footer content.
  * - page.footer_sub: Items for the content below footer.
+ * - page.footer_sub_menus: Items for menu content below footer.
  * - page.page_bottom: Items for the very bottom of the page.
  *
  * Theme variables:
@@ -299,15 +300,18 @@
             </div>
           </section>
           {% endif %}
-          {% if page.footer_sub or land_acknowledgment or info_security_privacy or copyright_notice %}
+          {% if page.footer_sub or page.footer_sub_menus or land_acknowledgment or info_security_privacy or copyright_notice %}
           <div id="footer_sub"{{ attributes.addClass(classes) }}>
             <div class="container">
               <div class="row">
                 {{ page.footer_sub }}
               </div>
               <div class="row">
+                {{ page.footer_sub_menus }}
+              </div>
+              <div class="row">
                 <div class="col text-center">
-                  {% if page.footer_sub %}
+                  {% if page.footer_sub or page.footer_sub_menus %}
                   <hr>
                   {% endif %}
                   {{ land_acknowledgment }}


### PR DESCRIPTION
## Description
- Adds a new theme region to the footer (`footer_sub_menus`), specifically for menu blocks (below existing `footer_sub` region)
- Sets the `bootstrap_barrio_region_clean_footer_sub_menus` theme setting to `true` by default 
- Changes default theme setting value for `bootstrap_barrio_region_clean_footer_sub` back to `false`
- Changes default theme region for global footer menu blocks to new region

## Related Issue
#1228, #1229

## How Has This Been Tested?
Locally with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
