### PR TITLE
Closes #1248: Fix undefined index notices generated for existing cards.

### DIFF
--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -140,7 +140,7 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
           if (!empty($parent_config['az_cards_paragraph_behavior'])) {
             $card_defaults = $parent_config['az_cards_paragraph_behavior'];
             // Is the card clickable?
-            if (isset($card_defaults['card_clickable']) && $card_defaults['card_clickable'] != FALSE) {
+            if (isset($card_defaults['card_clickable']) && $card_defaults['card_clickable']) {
               $link_render_array['#attributes']['class'][] = 'stretched-link';
             }
 

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -140,7 +140,7 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
           if (!empty($parent_config['az_cards_paragraph_behavior'])) {
             $card_defaults = $parent_config['az_cards_paragraph_behavior'];
             // Is the card clickable?
-            if (isset($card_defaults['card_clickable'] && $card_defaults['card_clickable'] === TRUE) {
+            if (isset($card_defaults['card_clickable']) && $card_defaults['card_clickable'] === TRUE) {
               $link_render_array['#attributes']['class'][] = 'stretched-link';
             }
 

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -140,7 +140,7 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
           if (!empty($parent_config['az_cards_paragraph_behavior'])) {
             $card_defaults = $parent_config['az_cards_paragraph_behavior'];
             // Is the card clickable?
-            if (isset($card_defaults['card_clickable']) && $card_defaults['card_clickable'] === TRUE) {
+            if (isset($card_defaults['card_clickable']) && $card_defaults['card_clickable'] != FALSE) {
               $link_render_array['#attributes']['class'][] = 'stretched-link';
             }
 

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -140,7 +140,7 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
           if (!empty($parent_config['az_cards_paragraph_behavior'])) {
             $card_defaults = $parent_config['az_cards_paragraph_behavior'];
             // Is the card clickable?
-            if ($card_defaults['card_clickable']) {
+            if (isset($card_defaults['card_clickable'] && $card_defaults['card_clickable'] === TRUE) {
               $link_render_array['#attributes']['class'][] = 'stretched-link';
             }
 


### PR DESCRIPTION
## Description
Should fix undefined index notices being generated on sites with existing cards after updating to 2.0.15.

## Related Issue
Closes #1248 
Issue introduced with #1220

## How Has This Been Tested?
Needs to be tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
