### PR TITLE
Closes #1254: Don't install quickedit module by default.

### DIFF
--- a/az_quickstart.info.yml
+++ b/az_quickstart.info.yml
@@ -40,7 +40,6 @@ install:
   - drupal:datetime
   - drupal:block_content
   - block_content_permissions:block_content_permissions
-  - drupal:quickedit
   - drupal:editor
   - drupal:help
   - drupal:image

--- a/composer.json
+++ b/composer.json
@@ -119,7 +119,6 @@
                 "Unnecessary restrictions on logo format: Can't upload replacement SVG logo": "https://www.drupal.org/files/issues/2021-09-02/2259567-146-9-2-x.patch",
                 "Ajax CSS load order issue": "https://www.drupal.org/files/issues/2020-06-05/1461322-25.patch",
                 "Layout builder revisions issue": "https://www.drupal.org/files/issues/2019-06-17/3033516-17.patch",
-                "Quickedit attributes issue": "https://www.drupal.org/files/issues/2021-11-05/3072231-61-9.2.x.patch",
                 "Allow text field to enforce a specific text format.": "https://www.drupal.org/files/issues/2021-03-26/784672-182.patch",
                 "Allow editing area in Claro to span full width": "https://www.drupal.org/files/issues/2020-12-16/3184667-8.patch",
                 "Unable to select single view display for view settings": "https://www.drupal.org/files/issues/2020-11-03/2552541-43.patch",


### PR DESCRIPTION
## Description
Expedites removal of quickedit from Quickstart's default installed modules to eliminate browser console errors.

Does not (currently) automatically uninstall quickedit.  I would be open to adding that.

## Related Issue
#1254 

## How Has This Been Tested?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
