### PR TITLE
Fixes #1215 Image Quality Issues

### DIFF
--- a/config/install/system.image.gd.yml
+++ b/config/install/system.image.gd.yml
@@ -1,0 +1,1 @@
+jpeg_quality: 92

--- a/config/install/system.image.yml
+++ b/config/install/system.image.yml
@@ -1,0 +1,1 @@
+toolkit: gd


### PR DESCRIPTION
This specifies a higher setting than default Drupal for image toolkit quality.

## Description
This changes the image toolkit rendering quality from 75 to 92. This number was chosen as a balance between quality and file size. The remaining points of percentage up to 100% quality greatly increase file size.

## Related Issue
#1215 

## How Has This Been Tested?

- verify that `/admin/config/media/image-toolkit` reports accurate quality
- create content with image styles and verify acceptable content quallity.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
