### PR TITLE
Closes #1262: Make az_barrio alert theme region full-width.

### DIFF
--- a/themes/custom/az_barrio/config/install/az_barrio.settings.yml
+++ b/themes/custom/az_barrio/config/install/az_barrio.settings.yml
@@ -37,7 +37,7 @@ bootstrap_barrio_region_clean_az_page_bottom: false
 
 # Layout region column classes.
 # -------------------------------
-bootstrap_barrio_region_class_alert: 'col-md'
+bootstrap_barrio_region_class_alert: ''
 bootstrap_barrio_region_class_header_ua_utilities: 'ml-auto d-none d-lg-block d-xl-block'
 bootstrap_barrio_region_class_branding: ''
 bootstrap_barrio_region_class_header: 'col-md'

--- a/themes/custom/az_barrio/templates/layout/page.html.twig
+++ b/themes/custom/az_barrio/templates/layout/page.html.twig
@@ -81,11 +81,7 @@
   <div id="page">
     <header id="header" class="header" role="banner" aria-label="{{ 'Site header'|t}}">
         {% if page.alert %}
-        <div class="{{ container }}">
-          <div class="row">
-            {{ page.alert }}
-          </div>
-        </div>
+          {{ page.alert }}
         {% endif %}
         <header class="bg-red arizona-header" id="header_arizona" role="banner">
           <div class="{{ container }}">


### PR DESCRIPTION
## Description
Removes container and row divs wrapping az_barrio alert theme region.

### Before
![Screen Shot 2022-01-28 at 5 23 49 PM](https://user-images.githubusercontent.com/471936/151638840-bff56898-1725-461f-bb33-28c730759739.png)

### After
![Screen Shot 2022-01-28 at 5 23 52 PM](https://user-images.githubusercontent.com/471936/151638850-b168539f-2d39-4701-8b5f-8003239a4300.png)

## Related Issue
Closes #1262 

## How Has This Been Tested?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
