### PR TITLE
Update composer branch alias for dev-main to 2.2.x-dev.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.1.x-dev"
+            "dev-main": "2.2.x-dev"
         },
         "patches": {
             "drupal/bootstrap_barrio": {


### PR DESCRIPTION
The `2.1.x` branch has been opened in preparation for creating the `2.1.0-alpha1` release.  We need to change the composer branch alias for `dev-main` to now be `2.2.x-dev` since main is now effectively `2.2.x`.  This change should also be back-ported to both the `2.1.x` and `2.0.x` branches.
