### PR TITLE
Closes #1280 Add block_class as dependency and make az_global_footer a dependency of its config.

### DIFF
--- a/modules/custom/az_global_footer/README.md
+++ b/modules/custom/az_global_footer/README.md
@@ -19,4 +19,5 @@ If you uninstall this module the following menu block configuration will also be
   - az-footer-social-media
   - az-footer-topics
 
-The menu content will not be deleted upon uninstallation.
+The menu link content provided by this module will also be deleted including any modifications to specific menu items.
+To ensure your menu links are not uninstalled by this module, create new menu links instead of changing existing menu links.

--- a/modules/custom/az_global_footer/README.md
+++ b/modules/custom/az_global_footer/README.md
@@ -21,4 +21,4 @@ If you uninstall this module the following menu block configuration will also be
 
 The menu link content provided by this module will also be deleted including any modifications to specific menu items.
 To ensure your menu links are not uninstalled by this module, create new menu links instead of changing the [links
-provided by this module](/migrations/az_global_footer_links.yml]).
+provided by this module](migrations/az_global_footer_links.yml]).

--- a/modules/custom/az_global_footer/README.md
+++ b/modules/custom/az_global_footer/README.md
@@ -20,5 +20,5 @@ If you uninstall this module the following menu block configuration will also be
   - az-footer-topics
 
 The menu link content provided by this module will also be deleted including any modifications to specific menu items.
-To ensure your menu links are not uninstalled by this module, create new menu links instead of changing the (links
-provided by this module)[/az_global_footer/migrations/az_global_footer_links.yml].
+To ensure your menu links are not uninstalled by this module, create new menu links instead of changing the [links
+provided by this module](/az_global_footer/migrations/az_global_footer_links.yml]).

--- a/modules/custom/az_global_footer/README.md
+++ b/modules/custom/az_global_footer/README.md
@@ -9,3 +9,14 @@ You must have administrator permissions in order to enable this module.
 ## Pre-existing Menu Links
 
 If your site already has menu links in the provided footer menus, those links will persist after enabling this module.
+
+## Uninstalling
+
+If you uninstall this module the following menu block configuration will also be uninstalled and deleted:
+  - az-footer-information-for
+  - az-footer-main
+  - az-footer-resources
+  - az-footer-social-media
+  - az-footer-topics
+
+The menu content will not be deleted upon uninstallation.

--- a/modules/custom/az_global_footer/README.md
+++ b/modules/custom/az_global_footer/README.md
@@ -21,4 +21,4 @@ If you uninstall this module the following menu block configuration will also be
 
 The menu link content provided by this module will also be deleted including any modifications to specific menu items.
 To ensure your menu links are not uninstalled by this module, create new menu links instead of changing the [links
-provided by this module](/az_global_footer/migrations/az_global_footer_links.yml]).
+provided by this module](/migrations/az_global_footer_links.yml]).

--- a/modules/custom/az_global_footer/README.md
+++ b/modules/custom/az_global_footer/README.md
@@ -21,4 +21,4 @@ If you uninstall this module the following menu block configuration will also be
 
 The menu link content provided by this module will also be deleted including any modifications to specific menu items.
 To ensure your menu links are not uninstalled by this module, create new menu links instead of changing the [links
-provided by this module](migrations/az_global_footer_links.yml).
+provided by this module](data/az_global_footer.json).

--- a/modules/custom/az_global_footer/README.md
+++ b/modules/custom/az_global_footer/README.md
@@ -20,4 +20,5 @@ If you uninstall this module the following menu block configuration will also be
   - az-footer-topics
 
 The menu link content provided by this module will also be deleted including any modifications to specific menu items.
-To ensure your menu links are not uninstalled by this module, create new menu links instead of changing existing menu links.
+To ensure your menu links are not uninstalled by this module, create new menu links instead of changing the (links
+provided by this module)[/az_global_footer/migrations/az_global_footer_links.yml].

--- a/modules/custom/az_global_footer/README.md
+++ b/modules/custom/az_global_footer/README.md
@@ -21,4 +21,4 @@ If you uninstall this module the following menu block configuration will also be
 
 The menu link content provided by this module will also be deleted including any modifications to specific menu items.
 To ensure your menu links are not uninstalled by this module, create new menu links instead of changing the [links
-provided by this module](migrations/az_global_footer_links.yml]).
+provided by this module](migrations/az_global_footer_links.yml).

--- a/modules/custom/az_global_footer/az_global_footer.info.yml
+++ b/modules/custom/az_global_footer/az_global_footer.info.yml
@@ -6,6 +6,7 @@ package: 'The University of Arizona'
 dependencies:
   - az_core
   - drupal:block
+  - drupal:block_class
   - drupal:menu_block
   - menu_link_attributes
   - migrate:migrate

--- a/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_info.yml
+++ b/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_info.yml
@@ -8,6 +8,9 @@ dependencies:
     - menu_block
   theme:
     - az_barrio
+  enforced:
+    module:
+      - az_global_footer
 third_party_settings:
   block_class:
     classes: 'col-12 col-sm-6 col-md-3'

--- a/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_main.yml
+++ b/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_main.yml
@@ -7,6 +7,9 @@ dependencies:
     - menu_block
   theme:
     - az_barrio
+  enforced:
+    module:
+      - az_global_footer
 id: az_barrio_footer_menu_main
 theme: az_barrio
 region: footer

--- a/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_resources.yml
+++ b/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_resources.yml
@@ -8,6 +8,9 @@ dependencies:
     - menu_block
   theme:
     - az_barrio
+  enforced:
+    module:
+      - az_global_footer
 third_party_settings:
   block_class:
     classes: 'col-12 col-sm-6 col-md-2'

--- a/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_social_media.yml
+++ b/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_social_media.yml
@@ -8,6 +8,9 @@ dependencies:
     - menu_block
   theme:
     - az_barrio
+  enforced:
+    module:
+      - az_global_footer
 third_party_settings:
   block_class:
     classes: 'col-12 col-sm-6 col-md-2'

--- a/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_topics.yml
+++ b/modules/custom/az_global_footer/config/install/block.block.az_barrio_footer_menu_topics.yml
@@ -8,6 +8,9 @@ dependencies:
     - menu_block
   theme:
     - az_barrio
+  enforced:
+    module:
+      - az_global_footer
 third_party_settings:
   block_class:
     classes: 'col-12 col-sm-6 col-md-5'


### PR DESCRIPTION
## Description
Make block_class a dependency of az_global_footer
Make az_global_footer a dependency of the config within az_global_footer.

## Related Issue
Closes #1280

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


Test by uninstalling az_global_footer and reinstalling az_global_footer.