### PR TITLE
Closes #1293 Make header columns configurable

### DIFF
--- a/az_quickstart.profile
+++ b/az_quickstart.profile
@@ -107,6 +107,6 @@ function az_quickstart_update_9209() {
   $config = \Drupal::service('config.factory')->getEditable('az_barrio.settings');
   $config
     ->set('header_one_col_classes', 'col-12 col-sm-6 col-lg-4')
-    ->set('header_one_col_classes', 'col-12 col-sm-6 col-lg-8')
+    ->set('header_two_col_classes', 'col-12 col-sm-6 col-lg-8')
     ->save(TRUE);
 }

--- a/az_quickstart.profile
+++ b/az_quickstart.profile
@@ -99,3 +99,14 @@ function az_quickstart_update_9208() {
     return t('Pantheon Advanced Page Cache module installed.');
   }
 }
+
+/**
+ * Set the default columns classes on the new theme setting.
+ */
+function az_quickstart_update_9209() {
+  $config = \Drupal::service('config.factory')->getEditable('az_barrio.settings');
+  $config
+    ->set('header_one_col_classes', 'col-12 col-sm-6 col-lg-4')
+    ->set('header_one_col_classes', 'col-12 col-sm-6 col-lg-8')
+    ->save(TRUE);
+}

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -143,8 +143,8 @@ function az_barrio_preprocess_page(&$variables, $hook) {
   // Allow wordmark to be disabled.
   $variables['wordmark'] = (theme_get_setting('wordmark')) ? TRUE : FALSE;
 
-  $variables['az_header_responsive_column_classes_one'] = theme_get_setting('az_header_responsive_column_classes_one');
-  $variables['az_header_responsive_column_classes_two'] = theme_get_setting('az_header_responsive_column_classes_two');
+  $variables['header_one_col_classes'] = theme_get_setting('header_one_col_classes');
+  $variables['header_two_col_classes'] = theme_get_setting('header_two_col_classes');
 
 }
 

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -142,6 +142,10 @@ function az_barrio_preprocess_page(&$variables, $hook) {
 
   // Allow wordmark to be disabled.
   $variables['wordmark'] = (theme_get_setting('wordmark')) ? TRUE : FALSE;
+
+  $variables['az_header_responsive_column_classes_one'] = theme_get_setting('az_header_responsive_column_classes_one');
+  $variables['az_header_responsive_column_classes_two'] = theme_get_setting('az_header_responsive_column_classes_two');
+
 }
 
 /**

--- a/themes/custom/az_barrio/config/install/az_barrio.settings.yml
+++ b/themes/custom/az_barrio/config/install/az_barrio.settings.yml
@@ -77,7 +77,7 @@ bootstrap_barrio_sidebar_first_offset: 0
 bootstrap_barrio_sidebar_second_width: 3
 bootstrap_barrio_sidebar_second_offset: 0
 
-# // Region column container class settings.
+# Responsive Header Grid.
 # -------------------------------
 header_one_col_classes: 'col-12 col-sm-6 col-lg-4'
 header_two_col_classes: 'col-12 col-sm-6 col-lg-8'

--- a/themes/custom/az_barrio/config/install/az_barrio.settings.yml
+++ b/themes/custom/az_barrio/config/install/az_barrio.settings.yml
@@ -79,8 +79,8 @@ bootstrap_barrio_sidebar_second_offset: 0
 
 # // Region column container class settings.
 # -------------------------------
-az_header_responsive_column_classes_one: 'col-12 col-sm-6 col-lg-4'
-az_header_responsive_column_classes_two: 'col-12 col-sm-6 col-lg-8'
+header_one_col_classes: 'col-12 col-sm-6 col-lg-4'
+header_two_col_classes: 'col-12 col-sm-6 col-lg-8'
 
 # Container
 # --------------

--- a/themes/custom/az_barrio/config/install/az_barrio.settings.yml
+++ b/themes/custom/az_barrio/config/install/az_barrio.settings.yml
@@ -77,6 +77,11 @@ bootstrap_barrio_sidebar_first_offset: 0
 bootstrap_barrio_sidebar_second_width: 3
 bootstrap_barrio_sidebar_second_offset: 0
 
+# // Region column container class settings.
+# -------------------------------
+az_header_responsive_column_classes_one: 'col-12 col-sm-6 col-lg-4'
+az_header_responsive_column_classes_two: 'col-12 col-sm-6 col-lg-8'
+
 # Container
 # --------------
 bootstrap_barrio_fluid_container: 0

--- a/themes/custom/az_barrio/config/schema/az_barrio.schema.yml
+++ b/themes/custom/az_barrio/config/schema/az_barrio.schema.yml
@@ -363,4 +363,4 @@ az_barrio.settings:
       label: 'Header column one classes'
     header_two_col_classes:
       type: string
-      label: 'Header column classes two'
+      label: 'Header column two classes'

--- a/themes/custom/az_barrio/config/schema/az_barrio.schema.yml
+++ b/themes/custom/az_barrio/config/schema/az_barrio.schema.yml
@@ -358,3 +358,9 @@ az_barrio.settings:
     footer_logo_path:
       type: path
       label: 'Footer logo path'
+    az_header_responsive_column_classes_one:
+      type: string
+      label: 'Header column classes one'
+    az_header_responsive_column_classes_two:
+      type: string
+      label: 'Header column classes two'

--- a/themes/custom/az_barrio/config/schema/az_barrio.schema.yml
+++ b/themes/custom/az_barrio/config/schema/az_barrio.schema.yml
@@ -360,7 +360,7 @@ az_barrio.settings:
       label: 'Footer logo path'
     header_one_col_classes:
       type: string
-      label: 'Header column classes one'
+      label: 'Header column one classes'
     header_two_col_classes:
       type: string
       label: 'Header column classes two'

--- a/themes/custom/az_barrio/config/schema/az_barrio.schema.yml
+++ b/themes/custom/az_barrio/config/schema/az_barrio.schema.yml
@@ -358,9 +358,9 @@ az_barrio.settings:
     footer_logo_path:
       type: path
       label: 'Footer logo path'
-    az_header_responsive_column_classes_one:
+    header_one_col_classes:
       type: string
       label: 'Header column classes one'
-    az_header_responsive_column_classes_two:
+    header_two_col_classes:
       type: string
       label: 'Header column classes two'

--- a/themes/custom/az_barrio/templates/layout/page.html.twig
+++ b/themes/custom/az_barrio/templates/layout/page.html.twig
@@ -112,10 +112,10 @@
         <div class="header page-row" id="header_site" role="banner">
           <div class="{{ container }}">
             <div class="row">
-              <div class="col-12 col-sm-6 col-lg-4">
+              <div class="{{ az_header_responsive_column_classes_one }}">
                 {{ page.branding }}
               </div>
-              <div class="col-12 col-sm-6 col-lg-8">
+              <div class="{{ az_header_responsive_column_classes_two }}">
                 <div class="row">
                   {{ page.header }}
                 </div>

--- a/themes/custom/az_barrio/templates/layout/page.html.twig
+++ b/themes/custom/az_barrio/templates/layout/page.html.twig
@@ -112,10 +112,10 @@
         <div class="header page-row" id="header_site" role="banner">
           <div class="{{ container }}">
             <div class="row">
-              <div class="{{ az_header_responsive_column_classes_one }}">
+              <div class="{{ header_one_col_classes }}">
                 {{ page.branding }}
               </div>
-              <div class="{{ az_header_responsive_column_classes_two }}">
+              <div class="{{ header_two_col_classes }}">
                 <div class="row">
                   {{ page.header }}
                 </div>

--- a/themes/custom/az_barrio/tests/src/Functional/AzBarrioTest.php
+++ b/themes/custom/az_barrio/tests/src/Functional/AzBarrioTest.php
@@ -77,7 +77,7 @@ class AzBarrioTest extends BrowserTestBase {
    * Tests that the header column class settings work on install.
    */
   public function testHeaderColumnClassesAreSet() {
-    $this->drupalGet('/');
+    $this->drupalGet('');
     $this->assertSession()->elementExists('css', '#header_site > div:nth-child(1) > div > div.col-12.col-sm-6.col-lg-4');
     $this->assertSession()->elementExists('css', '#header_site > div:nth-child(1) > div > div.col-12.col-sm-6.col-lg-8');
   }

--- a/themes/custom/az_barrio/tests/src/Functional/AzBarrioTest.php
+++ b/themes/custom/az_barrio/tests/src/Functional/AzBarrioTest.php
@@ -73,4 +73,13 @@ class AzBarrioTest extends BrowserTestBase {
     $this->assertSession()->pageTextContains('The Arizona Barrio theme has been uninstalled.');
   }
 
+  /**
+   * Tests that the header column class settings work on install.
+   */
+  public function testHeaderColumnClassesAreSet() {
+    $this->drupalGet('/');
+    $this->assertSession()->elementExists('css', '#header_site > div:nth-child(1) > div > div.col-12.col-sm-6.col-lg-4');
+    $this->assertSession()->elementExists('css', '#header_site > div:nth-child(1) > div > div.col-12.col-sm-6.col-lg-8');
+  }
+
 }

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -260,7 +260,6 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     '#title' => t('Column one classes'),
     '#description' => t('Responsive column classes for the parent <code>div</code> of the Site branding region. Should contain a string with classes separated by a space.'),
     '#default_value' => theme_get_setting('header_one_col_classes'),
-    '#element_validate' => ['token_element_validate'],
   ];
   $form['layout']['region_containers']['header_two_col_classes'] = [
     '#type' => 'textfield',

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -269,14 +269,14 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
   $form['layout']['region_containers']['header']['az_header_responsive_column_classes_one'] = [
     '#type' => 'textfield',
     '#title' => t('Column classes'),
-    '#description' => t('Responsive column classes for the parent <code>div</code> of the branding region.'),
+    '#description' => t('Responsive column classes for the parent <code>div</code> of the branding region. Should contain a string with classes separated by a space.'),
     '#default_value' => theme_get_setting('az_header_responsive_column_classes_one'),
     '#element_validate' => ['token_element_validate'],
   ];
   $form['layout']['region_containers']['header']['az_header_responsive_column_classes_two'] = [
     '#type' => 'textfield',
     '#title' => t('Column classes'),
-    '#description' => t('Responsive column classes for the parent <code>div</code> of the header 1 and header 2 regions.'),
+    '#description' => t('Responsive column classes for the parent <code>div</code> of the header 1 and header 2 regions. Should contain a string with classes separated by a space.'),
     '#default_value' => theme_get_setting('az_header_responsive_column_classes_two'),
     '#element_validate' => ['token_element_validate'],
   ];

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -248,20 +248,20 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     '#default_value' => theme_get_setting('sticky_footer'),
   ];
   // Responsive Header Grid.
-  $form['layout']['region_containers'] = [
+  $form['layout']['header_grid'] = [
     '#type' => 'details',
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
     '#title' => t('Responsive Header Grid'),
     '#description' => t('The header typically contains two columns on small screen sizes and larger with the "Site branding" region on the left and with "Header 1" and "Header 2" on the right.'),
   ];
-  $form['layout']['region_containers']['header_one_col_classes'] = [
+  $form['layout']['header_grid']['header_one_col_classes'] = [
     '#type' => 'textfield',
     '#title' => t('Column one classes'),
     '#description' => t('Responsive column classes for the parent <code>div</code> of the Site branding region. Should contain a string with classes separated by a space.'),
     '#default_value' => theme_get_setting('header_one_col_classes'),
   ];
-  $form['layout']['region_containers']['header_two_col_classes'] = [
+  $form['layout']['header_grid']['header_two_col_classes'] = [
     '#type' => 'textfield',
     '#title' => t('Column two classes'),
     '#description' => t('Responsive column classes for the parent <code>div</code> of the Header 1 and Header 2 regions. Should contain a string with classes separated by a space.'),

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -253,7 +253,7 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
     '#title' => t('Responsive Header Grid'),
-    '#description' => t('The header typically contains two columns with the "Site branding" region on the left, with "Header 1", and "Header 2" on the right.'),
+    '#description' => t('The header typically contains two columns on small screen sizes and larger with the "Site branding" region on the left and with "Header 1" and "Header 2" on the right.'),
   ];
   $form['layout']['region_containers']['header_one_col_classes'] = [
     '#type' => 'textfield',

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -247,6 +247,39 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     '#title' => t('Use the AZ Bootstrap sticky footer template.'),
     '#default_value' => theme_get_setting('sticky_footer'),
   ];
+  $form['azbs_settings']['settings']['az_bootstrap_style']['sticky_footer'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Use the AZ Bootstrap sticky footer template.'),
+    '#default_value' => theme_get_setting('sticky_footer'),
+  ];
+  $form['layout']['region_containers'] = [
+    '#type' => 'details',
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#title' => t('Az Barrio Region Containers.'),
+  ];
+  // Region column containers.
+  $form['layout']['region_containers']['header'] = [
+    '#description' => t('The header typically contains two columns with the "Site branding" region on the left, with "Header 1", and "Header 2" on the right.'),
+    '#type' => 'fieldset',
+    '#title' => t('Header Region Columns.'),
+    '#collapsible' => FALSE,
+    '#collapsed' => FALSE,
+  ];
+  $form['layout']['region_containers']['header']['az_header_responsive_column_classes_one'] = [
+    '#type' => 'textfield',
+    '#title' => t('Column classes'),
+    '#description' => t('Responsive column classes for the parent <code>div</code> of the branding region.'),
+    '#default_value' => theme_get_setting('az_header_responsive_column_classes_one'),
+    '#element_validate' => ['token_element_validate'],
+  ];
+  $form['layout']['region_containers']['header']['az_header_responsive_column_classes_two'] = [
+    '#type' => 'textfield',
+    '#title' => t('Column classes'),
+    '#description' => t('Responsive column classes for the parent <code>div</code> of the header 1 and header 2 regions.'),
+    '#default_value' => theme_get_setting('az_header_responsive_column_classes_two'),
+    '#element_validate' => ['token_element_validate'],
+  ];
   // Remove Navbar options.
   $form['affix']['navbar_top'] = [];
   $form['affix']['navbar'] = [];

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -266,7 +266,6 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     '#title' => t('Column two classes'),
     '#description' => t('Responsive column classes for the parent <code>div</code> of the Header 1 and Header 2 regions. Should contain a string with classes separated by a space.'),
     '#default_value' => theme_get_setting('header_two_col_classes'),
-    '#element_validate' => ['token_element_validate'],
   ];
   // Remove Navbar options.
   $form['affix']['navbar_top'] = [];

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -261,18 +261,18 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     '#collapsible' => FALSE,
     '#collapsed' => FALSE,
   ];
-  $form['layout']['region_containers']['header']['az_header_responsive_column_classes_one'] = [
+  $form['layout']['region_containers']['header']['header_one_col_classes'] = [
     '#type' => 'textfield',
     '#title' => t('Column classes'),
     '#description' => t('Responsive column classes for the parent <code>div</code> of the branding region. Should contain a string with classes separated by a space.'),
-    '#default_value' => theme_get_setting('az_header_responsive_column_classes_one'),
+    '#default_value' => theme_get_setting('header_one_col_classes'),
     '#element_validate' => ['token_element_validate'],
   ];
-  $form['layout']['region_containers']['header']['az_header_responsive_column_classes_two'] = [
+  $form['layout']['region_containers']['header']['header_two_col_classes'] = [
     '#type' => 'textfield',
     '#title' => t('Column classes'),
     '#description' => t('Responsive column classes for the parent <code>div</code> of the header 1 and header 2 regions. Should contain a string with classes separated by a space.'),
-    '#default_value' => theme_get_setting('az_header_responsive_column_classes_two'),
+    '#default_value' => theme_get_setting('header_two_col_classes'),
     '#element_validate' => ['token_element_validate'],
   ];
   // Remove Navbar options.

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -264,7 +264,7 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
   $form['layout']['region_containers']['header_two_col_classes'] = [
     '#type' => 'textfield',
     '#title' => t('Column two classes'),
-    '#description' => t('Responsive column classes for the parent <code>div</code> of the header 1 and header 2 regions. Should contain a string with classes separated by a space.'),
+    '#description' => t('Responsive column classes for the parent <code>div</code> of the Header 1 and Header 2 regions. Should contain a string with classes separated by a space.'),
     '#default_value' => theme_get_setting('header_two_col_classes'),
     '#element_validate' => ['token_element_validate'],
   ];

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -247,30 +247,24 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     '#title' => t('Use the AZ Bootstrap sticky footer template.'),
     '#default_value' => theme_get_setting('sticky_footer'),
   ];
+  // Responsive Header Grid.
   $form['layout']['region_containers'] = [
     '#type' => 'details',
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
-    '#title' => t('Az Barrio Region Containers.'),
-  ];
-  // Region column containers.
-  $form['layout']['region_containers']['header'] = [
+    '#title' => t('Responsive Header Grid'),
     '#description' => t('The header typically contains two columns with the "Site branding" region on the left, with "Header 1", and "Header 2" on the right.'),
-    '#type' => 'fieldset',
-    '#title' => t('Header Region Columns.'),
-    '#collapsible' => FALSE,
-    '#collapsed' => FALSE,
   ];
-  $form['layout']['region_containers']['header']['header_one_col_classes'] = [
+  $form['layout']['region_containers']['header_one_col_classes'] = [
     '#type' => 'textfield',
-    '#title' => t('Column classes'),
+    '#title' => t('Column one classes'),
     '#description' => t('Responsive column classes for the parent <code>div</code> of the branding region. Should contain a string with classes separated by a space.'),
     '#default_value' => theme_get_setting('header_one_col_classes'),
     '#element_validate' => ['token_element_validate'],
   ];
-  $form['layout']['region_containers']['header']['header_two_col_classes'] = [
+  $form['layout']['region_containers']['header_two_col_classes'] = [
     '#type' => 'textfield',
-    '#title' => t('Column classes'),
+    '#title' => t('Column two classes'),
     '#description' => t('Responsive column classes for the parent <code>div</code> of the header 1 and header 2 regions. Should contain a string with classes separated by a space.'),
     '#default_value' => theme_get_setting('header_two_col_classes'),
     '#element_validate' => ['token_element_validate'],

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -258,7 +258,7 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
   $form['layout']['region_containers']['header_one_col_classes'] = [
     '#type' => 'textfield',
     '#title' => t('Column one classes'),
-    '#description' => t('Responsive column classes for the parent <code>div</code> of the branding region. Should contain a string with classes separated by a space.'),
+    '#description' => t('Responsive column classes for the parent <code>div</code> of the Site branding region. Should contain a string with classes separated by a space.'),
     '#default_value' => theme_get_setting('header_one_col_classes'),
     '#element_validate' => ['token_element_validate'],
   ];

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -247,11 +247,6 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     '#title' => t('Use the AZ Bootstrap sticky footer template.'),
     '#default_value' => theme_get_setting('sticky_footer'),
   ];
-  $form['azbs_settings']['settings']['az_bootstrap_style']['sticky_footer'] = [
-    '#type' => 'checkbox',
-    '#title' => t('Use the AZ Bootstrap sticky footer template.'),
-    '#default_value' => theme_get_setting('sticky_footer'),
-  ];
   $form['layout']['region_containers'] = [
     '#type' => 'details',
     '#collapsible' => TRUE,


### PR DESCRIPTION
## Description
Adding two new theme settings for setting column classes on the parent divs of the branding region and the header1 &2 regions.

Set page variable keys for `az_header_responsive_column_classes_one` and `az_header_responsive_column_classes_two`
Should contain a string with classes separated by a space.

Added a new section on the `az_barrio` theme settings page.
<img width="1639" alt="image" src="https://user-images.githubusercontent.com/1023167/153097774-b5576775-9615-4da2-9432-96c67bef05dd.png">

I moved the existing classes that existed in the page.twig.html file into the default settings.

Added schema config for the two new settings.

Tested config distro update using the merge strategy to import the defaults.

**Header columns are missing until defaults imported via config distro.**
<img width="1383" alt="image" src="https://user-images.githubusercontent.com/1023167/153098082-161b3318-37b9-4dda-97c0-ef0987f52f5c.png">

**Once imported it looks like this with the imported classes:** 
<img width="1486" alt="image" src="https://user-images.githubusercontent.com/1023167/153098157-dcd9af9b-d495-483e-b76a-7ad3986af2f4.png">

## Related Issue
Closes #1293 

## How Has This Been Tested?
`lando drush cd-update -y` config updated.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
