### PR TITLE
Closes #1303: Add Drupal core patch to fix missing az_news_feeds local menu task when content_moderation module not installed.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,4 +1,4 @@
-name: az_quickstart-1303
+name: az_quickstart
 recipe: drupal9
 config:
   php: '7.4'

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,4 +1,4 @@
-name: az_quickstart
+name: az_quickstart-1303
 recipe: drupal9
 config:
   php: '7.4'

--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,8 @@
                 "Unrelated error message when running tests with database errors (3163925)": "https://git.drupalcode.org/project/drupal/-/merge_requests/212.diff",
                 "Allow menu_link source plugin to filter menu links by menu name (#3064016)": "https://git.drupalcode.org/project/drupal/-/commit/510b5904fcd2498800b733d4e3015003eed23c81.diff",
                 "Add skip-method option to file_copy and download process plugins (2766369)": "https://www.drupal.org/files/issues/2020-06-28/2766369-25.patch",
-                "Incorrect results on grouped exposed filters (1810148)": "https://www.drupal.org/files/issues/2022-02-02/1810148-101.patch"
+                "Incorrect results on grouped exposed filters (1810148)": "https://www.drupal.org/files/issues/2022-02-02/1810148-101.patch",
+                "Move content overview default task link out of content_moderation module (3199682)": "https://www.drupal.org/files/issues/2022-02-10/3199682-11-9-2-x.patch"
             },
             "drupal/config_distro": {
                 "fnmatch issue": "https://www.drupal.org/files/issues/2020-07-04/3144145-replace-fnmatch-with-preg-match-6.patch",


### PR DESCRIPTION
## Description
Adds a Drupal core patch to fix an issue that prevents our AZ News Feeds menu local task from appearing at `/admin/content` when the content_moderation module isn't installed.

See https://www.drupal.org/project/drupal/issues/3199682

## Related Issue
Fixes #1303.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
