### PR TITLE
Closes #1296: Use views label instead of rendered views inside paragraph previews.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,6 +142,9 @@
             },
             "drupal/metatag": {
                 "Module to support migrate upgrade": "https://www.drupal.org/files/issues/2020-12-11/support_migrate_upgrade-3187898-2.patch"
+            },
+            "drupal/viewsreference": {
+                "Add Label field formatter (2938433)": "https://www.drupal.org/files/issues/2021-01-27/add_label_formatter-2938433-7.patch"
             }
         },
         "drupal-scaffold": {

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/core.entity_view_display.paragraph.az_view_reference.preview.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/core.entity_view_display.paragraph.az_view_reference.preview.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.az_view_reference.field_az_title
+    - field.field.paragraph.az_view_reference.field_az_view_reference
+    - paragraphs.paragraphs_type.az_view_reference
+  module:
+    - field_group
+    - viewsreference
+third_party_settings:
+  field_group:
+    group_title:
+      children:
+        - field_az_title
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        id: ''
+        classes: ''
+        element: h2
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+      label: Title
+id: paragraph.az_view_reference.preview
+targetEntityType: paragraph
+bundle: az_view_reference
+mode: preview
+content:
+  field_az_title:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_az_view_reference:
+    weight: 2
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: viewsreference_label_formatter
+    region: content
+hidden: {  }


### PR DESCRIPTION
## Description
- Adds [patch from drupal.org](https://www.drupal.org/project/viewsreference/issues/2938433) for viewsreference module that adds a "Label" field formatter for viewsreference fields
- Enables customized preview entity field display config (view mode) for views paragraphs that uses new label formatter
- Should fix #1296 since the view(s) won't actually be rendered in the paragraphs preview/edit UIs anymore

### Before:
![Screen Shot 2022-02-11 at 12 35 13 PM](https://user-images.githubusercontent.com/471936/153659482-fd3405dc-dc7b-46d4-8953-59ad3db4bd3c.png)

### After:
![Screen Shot 2022-02-11 at 12 38 01 PM](https://user-images.githubusercontent.com/471936/153659545-ea56dde2-43f8-451a-97cb-50384d029f6e.png)

Note: the view label that is displayed is a clickable link _only_ if the current user has views edit access.  i.e. it looks like this for content editors:
![Screen Shot 2022-02-11 at 12 40 24 PM](https://user-images.githubusercontent.com/471936/153659746-b90ed40e-b75d-4617-bb7e-5baab52bff4a.png)


## Related Issue
Fixes #1296 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
