### PR TITLE
Closes #682: Added Better Exposed Filters module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,7 @@
         "drupal/webform": "6.1.2",
         "drupal/xmlsitemap": "1.2.0",
         "npm-asset/blazy": "1.8.2",
+        "npm-asset/jquery-ui-touch-punch": "0.2.3",
         "npm-asset/slick-carousel": "1.8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "drupal/access_unpublished": "1.3.0",
         "drupal/auto_entitylabel": "3.0-beta4",
         "drupal/background_image_formatter": "1.7",
+        "drupal/better_exposed_filters": "5.0-beta1",
         "drupal/block_class": "1.3",
         "drupal/block_content_permissions": "1.10",
         "drupal/bootstrap_barrio": "4.30",
@@ -95,6 +96,7 @@
         "drupal/webform": "6.1.2",
         "drupal/xmlsitemap": "1.2.0",
         "npm-asset/blazy": "1.8.2",
+        "npm-asset/jquery-ui-touch-punch": "0.2.3",
         "npm-asset/slick-carousel": "1.8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "drupal/access_unpublished": "1.3.0",
         "drupal/auto_entitylabel": "3.0-beta4",
         "drupal/background_image_formatter": "1.7",
-        "drupal/better_exposed_filters": "5.0-beta1",
+        "drupal/better_exposed_filters": "5.0",
         "drupal/block_class": "1.3",
         "drupal/block_content_permissions": "1.10",
         "drupal/bootstrap_barrio": "4.30",
@@ -96,7 +96,6 @@
         "drupal/webform": "6.1.2",
         "drupal/xmlsitemap": "1.2.0",
         "npm-asset/blazy": "1.8.2",
-        "npm-asset/jquery-ui-touch-punch": "0.2.3",
         "npm-asset/slick-carousel": "1.8.0"
     },
     "require-dev": {
@@ -107,6 +106,9 @@
             "dev-main": "2.2.x-dev"
         },
         "patches": {
+            "drupal/better_exposed_filters": {
+                "Remove jquery_ui_slider (3210947)": "https://www.drupal.org/files/issues/2022-02-16/3210947-12.patch"
+            },
             "drupal/bootstrap_barrio": {
                 "Fix schema (3217958)": "https://gist.githubusercontent.com/trackleft/6b7752228979c6932e8d09e01381dd28/raw/70bd7ed90ab487b454a1106aa9935a335b7d4f49/gistfile1.txt"
             },


### PR DESCRIPTION
## Description
Updated version of old PR for adding Better Exposed filters module.  This now uses the latest version of the module (5.0) and adds a patch to remove the dependency on jquery_ui_slider.

## Related Issue
#682 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
