### PR TITLE
Closes #1153: Change red bar wordmark link to https

### DIFF
--- a/themes/custom/az_barrio/templates/layout/page.html.twig
+++ b/themes/custom/az_barrio/templates/layout/page.html.twig
@@ -87,7 +87,7 @@
           <div class="{{ container }}">
             <div class="row">
               {% if wordmark %}
-              <a class="arizona-logo" href="http://www.arizona.edu" title="The University of Arizona homepage">
+              <a class="arizona-logo" href="https://www.arizona.edu" title="The University of Arizona homepage">
                 <img class="arizona-line-logo" alt="The University of Arizona Wordmark Line Logo White" src="https://cdn.digital.arizona.edu/logos/v1.0.0/ua_wordmark_line_logo_white_rgb.min.svg"/>
               </a>
               {% endif %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Closes #1153 by changing the University of Arizona wordmark link in the top red bar of every QS2 site from "http" to "https".

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#1153](https://github.com/az-digital/az_quickstart/issues/1153)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed locally with Lando that the link was changed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
