### PR TITLE
Closes #1333: Configure system mail interface to use SMTP during install.

### DIFF
--- a/modules/custom/az_mail/az_mail.install
+++ b/modules/custom/az_mail/az_mail.install
@@ -9,16 +9,26 @@
  * Implements hook_install().
  */
 function az_mail_install() {
-    $config_factory = \Drupal::service('config.factory');
-    $mail_config = $config_factory->getEditable('system.mail');
-    $mail_config->set('interface.default', 'SMTPMailSystem')->save();
+  $config_factory = \Drupal::service('config.factory');
+  $config = $config_factory->getEditable('smtp.settings');
+  $mail_config = $config_factory->getEditable('system.mail');
+  $mail_system = $mail_config->get('interface.default');
+  if ($mail_system != 'SMTPMailSystem') {
+    $config->set('prev_mail_system', $mail_system);
+  }    
+  $mail_config->set('interface.default', 'SMTPMailSystem')->save();
 }
 
 /**
- * Force update system.mail.interface.default.
+ * Configure system.mail interface to use SMTP (unless already configured).
  */
 function az_mail_update_9201() {
-    $config_factory = \Drupal::service('config.factory');
-    $mail_config = $config_factory->getEditable('system.mail');
-    $mail_config->set('interface.default', 'SMTPMailSystem')->save();
+  $config_factory = \Drupal::service('config.factory');
+  $config = $config_factory->getEditable('smtp.settings');
+  $mail_config = $config_factory->getEditable('system.mail');
+  $mail_system = $mail_config->get('interface.default');
+  if ($mail_system != 'SMTPMailSystem') {
+    $config->set('prev_mail_system', $mail_system);
+  }    
+  $mail_config->set('interface.default', 'SMTPMailSystem')->save();
 }

--- a/modules/custom/az_mail/az_mail.install
+++ b/modules/custom/az_mail/az_mail.install
@@ -12,10 +12,6 @@ function az_mail_install() {
   $config_factory = \Drupal::service('config.factory');
   $mail_config = $config_factory->getEditable('system.mail');
   $mail_system = $mail_config->get('interface.default');
-  if ($mail_system != 'SMTPMailSystem') {
-    $config = $config_factory->getEditable('smtp.settings');
-    $config->set('prev_mail_system', $mail_system)->save();
-  }
   $mail_config->set('interface.default', 'SMTPMailSystem')->save();
 }
 
@@ -26,9 +22,5 @@ function az_mail_update_9201() {
   $config_factory = \Drupal::service('config.factory');
   $mail_config = $config_factory->getEditable('system.mail');
   $mail_system = $mail_config->get('interface.default');
-  if ($mail_system != 'SMTPMailSystem') {
-    $config = $config_factory->getEditable('smtp.settings');
-    $config->set('prev_mail_system', $mail_system)->save();
-  }
   $mail_config->set('interface.default', 'SMTPMailSystem')->save();
 }

--- a/modules/custom/az_mail/az_mail.install
+++ b/modules/custom/az_mail/az_mail.install
@@ -15,12 +15,12 @@ function az_mail_install() {
   $mail_system = $mail_config->get('interface.default');
   if ($mail_system != 'SMTPMailSystem') {
     $config->set('prev_mail_system', $mail_system);
-  }    
+  }
   $mail_config->set('interface.default', 'SMTPMailSystem')->save();
 }
 
 /**
- * Configure system.mail interface to use SMTP (unless already configured).
+ * Configure system.mail interface to use SMTP.
  */
 function az_mail_update_9201() {
   $config_factory = \Drupal::service('config.factory');
@@ -29,6 +29,6 @@ function az_mail_update_9201() {
   $mail_system = $mail_config->get('interface.default');
   if ($mail_system != 'SMTPMailSystem') {
     $config->set('prev_mail_system', $mail_system);
-  }    
+  }
   $mail_config->set('interface.default', 'SMTPMailSystem')->save();
 }

--- a/modules/custom/az_mail/az_mail.install
+++ b/modules/custom/az_mail/az_mail.install
@@ -10,10 +10,10 @@
  */
 function az_mail_install() {
   $config_factory = \Drupal::service('config.factory');
-  $config = $config_factory->getEditable('smtp.settings');
   $mail_config = $config_factory->getEditable('system.mail');
   $mail_system = $mail_config->get('interface.default');
   if ($mail_system != 'SMTPMailSystem') {
+    $config = $config_factory->getEditable('smtp.settings');
     $config->set('prev_mail_system', $mail_system);
   }
   $mail_config->set('interface.default', 'SMTPMailSystem')->save();
@@ -24,10 +24,10 @@ function az_mail_install() {
  */
 function az_mail_update_9201() {
   $config_factory = \Drupal::service('config.factory');
-  $config = $config_factory->getEditable('smtp.settings');
   $mail_config = $config_factory->getEditable('system.mail');
   $mail_system = $mail_config->get('interface.default');
   if ($mail_system != 'SMTPMailSystem') {
+    $config = $config_factory->getEditable('smtp.settings');
     $config->set('prev_mail_system', $mail_system);
   }
   $mail_config->set('interface.default', 'SMTPMailSystem')->save();

--- a/modules/custom/az_mail/az_mail.install
+++ b/modules/custom/az_mail/az_mail.install
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for az_mail module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function az_mail_install() {
+    $config_factory = \Drupal::service('config.factory');
+    $mail_config = $config_factory->getEditable('system.mail');
+    $mail_config->set('interface.default', 'SMTPMailSystem')->save();
+}
+
+/**
+ * Force update system.mail.interface.default.
+ */
+function az_mail_update_9201() {
+    $config_factory = \Drupal::service('config.factory');
+    $mail_config = $config_factory->getEditable('system.mail');
+    $mail_config->set('interface.default', 'SMTPMailSystem')->save();
+}

--- a/modules/custom/az_mail/az_mail.install
+++ b/modules/custom/az_mail/az_mail.install
@@ -14,7 +14,7 @@ function az_mail_install() {
   $mail_system = $mail_config->get('interface.default');
   if ($mail_system != 'SMTPMailSystem') {
     $config = $config_factory->getEditable('smtp.settings');
-    $config->set('prev_mail_system', $mail_system);
+    $config->set('prev_mail_system', $mail_system)->save();
   }
   $mail_config->set('interface.default', 'SMTPMailSystem')->save();
 }
@@ -28,7 +28,7 @@ function az_mail_update_9201() {
   $mail_system = $mail_config->get('interface.default');
   if ($mail_system != 'SMTPMailSystem') {
     $config = $config_factory->getEditable('smtp.settings');
-    $config->set('prev_mail_system', $mail_system);
+    $config->set('prev_mail_system', $mail_system)->save();
   }
   $mail_config->set('interface.default', 'SMTPMailSystem')->save();
 }

--- a/modules/custom/az_mail/az_mail.install
+++ b/modules/custom/az_mail/az_mail.install
@@ -11,7 +11,6 @@
 function az_mail_install() {
   $config_factory = \Drupal::service('config.factory');
   $mail_config = $config_factory->getEditable('system.mail');
-  $mail_system = $mail_config->get('interface.default');
   $mail_config->set('interface.default', 'SMTPMailSystem')->save();
 }
 
@@ -21,6 +20,5 @@ function az_mail_install() {
 function az_mail_update_9201() {
   $config_factory = \Drupal::service('config.factory');
   $mail_config = $config_factory->getEditable('system.mail');
-  $mail_system = $mail_config->get('interface.default');
   $mail_config->set('interface.default', 'SMTPMailSystem')->save();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

## Related Issue
#1333 

## How Has This Been Tested?
- Created a new site with this change
- Installed `az_mail`
- Confirmed `system.mail.interface.default` was set to `SMTPMailSystem`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
