### PR TITLE
Closes #739 - Accordions should match Bootstrap

### DIFF
--- a/modules/custom/az_accordion/templates/az-accordion.html.twig
+++ b/modules/custom/az_accordion/templates/az-accordion.html.twig
@@ -24,7 +24,7 @@
       <h3 class="my-0">
         <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#{{ accordion_item_id }}" aria-expanded="{{ aria_expanded }}" aria-controls="{{ aria_controls }}">
           {% if title %}
-          <h3 class="h5 bold mt-0">{{ title }}</h3>
+            {{ title }}
           {% endif %}
         </button>
       </h3>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes Accordions so they match Bootstrap styling; nested `h3` tag has been removed from inside the `button` tag.

Accordions currently look like this on Quickstart:
![Screen Shot 2022-02-22 at 4 19 12 PM](https://user-images.githubusercontent.com/52931751/155236096-1f665663-2b26-4d52-bab7-486e182f974b.png)

This is what they will look like with this fix:
![Screen Shot 2022-02-22 at 4 21 00 PM](https://user-images.githubusercontent.com/52931751/155236310-cf82d06a-cda1-467b-99dd-f55da2908da0.png)

Review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-1335.probo.build/pages/accordions

## Related Issue
Closes #739 

## How Has This Been Tested?
Pending Probo test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
