### PR TITLE
Closes #1341: fix line break issues with names in AZ Person Grid View

### DIFF
--- a/themes/custom/az_barrio/templates/content/node--az-person--az-card.html.twig
+++ b/themes/custom/az_barrio/templates/content/node--az-person--az-card.html.twig
@@ -87,7 +87,7 @@
         </a>
       {% endif %}
       <div class="card-body">
-        <h3 class="h5 mt-0"><a href="{{ url }}">{{ content.field_az_fname.0 }}&nbsp;{{ content.field_az_lname.0 }}</a></h3>
+        <h3 class="h5 mt-0"><a href="{{ url }}">{{ content.field_az_fname.0 }} {{ content.field_az_lname.0 }}</a></h3>
         {% if content.field_az_titles[0] %}
           {% for key, item in content.field_az_titles if key|first != '#' %}
             <span class="d-block">{{ item }}</span>

--- a/themes/custom/az_barrio/templates/content/node--az-person--az_row.html.twig
+++ b/themes/custom/az_barrio/templates/content/node--az-person--az_row.html.twig
@@ -90,7 +90,7 @@
       {% endif %}
       </div>
       <div class="col-12 col-md-5">
-        <h3 class="h5 mt-0"><a href="{{ url }}">{{ content.field_az_fname.0 }}&nbsp;{{ content.field_az_lname.0 }}</a></h3>
+        <h3 class="h5 mt-0"><a href="{{ url }}">{{ content.field_az_fname.0 }} {{ content.field_az_lname.0 }}</a></h3>
         {% if content.field_az_titles[0] %}
           {% for key, item in content.field_az_titles if key|first != '#' %}
             <span class="d-block">{{ item }}</span>

--- a/themes/custom/az_barrio/templates/content/node--az-person--full.html.twig
+++ b/themes/custom/az_barrio/templates/content/node--az-person--full.html.twig
@@ -101,7 +101,7 @@
   <div{{ content_attributes.addClass('node__content', 'clearfix') }}>
     <div class="row d-md-none">
       <div class="col-12">
-        <h1 class="text-blue my-0">{{ content.field_az_fname.0 }}&nbsp;{{ content.field_az_lname.0 }}</h1>
+        <h1 class="text-blue my-0">{{ content.field_az_fname.0 }} {{ content.field_az_lname.0 }}</h1>
         {% if content.field_az_titles[0] %}
           {% for key, item in content.field_az_titles if key|first != '#' %}
             <span class="h4 d-block mt-0">{{ item }}</span>
@@ -113,7 +113,7 @@
       <div class="col-12 col-md-8 order-2">
 
         <div class="d-none d-md-block">
-          <h1 class="text-blue my-0">{{ content.field_az_fname.0 }}&nbsp;{{ content.field_az_lname.0 }}</h1>
+          <h1 class="text-blue my-0">{{ content.field_az_fname.0 }} {{ content.field_az_lname.0 }}</h1>
           {% if content.field_az_titles[0] %}
             {% for key, item in content.field_az_titles if key|first != '#' %}
               <span class="h4 d-block mt-0">{{ item }}</span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Closes #1341 with the following changes:

- In the theme implementation for AZ Person cards, replace the `&nbsp;` between the first and last names with standard whitespace. This allows the names to wrap as expected.
- Make the same replacement on Row and Full displays for AZ Person, for consistency.

(The original commit below was for issue 1328 before it was split into two issues, 1328 and 1341.)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1341 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with Probo and locally with Lando.

Before:
<img width="1310" alt="Screen Shot 2022-02-18 at 10 55 42 AM" src="https://user-images.githubusercontent.com/74572157/154764423-140c14be-a880-4161-8d70-015556390a7f.png">

After:
<img width="1246" alt="Screen Shot 2022-02-18 at 11 03 55 AM" src="https://user-images.githubusercontent.com/74572157/154764455-cbc303c8-644d-4781-8718-93a93557e688.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
