### PR TITLE
Closes #1344 Migration: Extra (blank) Text Boxes are showing up 

### DIFF
--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_flexible_page_sub.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_flexible_page_sub.yml
@@ -15,15 +15,16 @@ destination:
 
 process:
   field_az_text_area:
-    plugin: sub_process
-    source: field_uaqs_flexible_page_sub
-    process:
-      delta: delta
-      value: value
-      format:  
-        plugin: default_value
-        default_value: az_standard
-    
+    - plugin: sub_process
+      source: field_uaqs_flexible_page_sub
+      process:
+        delta: delta
+        value: value
+        format:
+          plugin: default_value
+          default_value: az_standard
+    - plugin: skip_on_empty
+      method: row
   behavior_settings:
     plugin: paragraphs_behavior_settings
 

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_flexible_page_sub.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_flexible_page_sub.yml
@@ -15,6 +15,15 @@ destination:
 
 process:
   field_az_text_area:
+    - plugin: extract
+      source: field_uaqs_flexible_page_sub
+      index:
+        - 0
+        - value
+      default: ''
+    # See https://drupal.stackexchange.com/questions/258896/why-doesnt-skip-on-empty-work-when-migrating-from-a-text-field
+    - plugin: skip_on_empty
+      method: row
     - plugin: sub_process
       source: field_uaqs_flexible_page_sub
       process:
@@ -23,8 +32,6 @@ process:
         format:
           plugin: default_value
           default_value: az_standard
-    - plugin: skip_on_empty
-      method: row
   behavior_settings:
     plugin: paragraphs_behavior_settings
 

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_flexible_page_sub.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_flexible_page_sub.yml
@@ -15,17 +15,11 @@ destination:
 
 process:
   field_az_text_area:
-    - plugin: extract
+    - plugin: single_value
       source: field_uaqs_flexible_page_sub
-      index:
-        - 0
-        - value
-      default: ''
-    # See https://drupal.stackexchange.com/questions/258896/why-doesnt-skip-on-empty-work-when-migrating-from-a-text-field
     - plugin: skip_on_empty
       method: row
     - plugin: sub_process
-      source: field_uaqs_flexible_page_sub
       process:
         delta: delta
         value: value


### PR DESCRIPTION
## Description
az_paragraph_flexible_page_sub migration adds extra text areas even if there is no subhead value.

## Related Issue
Closes #1344

## How Has This Been Tested?
Used arizonaedu test db to migrate subhead fields to text paragraphs.
If there was a value in the subhead a new paragraph is created
If there is no value in the subhead field, no new paragraph is created.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
