### PR TITLE
Closes #1331: Make sidebar not overlap text for Text with Background

### DIFF
--- a/modules/custom/az_paragraphs/css/az_paragraphs_az_text_media.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_az_text_media.css
@@ -30,7 +30,7 @@
 .az-video-playing .text-on-video {
   background: none !important;
 }
-.paragraph--type--az-text-media .box
+.paragraph--type--az-text-media .box,
 .paragraph--type--az-text-media .az-full-width-column-content.box {
   padding: 2em;
   margin-left: 0;
@@ -41,7 +41,7 @@
   padding-left: 2em;
   padding-right: 2em;
 }
-.bottom
+.bottom,
 .paragraph--type--az-text-media .az-full-width-column-content.bottom {
   margin-top: -5em;
   padding: 2em;

--- a/modules/custom/az_paragraphs/css/az_paragraphs_az_text_media.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_az_text_media.css
@@ -30,7 +30,8 @@
 .az-video-playing .text-on-video {
   background: none !important;
 }
-.paragraph--type--az-text-media .box {
+.paragraph--type--az-text-media .box
+.paragraph--type--az-text-media .az-full-width-column-content.box {
   padding: 2em;
   margin-left: 0;
   margin-right: 0;
@@ -40,7 +41,8 @@
   padding-left: 2em;
   padding-right: 2em;
 }
-.bottom {
+.bottom
+.paragraph--type--az-text-media .az-full-width-column-content.bottom {
   margin-top: -5em;
   padding: 2em;
 }

--- a/modules/custom/az_paragraphs/css/az_paragraphs_az_text_media.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_az_text_media.css
@@ -35,7 +35,8 @@
   margin-left: 0;
   margin-right: 0;
 }
-.paragraph--type--az-text-media .column {
+.paragraph--type--az-text-media .column,
+.paragraph--type--az-text-media .az-full-width-column-content.column {
   padding-left: 2em;
   padding-right: 2em;
 }

--- a/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
@@ -107,14 +107,11 @@
     }
 }
 @media (min-width: 768px) {
-    .layout-sidebar-first .region-content .full-width-background .az-full-width-column-content  {
+    .layout-sidebar-first .region-content .full-width-background .az-full-width-row {
         -ms-flex: 0 0 75%;
         flex: 0 0 75%;
         max-width: 75%;
-    }
-    .layout-sidebar-first .region-content .full-width-background .az-full-width-row {
-        margin-right: -30px;
-        margin-left: -30px;
+        margin-left: auto;
         -ms-flex-pack: end;
         justify-content: flex-end;
     }
@@ -135,12 +132,10 @@
         margin-left: calc(33.333333333333333% - 50vw);
         margin-right: calc(66.66666666666% - 50vw);
     }
-    .layout-sidebar-second .region-content .full-width-background .az-full-width-column-content {
+    .layout-sidebar-second .region-content .full-width-background .az-full-width-row {
         -ms-flex: 0 0 75%;
         flex: 0 0 75%;
         max-width: 75%;
-    }
-    .layout-sidebar-second .region-content .full-width-background .az-full-width-row {
         -ms-flex-pack: start!important;
         justify-content: flex-start!important;
     }
@@ -152,10 +147,14 @@
         -ms-flex-pack: center!important;
         justify-content: center!important;
     }
-    .layout-two-sidebars .region-content .full-width-background .az-full-width-column-content {
+    .layout-two-sidebars .region-content .full-width-background .az-full-width-row {
         -ms-flex: 0 0 50%;
         flex: 0 0 50%;
         max-width: 50%;
+    }
+    .layout-sidebar-first .region-content .az-full-width-column-content {
+        padding-left: 0;
+        padding-right: 0;
     }
     .layout-two-sidebars .region-content .full-width-background .full-width-background {
         margin-left: calc(50% - 50vw);

--- a/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
@@ -113,7 +113,6 @@
         max-width: 75%;
         margin-left: auto;
         -ms-flex-pack: end;
-        justify-content: flex-end;
     }
     .layout-sidebar-first .region-content .az-aspect-ratio.full-width-background .az-full-width-row,
     .layout-sidebar-second .region-content .az-aspect-ratio.full-width-background .az-full-width-row {

--- a/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
@@ -107,7 +107,7 @@
     }
 }
 @media (min-width: 768px) {
-    .layout-sidebar-first .region-content .full-width-background .az-full-width-row  {
+    .layout-sidebar-first .region-content .full-width-background .az-full-width-column-content  {
         -ms-flex: 0 0 75%;
         flex: 0 0 75%;
         max-width: 75%;
@@ -135,7 +135,7 @@
         margin-left: calc(33.333333333333333% - 50vw);
         margin-right: calc(66.66666666666% - 50vw);
     }
-    .layout-sidebar-second .region-content .full-width-background .az-full-width-row {
+    .layout-sidebar-second .region-content .full-width-background .az-full-width-column-content {
         -ms-flex: 0 0 75%;
         flex: 0 0 75%;
         max-width: 75%;
@@ -152,7 +152,7 @@
         -ms-flex-pack: center!important;
         justify-content: center!important;
     }
-    .layout-two-sidebars .region-content .full-width-background .az-full-width-row {
+    .layout-two-sidebars .region-content .full-width-background .az-full-width-column-content {
         -ms-flex: 0 0 50%;
         flex: 0 0 50%;
         max-width: 50%;

--- a/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
@@ -151,7 +151,7 @@
         flex: 0 0 50%;
         max-width: 50%;
     }
-    .layout-sidebar-first .region-content .az-full-width-column-content {
+    .layout-sidebar-first .region-content .paragraph--type--az-text-background.full-width-background {
         padding-left: 0;
         padding-right: 0;
     }

--- a/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
@@ -112,7 +112,7 @@
         flex: 0 0 75%;
         max-width: 75%;
         margin-left: auto;
-        -ms-flex-pack: end;
+        margin-right: 0;
     }
     .layout-sidebar-first .region-content .az-aspect-ratio.full-width-background .az-full-width-row,
     .layout-sidebar-second .region-content .az-aspect-ratio.full-width-background .az-full-width-row {
@@ -151,7 +151,7 @@
         flex: 0 0 50%;
         max-width: 50%;
     }
-    .layout-sidebar-first .region-content .paragraph--type--az-text-background.full-width-background {
+    .region-content .paragraph--type--az-text-background.full-width-background .az-full-width-column-content {
         padding-left: 0;
         padding-right: 0;
     }


### PR DESCRIPTION
## Description
Simple fix of the class specified in the modules/custom/az_paragraphs/css/az_paragraphs_full_width.css to match the class on the elements in Text with Background

## Related Issue
#1331 

## How Has This Been Tested?
Locally and in Probo
Appreciate testing to make sure it doesn't break Text on Media (particularly when using Media Aspect Ratio) or other full-width elements.

https://5ec40ba7-e988-4dc9-9e2f-0560bea3e812.probo.build/pages/test-page

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
