### PR TITLE
Fixes #1361 NodeWithFieldCollection source plugin not accessible.

### DIFF
--- a/modules/custom/az_migration/src/Plugin/migrate/source/NodeWithFieldCollection.php
+++ b/modules/custom/az_migration/src/Plugin/migrate/source/NodeWithFieldCollection.php
@@ -43,7 +43,7 @@ use Drupal\node\Plugin\migrate\source\d7\Node as D7Node;
  *
  * @MigrateSource(
  *   id = "az_node_with_field_collection",
- *   source_provider = "az_migration"
+ *   source_module = "node"
  * )
  */
 class NodeWithFieldCollection extends D7Node {

--- a/modules/custom/az_migration/src/Plugin/migrate/source/NodeWithFieldCollection.php
+++ b/modules/custom/az_migration/src/Plugin/migrate/source/NodeWithFieldCollection.php
@@ -43,7 +43,7 @@ use Drupal\node\Plugin\migrate\source\d7\Node as D7Node;
  *
  * @MigrateSource(
  *   id = "az_node_with_field_collection",
- *   source_module = "az_migration"
+ *   source_provider = "az_migration"
  * )
  */
 class NodeWithFieldCollection extends D7Node {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The recently added `NodeWithFieldCollection` source plugin seems to not be available to migrations. Migrations using it cannot be run and report 'Migration not found.' 

## Related Issue
#1361 

## How Has This Been Tested?

- Create migration using the plugin
- Run migration before and after applying this pull request
- Verify that the migration was previously not available
- Verify that the migration runs after this PR's change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added this Pull Request to the AZ Quickstart Github project and set it to "Review in progress".
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
