### PR TITLE
Adding z-index for rendering full-width backgrounds behind sidebars

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs_text_background/templates/paragraph--az-text-background--default.html.twig
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_background/templates/paragraph--az-text-background--default.html.twig
@@ -48,7 +48,8 @@
   text_with_background.text_background_pattern,
   text_with_background.text_background_color,
   text_with_background.text_background_padding,
-  text_with_background.text_background_full_width
+  text_with_background.text_background_full_width,
+  text_with_background.text_background_full_width ? 'position-relative' : ''
 ]
 %}
 

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/config/install/core.entity_view_display.paragraph.az_text_media.default.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/config/install/core.entity_view_display.paragraph.az_text_media.default.yml
@@ -140,7 +140,7 @@ content:
     settings:
       image_style: az_full_width_background
       css_settings:
-        z_index: auto
+        z_index: -1
         color: transparent
         x: center
         'y': center

--- a/modules/custom/az_paragraphs/css/az_paragraphs_az_text_background.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_az_text_background.css
@@ -2,4 +2,5 @@
 
 .region-content .background-wrapper.full-width-background {
   width: initial;
+  z-index: -1;
 }

--- a/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
@@ -7,6 +7,8 @@
 .layout-sidebar-first .full-width-background,
 .layout-sidebar-second .full-width-background {
     max-width: calc(100vw - var(--scrollbar-width));
+    position: relative;
+    z-index: -1;
 }
 .region-content .full-width-background {
     margin-left: calc(50% - 50vw);


### PR DESCRIPTION
## Description
Updated config for text on media background field formatter to use z-index: -1 instead of z-index: auto. Requires `drush cd-update`

Updated css for text on background adding z-index: -1
Updated class list added to text on background if full width is selected to include the position-relative class.

## Related Issue
#1356 

## How Has This Been Tested?
Locally on Firefox.

## Types of changes
**Arizona Quickstart** (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

**Drupal core**
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

**Drupal contrib projects**
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
