### PR TITLE
#1367: Update composer branch alias for dev-main to 2.3.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.2.x-dev"
+            "dev-main": "2.3.x-dev"
         },
         "patches": {
             "drupal/antibot" : {


### PR DESCRIPTION
We need to change the composer branch alias for dev-main to now be 2.3.x-dev since main will effectively be 2.3.x once we release 2.2.0. 

This should be merged _after_ any remaining PRs that we still want to include in the `2.2.0` release.

This change should also be back-ported to both the 2.1.x and 2.0.x branches.