### PR TITLE
Closes #1390 by setting maxlength of Card Link URL field to 2048 characters

### DIFF
--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -239,6 +239,7 @@ class AZCardWidget extends WidgetBase {
       '#title' => $this->t('Card Link URL'),
       '#element_validate' => [[$this, 'validateCardLink']],
       '#default_value' => isset($items[$delta]->link_uri) ? $items[$delta]->link_uri : NULL,
+      '#maxlength' => 2048,
     ];
 
     $element['link_style'] = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Closes #1390 by setting the maxlength for the link_uri textfield in AZCardWidget.php. On the Card paragraph form, the current textfield for the Card Link URL has the default maxlength of 128 characters. This PR sets the maxlength to 2048 characters to match the storage limit of the field.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1390 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Probo on [this page](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-1392.probo.build/1390-test) with these links:

- [Google Maps](https://www.google.com/maps/place/32%C2%B025'50.6%22N+110%C2%B051'39.1%22W/@32.43072,-110.8630387,17z/data=!3m1!4b1!4m6!3m5!1s0x0:0x22ac80a3fa642aa9!7e2!8m2!3d32.4307203!4d-110.8608496) (184 characters)
- [Google Search](https://www.google.com/search?as_q=you%20have%20to%20write%20a%20really%20really%20long%20search%20to%20get%20to%202000%20characters.%20like%20seriously%2C%20you%20have%20no%20idea%20how%20long%20it%20has%20to%20be&as_epq=2000%20characters%20is%20absolutely%20freaking%20enormous.%20You%20can%20fit%20sooooooooooooooooooooooooooooooooo%20much%20data%20into%202000%20characters.%20My%20hands%20are%20getting%20tired%20typing%20this%20many%20characters.%20I%20didn%27t%20even%20realise%20how%20long%20it%20was%20going%20to%20take%20to%20type%20them%20all.&as_oq=Argh%21%20So%20many%20characters.%20I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.%20I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.I%27m%20bored%20now%2C%20so%20I%27ll%20just%20copy%20and%20paste.&as_eq=It%20has%20to%20be%20freaking%20enormously%20freaking%20enormous&as_nlo=123&as_nhi=456&lr=lang_hu&cr=countryAD&as_qdr=m&as_sitesearch=stackoverflow.com&as_occt=title&safe=active&tbs=rl%3A1%2Crls%3A0&as_filetype=xls&as_rights=%28cc_publicdomain%7Ccc_attribute%7Ccc_sharealike%7Ccc_nonderived%29.-%28cc_noncommercial%29&gws_rd=ssl) (1999 characters)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
**Arizona Quickstart** (install profile, custom modules, custom theme)
- Patch release changes
   - [X] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

**Drupal core**
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

**Drupal contrib projects**
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
