### PR TITLE
Fixes #1397 Update migrations to add text_media_spacing default and change bg_attach to bg_attachment

### DIFF
--- a/modules/custom/az_demo/migrations/az_demo_text_media_paragraph.yml
+++ b/modules/custom/az_demo/migrations/az_demo_text_media_paragraph.yml
@@ -81,7 +81,7 @@ process:
     paragraph_behavior_plugins:
       az_text_media_paragraph_behavior:
         bg_color: bg_color
-        bg_attach: bg_attachment
+        bg_attachment: bg_attachment
         position: position
         full_width: full_width
         style: content_style

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_content_marquee.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_content_marquee.yml
@@ -41,7 +41,6 @@ process:
   field_az_text_area/format:
     plugin: default_value
     default_value: az_standard
-
   bg_attach_value_processed:
     - plugin: extract
       source: field_uaqs_setting_bg_attach
@@ -55,7 +54,6 @@ process:
         bg-attachment-fixed: 'bg-fixed'
         bg-fixed: 'bg-fixed'
         bg-attachment-scroll: ''
-
   bg_color_processed:
     - plugin: extract
       source: field_uaqs_setting_text_bg_color
@@ -73,7 +71,6 @@ process:
         bg-trans-black: dark
         dark: dark
         light: light
-
   view_mode_processed:
     - plugin: static_map
       source: view_mode
@@ -83,7 +80,6 @@ process:
         uaqs_bg_img_content_center: 'col-xs-12'
         uaqs_bg_img_content_right: 'col-md-8 col-lg-6 col-md-offset-4'
         uaqs_bg_img_content_bottom: ''
-
   content_style_processed:
     - plugin: static_map
       source: view_mode
@@ -93,25 +89,27 @@ process:
         uaqs_bg_img_content_right: 'box'
         uaqs_bg_img_content_left: 'box'
         uaqs_bg_img_content_center: 'box'
-
   bottom_spacing_processed:
     - plugin: default_value
       default_value: 'mb-0'
       source: bottom_spacing
-
   processed_full_width:
     plugin: default_value
     default_value: 'full-width-background'
+  text_media_spacing_processed:
+    - plugin: default_value
+      default_value: 'y-5'
 
   behavior_settings:
     plugin: az_paragraphs_behavior_settings
     paragraph_behavior_plugins:
       az_text_media_paragraph_behavior:
         bg_color: '@bg_color_processed'
-        bg_attach: '@bg_attach_value_processed'
+        bg_attachment: '@bg_attach_value_processed'
         position: '@view_mode_processed'
         full_width: '@processed_full_width'
         style: '@content_style_processed'
+        text_media_spacing: '@text_media_spacing_processed'
         az_display_settings:
             bottom_spacing: '@bottom_spacing_processed'
 

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_full_width_media_row.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_full_width_media_row.yml
@@ -86,6 +86,9 @@ process:
   content_style_processed:
     - plugin: default_value
       default_value: 'column'
+  text_media_spacing_processed:
+    - plugin: default_value
+      default_value: 'y-5'
   bottom_spacing_processed:
     - plugin: default_value
       default_value: 'mb-0'
@@ -96,10 +99,11 @@ process:
     paragraph_behavior_plugins:
       az_text_media_paragraph_behavior:
         bg_color: '@bg_color_processed'
-        bg_attach: '@bg_attach_processed'
+        bg_attachment: '@bg_attach_processed'
         position: '@view_mode_processed'
         full_width: '@full_width_processed'
         style: '@content_style_processed'
+        text_media_spacing: '@text_media_spacing_processed'
         az_display_settings:
             bottom_spacing: '@bottom_spacing_processed'
 


### PR DESCRIPTION
## Description
Add back appropriate fields for background styles in text_on_media paragraphs during migration.

## Related Issue
Fixes #1397
Fixes #1132

## How Has This Been Tested?
Locally

## Types of changes
**Arizona Quickstart** (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

**Drupal core**
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

**Drupal contrib projects**
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
