### PR TITLE
Fixes #1415: Add required default_theme property to all tests.

### DIFF
--- a/modules/custom/az_core/tests/src/Functional/ConfigOverrideTest.php
+++ b/modules/custom/az_core/tests/src/Functional/ConfigOverrideTest.php
@@ -26,6 +26,11 @@ class ConfigOverrideTest extends BrowserTestBase {
   protected $strictConfigSchema = FALSE;
 
   /**
+   * @var string
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
    * Modules to enable.
    *
    * @var array

--- a/modules/custom/az_demo/tests/src/Functional/AZDemoContentTest.php
+++ b/modules/custom/az_demo/tests/src/Functional/AZDemoContentTest.php
@@ -25,6 +25,11 @@ class AZDemoContentTest extends BrowserTestBase {
   protected $strictConfigSchema = FALSE;
 
   /**
+   * @var string
+   */
+  protected $defaultTheme = 'az_barrio';
+
+  /**
    * Modules to enable.
    *
    * @var array

--- a/modules/custom/az_paragraphs/tests/src/Functional/AZParagraphsTest.php
+++ b/modules/custom/az_paragraphs/tests/src/Functional/AZParagraphsTest.php
@@ -26,6 +26,11 @@ class AZParagraphsTest extends BrowserTestBase {
   protected $strictConfigSchema = FALSE;
 
   /**
+   * @var string
+   */
+  protected $defaultTheme = 'az_barrio';
+
+  /**
    * Modules to enable.
    *
    * @var array

--- a/modules/custom/az_paragraphs/tests/src/FunctionalJavascript/AZParagraphsJavascriptTest.php
+++ b/modules/custom/az_paragraphs/tests/src/FunctionalJavascript/AZParagraphsJavascriptTest.php
@@ -26,6 +26,11 @@ class AZParagraphsJavascriptTest extends WebDriverTestBase {
   protected $strictConfigSchema = FALSE;
 
   /**
+   * @var string
+   */
+  protected $defaultTheme = 'az_barrio';
+
+  /**
    * Modules to enable.
    *
    * @var array


### PR DESCRIPTION
## Description
Upgrading PHPstan caused more issues to be found in our existing tests related to this Drupal change record:
https://www.drupal.org/node/3083055

## Related Issue
Fixes #1415 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
**Arizona Quickstart** (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

**Drupal core**
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

**Drupal contrib projects**
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
