### PR TITLE
Closes #396 Updated CKEditor icons for embed buttons

### DIFF
--- a/modules/custom/az_paragraphs/config/optional/embed.button.az_embed_content.yml
+++ b/modules/custom/az_paragraphs/config/optional/embed.button.az_embed_content.yml
@@ -22,5 +22,7 @@ type_settings:
     - 'view_mode:node.teaser'
   entity_browser: ''
   entity_browser_settings: {  }
-icon: {  }
+icon:
+  data: iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAz0lEQVRYhe2W4Q2CMBBGn8YxGETDGriHi5iwB65B0kHYA/8UbbAHPW0FtC+5cJBre/S+Ngf/zi7h3AVwtL4BuoRreamA3lolBe2/ls5aEzh4vonbJXCzT7fmAKXgw4wmeqW5iYeOefzkKkswYICrYi4DnJ33ErhYvwbaUazIsE2NYnEfv3UMG/SiDGJKA5/iakKseWgC7XzICx3PO0JFLBEGkVID2zgFKTUQNYHaWnQWvweyBjajgWRM7UCBvj1zOb07UNuSqVqwMYuXIJO5AwPmbJF9Gh3mAAAAAElFTkSuQmCC
+  uri: 'public://embed_buttons/sharp_post_add_black_24dp.png'
 icon_uuid: null

--- a/modules/custom/az_paragraphs/config/optional/embed.button.az_embed_content.yml
+++ b/modules/custom/az_paragraphs/config/optional/embed.button.az_embed_content.yml
@@ -23,11 +23,6 @@ type_settings:
   entity_browser: ''
   entity_browser_settings: {  }
 icon:
-<<<<<<< HEAD
   data: iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAz0lEQVRYhe2W4Q2CMBBGn8YxGETDGriHi5iwB65B0kHYA/8UbbAHPW0FtC+5cJBre/S+Ngf/zi7h3AVwtL4BuoRreamA3lolBe2/ls5aEzh4vonbJXCzT7fmAKXgw4wmeqW5iYeOefzkKkswYICrYi4DnJ33ErhYvwbaUazIsE2NYnEfv3UMG/SiDGJKA5/iakKseWgC7XzICx3PO0JFLBEGkVID2zgFKTUQNYHaWnQWvweyBjajgWRM7UCBvj1zOb07UNuSqVqwMYuXIJO5AwPmbJF9Gh3mAAAAAElFTkSuQmCC
   uri: 'public://embed_buttons/sharp_post_add_black_24dp.png'
-=======
-  data: iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAQAAABKfvVzAAAAJElEQVQ4y2NgGLTgPxFwqGjA5z/qaBj1A+l+oIWGoZxaBxEAAKCVDQIr7yBuAAAAAElFTkSuQmCC
-  uri: 'public://embed_buttons/sharp_article_black_24dp.png'
->>>>>>> 259adada76f81e223a285d23efde7b6ebf0b5414
 icon_uuid: null

--- a/modules/custom/az_paragraphs/config/optional/embed.button.az_embed_content_block.yml
+++ b/modules/custom/az_paragraphs/config/optional/embed.button.az_embed_content_block.yml
@@ -17,11 +17,6 @@ type_settings:
   entity_browser: ''
   entity_browser_settings: {  }
 icon:
-<<<<<<< HEAD
   data: iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAiUlEQVRYhe2WYQqAIAxGP6NDBZ3De3SU7mHX8Fz1o4Jls3Qg/vkeDMZk8ESXAYS82QsjiJ5Q0fdgaLSJYihAAQpQYFRqW2FvzOSkCqfUglLTiADWzNoCYL5yXytleQ1T5Ov4Sfcp6C6gjaEFeeYAMIk8ParfO8E/Igse50jfIb+mLokmAmYoQMgB49tAGQ6ExnQAAAAASUVORK5CYII=
   uri: 'public://embed_buttons/sharp_dashboard_customize_black_24dp.png'
-=======
-  data: iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAQAAABKfvVzAAAAMUlEQVQ4T2NgGMHgPxwGM6xG4iHDUQ3IGkIZ6rFCIjSEMmgRowHhpNVAHkJmVMOIAgAdfdraiZTr/wAAAABJRU5ErkJggg==
-  uri: 'public://embed_buttons/sharp_view_quilt_black_24dp.png'
->>>>>>> 259adada76f81e223a285d23efde7b6ebf0b5414
 icon_uuid: null

--- a/modules/custom/az_paragraphs/config/optional/embed.button.az_embed_content_block.yml
+++ b/modules/custom/az_paragraphs/config/optional/embed.button.az_embed_content_block.yml
@@ -1,6 +1,8 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - core.entity_view_mode.block_content.full
   module:
     - block_content
     - entity_embed
@@ -14,5 +16,7 @@ type_settings:
     - 'view_mode:block_content.full'
   entity_browser: ''
   entity_browser_settings: {  }
-icon: {  }
+icon:
+  data: iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAiUlEQVRYhe2WYQqAIAxGP6NDBZ3De3SU7mHX8Fz1o4Jls3Qg/vkeDMZk8ESXAYS82QsjiJ5Q0fdgaLSJYihAAQpQYFRqW2FvzOSkCqfUglLTiADWzNoCYL5yXytleQ1T5Ov4Sfcp6C6gjaEFeeYAMIk8ParfO8E/Igse50jfIb+mLokmAmYoQMgB49tAGQ6ExnQAAAAASUVORK5CYII=
+  uri: 'public://embed_buttons/sharp_dashboard_customize_black_24dp.png'
 icon_uuid: null


### PR DESCRIPTION
Updated two embed button icons in the CKEditor (embed content and embed content block) using the icons designated in issue #396. 

Update involved two files:
- embed.button.az_embed_content.yml
- embed.button.az_embed_content_block.yml