### PR TITLE
Closes #1433 Fix alignment and label issues with Quickstart Select Menu

### DIFF
--- a/modules/custom/az_select_menu/css/az-select-menu.css
+++ b/modules/custom/az_select_menu/css/az-select-menu.css
@@ -44,7 +44,7 @@ select.select-primary {
   }
 
   .input-group .select-menu-label {
-    margin: 0.7em 0.7em 0;
+    margin: 0.4375em 0.7em 0;
   }
   
   select.select-primary:active,

--- a/modules/custom/az_select_menu/css/az-select-menu.css
+++ b/modules/custom/az_select_menu/css/az-select-menu.css
@@ -9,7 +9,7 @@ select.select-primary {
     background-repeat: no-repeat;
     background-position: 95% 50%;
     background-position: calc(100% - 10px)  50%;
-    border-top: 1px solid transparent;
+    border-top: 0;
     border-right: 0;
     border-bottom: 3px solid #cbd1e0;
     border-left: 0;
@@ -26,7 +26,7 @@ select.select-primary {
     -webkit-transition: .15s all ease-in-out;
     transition: .15s all ease-in-out;
     text-overflow: '';
-    height: calc(1.6em + 0.75rem + 2px);
+    height: unset;
   }
   
   /*This only works in Internet Explorer 10 and beyond. */

--- a/modules/custom/az_select_menu/css/az-select-menu.css
+++ b/modules/custom/az_select_menu/css/az-select-menu.css
@@ -36,8 +36,7 @@ select.select-primary {
 
   select.select-primary:focus,
   select.select-primary:hover {
-    border-top: 1px solid transparent;
-    border-bottom: 3px solid var(--red);
+    border-bottom-color: var(--red);
   }
 
   label.select-menu-label {

--- a/modules/custom/az_select_menu/templates/az-select-menu.html.twig
+++ b/modules/custom/az_select_menu/templates/az-select-menu.html.twig
@@ -49,15 +49,17 @@
 
     <form {{form_attributes}}>
         <div class="input-group">
-          <span class="input-group-addon input-group-addon-no-border">
-            <div class="select-menu-label">{{menu_block_configuration.az_select_menu.preform_text}}</div>
-          </span>
-          <label class="sr-only select-menu-label-sr">{{menu_block_configuration.az_select_menu.button_text_sr_only}}</label>
+          {% if menu_block_configuration.az_select_menu.preform_text %}
+            <span class="input-group-addon input-group-addon-no-border">
+              <div class="select-menu-label">{{menu_block_configuration.az_select_menu.preform_text}}</div>
+            </span>
+          {% endif %}
+          <label class="sr-only select-menu-label-sr">{{menu_block_configuration.az_select_menu.preform_text_sr_only}}</label>
           {% import _self as menus %}
           {% if items %}
             <select {{ select_attributes }}>
-            {% if menu_block_configuration.az_select_menu.empty_option and  menu_block_configuration.az_select_menu.empty_option_label %}
-             <option data-href="">{{menu_block_configuration.az_select_menu.empty_option_label}}</option>
+            {% if menu_block_configuration.az_select_menu.empty_option and menu_block_configuration.az_select_menu.empty_option_label %}
+              <option data-href="">{{menu_block_configuration.az_select_menu.empty_option_label}}</option>
             {% endif %}
             {% for item in items %}
               <option data-href="{{item.url}}">{{item.title}}</option>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Closes #1433 with the following changes:

- In az-select-menu.css, update styling of the select element to match the height of the Go button
- In az-select-menu.css, update top margin of div.select-menu-label to vertically align the label text with the other text in the menu
- In az-select-menu.html.twig, add if statement to display the pre-form text element only if the text is not empty
- In az-select-menu.html.twig, correct the screen reader label for the pre-form text to reference preform_text_sr_only instead of button_text_sr_only

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1433 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in Probo: please see the [Select Menu Test](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-1434.probo.build/select-menu-test) page.

Before:
![image](https://user-images.githubusercontent.com/74572157/160711286-44b1da1f-5111-4220-8f6f-638f3d0bd928.png)

After:
![image](https://user-images.githubusercontent.com/74572157/160711341-b6e8f36b-49ab-444e-b986-21c529fccc22.png)

After (showing "I am a" label alignment):
![image](https://user-images.githubusercontent.com/74572157/160711402-a04d2c2f-d67f-471b-b3bf-20fd18f5e3fe.png)

To test the changes:

1. Enable the Quickstart Select Menu.
2. Create a menu with at least one option. (If you like, create a test page for the menu as well.)
3. In Block Layout, place the menu as a block with the "Quickstart select menu block" category.
4. In the configuration for the block under "Quickstart menu options", confirm that text is present in the "Form help for screen-readers" field. You can leave the "I am a" text or delete it depending on what you are testing.
5. Save the blocks and then go to a page where the menu is placed to check that the issues from #1433 have been fixed.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
**Arizona Quickstart** (install profile, custom modules, custom theme)
- Patch release changes
   - [X] Bug fix
   - [X] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

**Drupal core**
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

**Drupal contrib projects**
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
