### PR TITLE
Fixes #1438: Add patch for AP Style Date module time display issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -146,7 +146,7 @@
                 "Storage comparer issue": "https://gist.githubusercontent.com/tadean/4ad67c67a56d9fcec83db8f403ac58d7/raw/9a6762de5b014dffecf06c9a5b311f75c534fce4/config_distro_comparer.patch"
             },
             "drupal/date_ap_style": {
-                "All Day Setting hides time display (3272760)": "https://www.drupal.org/files/issues/2022-03-31/date_ap_style-3272760-1.patch"
+                "All Day Setting hides time display (3272760)": "https://www.drupal.org/files/issues/2022-03-31/3272760-7.patch"
             },
             "drupal/image_widget_crop": {
                 "Reset crop triggered when ENTER is pressed in the form": "https://www.drupal.org/files/issues/2020-03-04/image_widget_crop-3117828-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -146,7 +146,7 @@
                 "Storage comparer issue": "https://gist.githubusercontent.com/tadean/4ad67c67a56d9fcec83db8f403ac58d7/raw/9a6762de5b014dffecf06c9a5b311f75c534fce4/config_distro_comparer.patch"
             },
             "drupal/date_ap_style": {
-                "All Day Setting hides time display (3272760)": "https://gist.githubusercontent.com/trackleft/50f66a4c55f30d3bffee8d7cea3313bf/raw/d1f0ef18a623b8721425ada3787ec3836c1d5e75/date_ap_style-687758bfaca93200e1e333c5af7c95752db23d08.patch"
+                "All Day Setting hides time display (3272760)": "https://www.drupal.org/files/issues/2022-03-31/date_ap_style-3272760-1.patch"
             },
             "drupal/image_widget_crop": {
                 "Reset crop triggered when ENTER is pressed in the form": "https://www.drupal.org/files/issues/2020-03-04/image_widget_crop-3117828-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -146,7 +146,7 @@
                 "Storage comparer issue": "https://gist.githubusercontent.com/tadean/4ad67c67a56d9fcec83db8f403ac58d7/raw/9a6762de5b014dffecf06c9a5b311f75c534fce4/config_distro_comparer.patch"
             },
             "drupal/date_ap_style": {
-                "All Day Setting hides time display (3272760)": "https://gist.githubusercontent.com/trackleft/016272df02516cfdad7bd6e645634e8d/raw/0b847cec6972f082548ed9f36aeb685a793dc072/date_ap_style-3c9695fb21433121cdeb2272d041b47b26132964.patch"
+                "All Day Setting hides time display (3272760)": "https://gist.githubusercontent.com/trackleft/50f66a4c55f30d3bffee8d7cea3313bf/raw/d1f0ef18a623b8721425ada3787ec3836c1d5e75/date_ap_style-687758bfaca93200e1e333c5af7c95752db23d08.patch"
             },
             "drupal/image_widget_crop": {
                 "Reset crop triggered when ENTER is pressed in the form": "https://www.drupal.org/files/issues/2020-03-04/image_widget_crop-3117828-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -145,6 +145,9 @@
                 "missing parent class": "https://git.drupalcode.org/issue/config_distro-3199197/-/commit/c312096d486caa2f01703ca7de1abf2285b6fac8.diff",
                 "Storage comparer issue": "https://gist.githubusercontent.com/tadean/4ad67c67a56d9fcec83db8f403ac58d7/raw/9a6762de5b014dffecf06c9a5b311f75c534fce4/config_distro_comparer.patch"
             },
+            "drupal/date_ap_style": {
+                "All Day Setting hides time display (3272760)": "https://gist.githubusercontent.com/trackleft/d30c91c76b1ece73a86837f0b17b1553/raw/d7f3a4aa62ee7870773f7f3540c56e3037fca9d4/date_ap_style-9a7617aad566f7e145ea3a51c599315f31b42183.patch"
+            },
             "drupal/image_widget_crop": {
                 "Reset crop triggered when ENTER is pressed in the form": "https://www.drupal.org/files/issues/2020-03-04/image_widget_crop-3117828-2.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -146,7 +146,7 @@
                 "Storage comparer issue": "https://gist.githubusercontent.com/tadean/4ad67c67a56d9fcec83db8f403ac58d7/raw/9a6762de5b014dffecf06c9a5b311f75c534fce4/config_distro_comparer.patch"
             },
             "drupal/date_ap_style": {
-                "All Day Setting hides time display (3272760)": "https://gist.githubusercontent.com/trackleft/d30c91c76b1ece73a86837f0b17b1553/raw/d7f3a4aa62ee7870773f7f3540c56e3037fca9d4/date_ap_style-9a7617aad566f7e145ea3a51c599315f31b42183.patch"
+                "All Day Setting hides time display (3272760)": "https://gist.githubusercontent.com/trackleft/016272df02516cfdad7bd6e645634e8d/raw/0b847cec6972f082548ed9f36aeb685a793dc072/date_ap_style-3c9695fb21433121cdeb2272d041b47b26132964.patch"
             },
             "drupal/image_widget_crop": {
                 "Reset crop triggered when ENTER is pressed in the form": "https://www.drupal.org/files/issues/2020-03-04/image_widget_crop-3117828-2.patch"


### PR DESCRIPTION
## Description
Patching Date Ap Style to fix all day setting in relation to time display.

## Related Issue
Fixes #1438 

## How to test this.
Log into probo site
Go to the calendar page `/calendar`
See time appears.
Go to `/events/pi-day`
edit the pi-day site to be an all-day event.
See All Day appears

## Types of changes
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

**Drupal core**
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

**Drupal contrib projects**
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
