### PR TITLE
Closes #1302: Fix AZ News Feed if <30 stories match configured tag(s).

### DIFF
--- a/modules/custom/az_news/az_news_feeds/src/EventSubscriber/AzNewsFeedsMigrateSubscriber.php
+++ b/modules/custom/az_news/az_news_feeds/src/EventSubscriber/AzNewsFeedsMigrateSubscriber.php
@@ -58,31 +58,16 @@ class AzNewsFeedsMigrateSubscriber implements EventSubscriberInterface {
 
     /** @var \Drupal\migrate\Plugin\MigrationInterface $migration */
     $migration = $event->getMigration();
-    if (
-      $migration->id() === 'az_news_feed_stories' ||
-      $migration->id() === 'az_news_feed_stories_files' ||
-      $migration->id() === 'az_news_feed_stories_media'
-    ) {
-      // Change the news.arizona.edu feed url.
+    if ($migration->id() === 'az_news_feed_stories') {
       $az_news_feeds_config = $this->configFactory->getEditable('az_news_feeds.settings');
-      $base_uri = $az_news_feeds_config->get('uarizona_news_base_uri');
-      $content_path = $az_news_feeds_config->get('uarizona_news_content_path');
       $selected_terms = $az_news_feeds_config->get('uarizona_news_terms');
-      $views_contextual_argument = implode('+', array_keys($selected_terms));
-      $urls = $base_uri . $content_path . $views_contextual_argument;
-      $sourceConfig = $migration->getSourceConfiguration();
-      $sourceConfig['urls'] = $urls;
-      $migration->set('source', $sourceConfig);
-
-      if ($migration->id() === 'az_news_feed_stories') {
-        $processConfig = $migration->getProcess();
-        $array_intersect_process = [
-          'plugin' => 'array_intersect',
-          'match'  => array_values($selected_terms),
-        ];
-        $processConfig['field_az_news_tags_processed'][] = $array_intersect_process;
-        $migration->set('process', $processConfig);
-      }
+      $processConfig = $migration->getProcess();
+      $array_intersect_process = [
+        'plugin' => 'array_intersect',
+        'match'  => array_values($selected_terms),
+      ];
+      $processConfig['field_az_news_tags_processed'][] = $array_intersect_process;
+      $migration->set('process', $processConfig);
     }
   }
 

--- a/modules/custom/az_news/az_news_feeds/src/Form/AzNewsFeedsAdminForm.php
+++ b/modules/custom/az_news/az_news_feeds/src/Form/AzNewsFeedsAdminForm.php
@@ -92,7 +92,6 @@ class AzNewsFeedsAdminForm extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $az_news_feeds_config = $this->config('az_news_feeds.settings');
-    $config = $this->config('migrate_plus.migration_group.az_news_feeds');
     $selected_categories = $az_news_feeds_config->get('uarizona_news_terms');
     $selected_categories = array_keys($selected_categories);
     $term_options = $this->getRemoteTermOptions();
@@ -143,6 +142,17 @@ class AzNewsFeedsAdminForm extends ConfigFormBase {
     }
     $az_news_feeds_config
       ->set('uarizona_news_terms', $selected_terms)
+      ->save();
+
+    // Update the news.arizona.edu feed url in the migration group config.
+    $group_config = $this->configFactory->getEditable('migrate_plus.migration_group.az_news_feeds');
+    $base_uri = $az_news_feeds_config->get('uarizona_news_base_uri');
+    $content_path = $az_news_feeds_config->get('uarizona_news_content_path');
+    $selected_terms = $az_news_feeds_config->get('uarizona_news_terms');
+    $views_contextual_argument = implode('+', array_keys($selected_terms));
+    $urls = $base_uri . $content_path . $views_contextual_argument;
+    $group_config
+      ->set('shared_configuration.source.urls', $urls)
       ->save();
 
     drupal_flush_all_caches();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Moves AZ News Feed URL modification out of Pre:Import event subscriber and into settings form submit handler since modifying the URL during the migrate Pre:Import hook doesn't allow the migration to correctly detect how many source rows are available.

## Related Issue
Closes #1302 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with lando.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
**Arizona Quickstart** (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

**Drupal core**
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

**Drupal contrib projects**
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
