### PR TITLE
Add ability to place header 1 and header 2 regions in the off-canvas region with a theme setting

### DIFF
--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -146,7 +146,12 @@ function az_barrio_preprocess_page(&$variables, $hook) {
   $variables['header_one_col_classes'] = theme_get_setting('header_one_col_classes');
   $variables['header_two_col_classes'] = theme_get_setting('header_two_col_classes');
 
-  $variables['az_barrio_header_offcanvas'] = (theme_get_setting('az_barrio_header_offcanvas')) ? TRUE : FALSE;
+  if ($variables['az_barrio_navbar_offcanvas'] === TRUE) {
+    $variables['az_barrio_header_offcanvas'] = (theme_get_setting('az_barrio_header_offcanvas')) ? TRUE : FALSE;
+  }
+  else {
+    $variables['az_barrio_header_offcanvas'] = FALSE;
+  }
 }
 
 /**

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -146,6 +146,7 @@ function az_barrio_preprocess_page(&$variables, $hook) {
   $variables['header_one_col_classes'] = theme_get_setting('header_one_col_classes');
   $variables['header_two_col_classes'] = theme_get_setting('header_two_col_classes');
 
+  $variables['az_barrio_header_offcanvas'] = (theme_get_setting('az_barrio_header_offcanvas')) ? TRUE : FALSE;
 }
 
 /**

--- a/themes/custom/az_barrio/config/install/az_barrio.settings.yml
+++ b/themes/custom/az_barrio/config/install/az_barrio.settings.yml
@@ -109,6 +109,7 @@ copyright_notice: 'The Arizona Board of Regents on behalf of <a href="https://ww
 az_hide_front_title: false
 az_back_to_top: true
 az_barrio_navbar_offcanvas: true
+az_barrio_header_offcanvas: false
 az_barrio_font: true
 az_bootstrap_source: 'cdn'
 az_bootstrap_cdn_version: 'stable'

--- a/themes/custom/az_barrio/css/az-barrio-off-canvas-nav.css
+++ b/themes/custom/az_barrio/css/az-barrio-off-canvas-nav.css
@@ -6,3 +6,7 @@ header#header_arizona {
 .navbar-offcanvas.no-navigation-region {
   border: 0;
 }
+
+#headerOffcanvas {
+  border-top: 1px solid #fff;
+}

--- a/themes/custom/az_barrio/js/az-barrio-off-canvas-nav.js
+++ b/themes/custom/az_barrio/js/az-barrio-off-canvas-nav.js
@@ -6,6 +6,10 @@
           $('#block-az-barrio-offcanvas-searchform input').trigger('focus');
 	      }
       });
+
+      $('#headerOffcanvas>section').removeClass('col-md');
+      $('#headerOffcanvas ul').removeClass().addClass('clearfix navbar-nav');
+      $('#headerOffcanvas .nav-item>a').removeClass('text-muted');
     }
   };
 })(jQuery, Drupal);

--- a/themes/custom/az_barrio/templates/layout/page.html.twig
+++ b/themes/custom/az_barrio/templates/layout/page.html.twig
@@ -18,6 +18,8 @@
  *   administration pages.
  * - az_barrio_navbar_offcanvas: A flag indicating if the offcanvas nav is
  *   enabled.
+ * - az_barrio_header_offcanvas: A flag indicating if the offcanvas header is
+ *   enabled.
  *
  * Site identity:
  * - front_page: The URL of the front page. Use this instead of base_path when
@@ -125,7 +127,11 @@
               <div class="{{ header_one_col_classes }}">
                 {{ page.branding }}
               </div>
+              {% if az_barrio_header_offcanvas %}
+              <div class="d-none d-lg-block {{ header_two_col_classes }}">
+              {% else %}
               <div class="{{ header_two_col_classes }}">
+              {% endif %}
                 <div class="row">
                   {{ page.header }}
                 </div>
@@ -163,6 +169,14 @@
                     {{ page.navigation }}
                   {% endif %}
               {% if az_barrio_navbar_offcanvas %}
+                {% if az_barrio_header_offcanvas %}
+                <div class="d-lg-none">
+                  {{ page.header }}
+                  {% if page.header_2 %}
+                  {{ page.header_2 }}
+                  {% endif %}
+                </div>
+                {% endif %}
                 </nav>
               </div>
               {% endif %}

--- a/themes/custom/az_barrio/templates/layout/page.html.twig
+++ b/themes/custom/az_barrio/templates/layout/page.html.twig
@@ -170,7 +170,7 @@
                   {% endif %}
               {% if az_barrio_navbar_offcanvas %}
                 {% if az_barrio_header_offcanvas %}
-                <div class="d-lg-none">
+                <div class="d-lg-none" id="headerOffcanvas">
                   {{ page.header }}
                   {% if page.header_2 %}
                   {{ page.header_2 }}

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -287,7 +287,7 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
   $form['components']['navbar_offcanvas']['az_barrio_header_offcanvas'] = [
     '#type' => 'checkbox',
     '#title' => t('Fold header blocks into Off Canvas'),
-    '#description' => t('Check to move the header blocks into Off Canvas region.'),
+    '#description' => t('Check to move the header blocks into Off Canvas region. No effect if Use Navbar Off Canvas is unchecked.'),
     '#default_value' => theme_get_setting('az_barrio_header_offcanvas'),
   ];
   // Logos.

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -284,6 +284,12 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     '#description' => t('Check to use the Arizona Bootstrap Off Canvas Navbar instead of the bootstrap navbar.'),
     '#default_value' => theme_get_setting('az_barrio_navbar_offcanvas'),
   ];
+  $form['components']['navbar_offcanvas']['az_barrio_header_offcanvas'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Fold header blocks into Off Canvas'),
+    '#description' => t('Check to move the header blocks into Off Canvas region.'),
+    '#default_value' => theme_get_setting('az_barrio_header_offcanvas'),
+  ];
   // Logos.
   $form['logo']['az_barrio_logo_svg_inline'] = [
     '#type' => 'checkbox',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

This adds a theme setting to display the header 1 and header 2 regions in the off-canvas region. 

Currently, this only works for `ul` elements in those regions, like the Utility links menu block. Other header 1 and 2 region contents are not supported.

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#1358

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

First, enable the theme settings at Components > Navbar with Off Canvas Drawer for mobile devices > Fold header blocks into Off Canvas.

To test header 1, add links to the Utility links menu. Then view the site at medium breakpoint or lower and trigger the off-canvas menu.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [x] New feature
   - [x] Breaking or visual change to existing behavior (not breaking since it's optional, but it does have a visual component)
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. (Maybe?)
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
