### PR TITLE
Closes #821 Adding process plugin for datetime to smart_date to fix duration field.

### DIFF
--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_node_event.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_node_event.yml
@@ -136,29 +136,11 @@ process:
           index:
             - 1
   field_az_event_date:
-    plugin: sub_process
-    source: field_uaqs_date
-    process:
-      delta: delta
-      value:
-        -
-          plugin: concat
-          source:
-            - value
-            - ' UTC'
-        -
-          plugin: callback
-          callable: strtotime
-      end_value:
-        -
-          plugin: concat
-          source:
-            - value2
-            - ' UTC'
-        -
-          plugin: callback
-          callable: strtotime
-      rrule: rrule
+    - plugin: single_value
+      source: field_uaqs_date
+    - plugin: az_datetime_to_smart_date
+      source_start: value
+      source_end: value2
 
   uid:
     -

--- a/modules/custom/az_migration/src/Plugin/migrate/process/DateTimeToSmartDate.php
+++ b/modules/custom/az_migration/src/Plugin/migrate/process/DateTimeToSmartDate.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Drupal\az_migration\Plugin\migrate\process;
+
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * Process Plugin to handle migrating Drupal datetime field to smart_date field.
+ *
+ * Expects a multidimentional array typical of a Drupal datetime field.
+ *
+ * Available configuration keys
+ * - source_start: (required) Field to copy start time from.
+ * - source_end: (optional) Field to copy end time from, if not set the
+ *   source_start field value will be used.
+ * - default_duration: (int, optional) If no end date, assumed duration.
+ *
+ * Consider a datetime field migration
+ * @code
+ *   process:
+ *     field_az_event_date:
+ *       - plugin: single_value
+ *         source: field_uaqs_event_date
+ *       - plugin: az_drupal_date_to_smart_date
+ *         source_start: value
+ *         source_end: value2
+ *         timezone: 'America/Phoenix'
+ * @endcode
+ *
+ * @MigrateProcessPlugin(
+ *   id = "az_datetime_to_smart_date"
+ * )
+ */
+class DateTimeToSmartDate extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    if (empty($this->configuration['source_start'])) {
+      throw new InvalidPluginDefinitionException(
+        $this->getPluginId(),
+        "Configuration option 'source_start' is required."
+      );
+    }
+    if (isset($this->configuration['default_duration']) && !is_numeric($this->configuration['default_duration'])) {
+      throw new InvalidPluginDefinitionException(
+        $this->getPluginId(),
+        "Configuration option 'default_duration' should be a numeric represention of a length of time in seconds,
+        for example 60 is one minute."
+      );
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+    );
+
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+
+    if (isset($this->configuration['default_duration'])) {
+      $def_duration = (int) $this->configuration['default_duration'];
+    }
+    else {
+      $def_duration = 0;
+    }
+    $utc = new \DateTimeZone('UTC');
+    if (is_array($value) || $value instanceof \Traversable) {
+      foreach ($value as $delta => $date) {
+        $source_start = $date[$this->configuration['source_start']];
+        $start_date = $source_start;
+        if (isset($this->configuration['source_end']) && isset($date[$this->configuration['source_end']])) {
+          $source_end = $date[$this->configuration['source_end']];
+        }
+        else {
+          $source_end = $source_start;
+        }
+        $start_date = new \DateTime($start_date, $utc);
+        $start_date = $start_date->format('U');
+
+        // Remove any seconds from the incoming value.
+        $start_date -= $start_date % 60;
+
+        $end_date = NULL;
+        // Assume a datetime range, so look for the end_value.
+        if (!empty($source_end)) {
+          $end_date = $source_end;
+        }
+        if (!empty($end_date)) {
+          $end_date = new \DateTime($end_date, $utc);
+          $end_date = $end_date->format('U');
+
+          // Remove any seconds from the incoming value.
+          $end_date -= $end_date % 60;
+
+          // If valid end date, set duration. Otherwise make a new end date.
+          if ($start_date < $end_date) {
+            $duration = (int) round(($end_date - $start_date) / 60);
+          }
+          else {
+            $end_date = $start_date;
+            $duration = (int) round(($end_date - $start_date) / 60);
+          }
+
+          if (!$end_date) {
+            // If the end date is bogus, use default duration.
+            $end_date = $start_date + ($def_duration * 60);
+            $duration = $def_duration;
+          }
+
+        }
+        $value[$delta] = [
+          'value' => $start_date,
+          'end_value' => $end_date,
+          'duration' => $duration,
+          'rrule' => NULL,
+          'rrule_index' => NULL,
+          'timezone' => '',
+        ];
+      }
+    }
+    return $value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function multiple() {
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
## Description
Adding a new migrate process plugin to fix duration field migration.

## Related issues
Closes #821 

## How to test

Wire up a migration site with many different event date value configurations.
I used techlaunch.arizona.edu

Consider the following event time configurations:

**No end time**
Source:
<img width="646" alt="Screen Shot 2022-04-11 at 2 51 53 PM" src="https://user-images.githubusercontent.com/1023167/162840225-258ea8e0-c9d2-404a-b098-7950e392c502.png">
Destination:
<img width="1037" alt="Screen Shot 2022-04-11 at 2 52 52 PM" src="https://user-images.githubusercontent.com/1023167/162840253-751f9b64-a976-4f77-b140-f005f8b1d518.png">

**Start and end date on the same day, end time is after start time.**
Source:
<img width="561" alt="image" src="https://user-images.githubusercontent.com/1023167/162841026-344243bb-f915-4939-a782-d71668c9ee5f.png">
Destination:
<img width="680" alt="image" src="https://user-images.githubusercontent.com/1023167/162840989-9c950a2c-d0f2-455c-9256-529224727478.png">

**All Day event.**
Source:
<img width="502" alt="image" src="https://user-images.githubusercontent.com/1023167/162841382-1ab75da5-06ed-4706-a84f-42b41a024fca.png">

Destination:
<img width="625" alt="image" src="https://user-images.githubusercontent.com/1023167/162841506-1b2e90fb-b899-4c63-b7fc-c573fce40473.png">

**Repeating event**
Source:
<img width="612" alt="image" src="https://user-images.githubusercontent.com/1023167/162841912-423b7a2c-9e80-41de-a33d-6479828bd0e0.png">
Destination:
<img width="509" alt="image" src="https://user-images.githubusercontent.com/1023167/162842051-77f0f4ad-3370-46f3-91a4-37bc1b7366a8.png">

**Repeating event that stops repeating on a specific date**
Source:
<img width="603" alt="image" src="https://user-images.githubusercontent.com/1023167/162842417-73d7206e-aa1a-4f60-9ae6-4c8f0e557d62.png">
Destination:
<img width="583" alt="image" src="https://user-images.githubusercontent.com/1023167/162842509-d0a4240d-3319-417a-9eb3-943776feeb60.png">

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
