### PR TITLE
Closes 1403: Added style for Natural Image behavior

### DIFF
--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml
@@ -6,7 +6,7 @@ dependencies:
     - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_az_credit
     - field.field.media.az_image.field_media_az_image
-    - image.style.natural
+    - image.style.az_natural
     - media.type.az_image
   module:
     - field_group

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.media.az_image.field_az_caption
     - field.field.media.az_image.field_az_credit
     - field.field.media.az_image.field_media_az_image
+    - image.style.natural
     - media.type.az_image
   module:
     - field_group
@@ -17,13 +18,11 @@ third_party_settings:
       children:
         - field_media_az_image
         - group_fig_caption
-      parent_name: ''
-      weight: 0
+      parent_name: group_image_wrap
+      weight: 1
       format_type: html_element
       region: content
       format_settings:
-        id: ''
-        classes: ''
         element: figure
         show_label: false
         label_element: h3
@@ -31,13 +30,16 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
+        id: ''
+        classes: center
+        show_empty_fields: false
       label: Figure
     group_fig_caption:
       children:
         - field_az_caption
         - group_cite
       parent_name: group_figure
-      weight: 2
+      weight: 3
       format_type: html_element
       region: content
       format_settings:
@@ -69,6 +71,25 @@ third_party_settings:
         id: ''
         classes: small
       label: Cite
+    group_image_wrap:
+      children:
+        - group_figure
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        id: ''
+        classes: align-natural-image
+        show_empty_fields: false
+      label: 'Figure Wrap'
 id: media.az_image.az_natural_size
 targetEntityType: media
 bundle: az_image
@@ -89,13 +110,13 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_media_az_image:
-    label: visually_hidden
+    label: hidden
     settings:
-      image_style: ''
+      image_style: natural
       image_link: ''
     third_party_settings: {  }
     type: image
-    weight: 1
+    weight: 2
     region: content
 hidden:
   created: true

--- a/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml
+++ b/modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml
@@ -18,7 +18,7 @@ third_party_settings:
       children:
         - field_media_az_image
         - group_fig_caption
-      parent_name: group_image_wrap
+      parent_name: group_natural_flex
       weight: 1
       format_type: html_element
       region: content
@@ -31,7 +31,7 @@ third_party_settings:
         effect: none
         speed: fast
         id: ''
-        classes: center
+        classes: ''
         show_empty_fields: false
       label: Figure
     group_fig_caption:
@@ -71,7 +71,7 @@ third_party_settings:
         id: ''
         classes: small
       label: Cite
-    group_image_wrap:
+    group_natural_flex:
       children:
         - group_figure
       parent_name: ''
@@ -79,6 +79,9 @@ third_party_settings:
       format_type: html_element
       region: content
       format_settings:
+        show_empty_fields: false
+        id: ''
+        classes: d-flex
         element: div
         show_label: false
         label_element: h3
@@ -86,10 +89,7 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-        id: ''
-        classes: align-natural-image
-        show_empty_fields: false
-      label: 'Figure Wrap'
+      label: 'Natural Flex'
 id: media.az_image.az_natural_size
 targetEntityType: media
 bundle: az_image
@@ -112,7 +112,7 @@ content:
   field_media_az_image:
     label: hidden
     settings:
-      image_style: natural
+      image_style: az_natural
       image_link: ''
     third_party_settings: {  }
     type: image

--- a/modules/custom/az_media/config/install/image.style.az_natural.yml
+++ b/modules/custom/az_media/config/install/image.style.az_natural.yml
@@ -1,0 +1,6 @@
+langcode: en
+status: true
+dependencies: {  }
+name: az_natural
+label: 'Natural Size'
+effects: {  }

--- a/themes/custom/az_barrio/css/style.css
+++ b/themes/custom/az_barrio/css/style.css
@@ -6,6 +6,11 @@
  * of these @include files will be combined into a single file.
  */
 
+/* Class for Natural Image block alignment issue */
+.align-natural-image {
+  display:flex;
+}
+
 /* For structuring header utilities*/
 header#header_arizona {
   min-height: 10px;

--- a/themes/custom/az_barrio/css/style.css
+++ b/themes/custom/az_barrio/css/style.css
@@ -6,7 +6,6 @@
  * of these @include files will be combined into a single file.
  */
 
-
 /* For structuring header utilities*/
 header#header_arizona {
   min-height: 10px;

--- a/themes/custom/az_barrio/css/style.css
+++ b/themes/custom/az_barrio/css/style.css
@@ -6,18 +6,10 @@
  * of these @include files will be combined into a single file.
  */
 
-/* Class for Natural Image block alignment issue */
-.align-natural-image {
-  display:flex;
-}
 
 /* For structuring header utilities*/
 header#header_arizona {
   min-height: 10px;
-}
-
-.align-natural-image {
-  display:flex;
 }
 
 /* Sticky footer */


### PR DESCRIPTION
This issue in #1403 was when you embed an image, set the size to Natural, and align center ... the block aligned left. So I added a wrapper class to override that display setting and make it `flex` instead of `block`. Changes should apply only to the Natural Image display. Did a new class because I didn't want to bother existing blocks using that behavior.

It required changes to two files:

1. Structure > Media Type > Image (Edit) > Manage display (Filename: modules/custom/az_media/config/install/core.entity_view_display.media.az_image.az_natural_size.yml) to add new container/wrapper setting the class to align-image-natural.
2. Added those class settings to style.css:

```
.align-natural-image {
  display:flex;
}
```