### PR TITLE
Fixes #1460 Allow for Delayed Configuration Overrides.

### DIFF
--- a/modules/custom/az_core/src/AZConfigOverride.php
+++ b/modules/custom/az_core/src/AZConfigOverride.php
@@ -87,11 +87,14 @@ class AZConfigOverride {
     $module_keys = array_flip($modules);
     $extensions = array_intersect_key($module_list, $module_keys);
 
+    // Previously enabled extensions.
+    $old_extensions = array_diff_key($module_list, $module_keys);
+
     // Ask the override provider for direct overrides available.
     foreach ($providers as $provider) {
       // Only query config for the Quickstart provider.
       if ($provider instanceof QuickstartConfigProvider) {
-        $overrides = $provider->getOverrideConfig($extensions);
+        $overrides = $provider->getOverrideConfig($extensions, $old_extensions);
 
         // Edit active configuration for each explicit override.
         foreach ($overrides as $name => $data) {

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -35,22 +35,64 @@ class QuickstartConfigProvider extends ConfigProviderBase {
    *
    * @param \Drupal\Core\Extension\Extension[] $extensions
    *   An associative array of Extension objects, keyed by extension name.
+   * @param \Drupal\Core\Extension\Extension[] $old_extensions
+   *   Already loaded Extension objects, keyed by extension name.
    *
    * @return array
    *   A list of the configuration data keyed by configuration object name.
    */
-  public function getOverrideConfig(array $extensions = []) {
+  public function getOverrideConfig(array $extensions = [], array $old_extensions = []) {
 
     // Find the direct overrides for use at module install time.
     $storage = $this->getExtensionInstallStorage(static::ID);
     $config_names = $this->listConfig($storage, $extensions);
     $data = $storage->readMultiple($config_names);
 
+    // Get active configuration to check dependencies with.
+    $existing_config = $this->getActiveStorages()->listAll();
+    $all_config = $this->getActiveStorages()->readMultiple($existing_config) + $data;
+    $enabled_extensions = $this->getEnabledExtensions();
+
+    // Get the install configuration present for the specified modules.
+    // We need to check if an already-enabled module contained passive override.
+    $install_storage = $this->getExtensionInstallStorage(InstallStorage::CONFIG_INSTALL_DIRECTORY);
+    $install_config_names = $this->listConfig($install_storage, $extensions);
+
+    // Now compare to quickstart config of already-loaded modules;
+    // We are checking to see if an already loaded module contained a change
+    // that couldn't be loaded previously for dependency reasons.
+    $override_storage = $this->getExtensionInstallStorage(static::ID);
+    $override_config_names = $this->listConfig($override_storage, $old_extensions);
+    $intersect = array_intersect($override_config_names, $install_config_names);
+    $overrides = $storage->readMultiple($intersect);
+
+    // Merge passive overrides, eg. overrides to a new module from a module that
+    // had already been loaded.
+    $data = array_merge($data, $overrides);
+
     // Add default config hash to overrides.
     foreach ($data as $name => &$value) {
       $value = $this->addDefaultConfigHash($value);
+      if (!$this->validateDependencies($name, $data, $enabled_extensions, $all_config)) {
+        // Couldn't validatge dependency.
+        unset($data[$name]);
+      }
     }
     return $data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function validateDependencies($config_name, array $data, array $enabled_extensions, array $all_config) {
+
+    // Parent version does not account for simple config module dependencies.
+    if (!isset($data['dependencies'])) {
+      // Simple config or a config entity without dependencies.
+      list($provider) = explode('.', $config_name, 2);
+      return in_array($provider, $enabled_extensions, TRUE);
+    }
+    return parent::validateDependencies($config_name, $data, $enabled_extensions, $all_config);
   }
 
   /**

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -74,7 +74,7 @@ class QuickstartConfigProvider extends ConfigProviderBase {
     foreach ($data as $name => &$value) {
       $value = $this->addDefaultConfigHash($value);
       if (!$this->validateDependencies($name, $data, $enabled_extensions, $all_config)) {
-        // Couldn't validatge dependency.
+        // Couldn't validate dependency.
         unset($data[$name]);
       }
     }

--- a/modules/custom/az_security/az_security.install
+++ b/modules/custom/az_security/az_security.install
@@ -4,3 +4,15 @@
  * @file
  * Install, update and uninstall functions for az_security module.
  */
+
+/**
+ * Delete seckit settings if they were mistakenly installed.
+ */
+function az_security_update_920101() {
+  $module_handler = \Drupal::service('module_handler');
+  if (!$module_handler->moduleExists('seckit')) {
+    // Remove seckit settings if they were installed too early.
+    $config_factory = \Drupal::service('config.factory');
+    $config_factory->getEditable('seckit.settings')->delete();
+  }
+}


### PR DESCRIPTION
This PR adds functionality for quickstart configuration overrides to not install themselves until the module that uses them is ready; this covers the case of `az_security` where it contains overrides for `seckit.settings` but `seckit` is not installed by default.

This means that an attempt to install `seckit.settings` would create problems because it installs configuration for a module that doesn't exist. When a user later attempts to install  `seckit` it would fail, because it would find that its configuration already exists.

This PR attempts to extend the Quickstart configuration provider to wait to install configuration overrides until the dependencies it is based on are present. This creates the notion of a "passive" override that has not be installed yet because a module it depends upon doesn't exist yet.

A database update is included to remove `seckit.settings` on sites where `seckit` is not enabled.

## Related issues
#1460 

## How to test
- Add `config/quickstart` overrides for a module that does not exist yet
- Install the module containing the overrides
- Verify overrides not installed
- Install the module the overrides depend upon
- Verify the overrides are installed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [x] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [x] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [x] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
