### PR TITLE
Closes #1476: Add az_files_oembed migration to handle remote files.

### DIFF
--- a/modules/custom/az_migration/migrations/az_files_oembed.yml
+++ b/modules/custom/az_migration/migrations/az_files_oembed.yml
@@ -1,0 +1,33 @@
+id: az_files_oembed
+label: Remote Files (oEmbed)
+migration_group: az_migration
+migration_tags:
+  - Quickstart Content Migration
+source:
+  plugin: d7_file
+  scheme: oembed
+
+process:
+  filename: filename
+  uri:
+    -
+      plugin: skip_on_empty
+      method: row
+      source: uri
+      message: 'Cannot import empty URI, check the source site for missing files.'
+  filemime: filemime
+  status: status
+  created: timestamp
+  changed: timestamp
+  uid:
+    -
+      plugin: migration_lookup
+      migration: az_user
+      no_stub: true
+      source: uid
+    -
+      plugin: default_value
+      default_value: 0
+
+destination:
+  plugin: entity:file

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_files.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_files.yml
@@ -11,12 +11,7 @@ source:
     old_files_path: ''
 
 process:
-  filename:
-    - plugin: skip_on_empty
-      method: row
-      source: filename
-      message: 'Cannot import empty filename.'
-
+  filename: filename
   source_full_path:
     -
       plugin: concat
@@ -28,17 +23,11 @@ process:
     -
       plugin: urlencode
   uri:
-    -
-      plugin: skip_on_empty
-      method: row
-      source: uri
-      message: 'Cannot import empty URI, check the source site for missing files.'
-    -
-      plugin: file_copy
-      source:
-        - '@source_full_path'
-        - uri
-      file_exists: "use existing"
+    plugin: file_copy
+    source:
+      - '@source_full_path'
+      - uri
+    file_exists: "use existing"
 
   filemime: filemime
   # filesize is dynamically computed when file entities are saved, so there is

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_media.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_media.yml
@@ -38,7 +38,9 @@ process:
   # Lookup fid through migration lookup. Should not depend on fid not changing.
   mfid:
     plugin: migration_lookup
-    migration: az_files
+    migration:
+      - az_files
+      - az_files_oembed
     source: fid
   # Bundles have different field names for their target reference.
   field_media_az_audio_file/target_id: '@mfid'
@@ -79,6 +81,7 @@ migration_dependencies:
   required:
     - az_user
     - az_files
+    - az_files_oembed
 
 dependencies:
   enforced:

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_media.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_media.yml
@@ -38,9 +38,7 @@ process:
   # Lookup fid through migration lookup. Should not depend on fid not changing.
   mfid:
     plugin: migration_lookup
-    migration:
-      - az_files
-      - az_files_oembed
+    migration: az_files
     source: fid
   # Bundles have different field names for their target reference.
   field_media_az_audio_file/target_id: '@mfid'
@@ -67,7 +65,13 @@ process:
         plugin: default_value
         default_value: plain_text
   field_media_az_video_file: '@mfid'
-  field_media_az_oembed_video/value: uri
+  field_media_az_oembed_video/value:
+    - plugin: str_replace
+      source: uri
+      search: "oembed://"
+      replace: ''
+    - plugin: callback
+      callable: urldecode
 
   name: filename
   created: timestamp
@@ -81,10 +85,10 @@ migration_dependencies:
   required:
     - az_user
     - az_files
-    - az_files_oembed
 
 dependencies:
   enforced:
     module:
       - az_migration
       - az_media
+      - migrate_plus


### PR DESCRIPTION
## Description

## Related issues
Closes #1476

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

- Import the migrations in the `az_migration` group using a source site containing file entities with `oembed://...` uri values (e.g. YouTube videos) into a destination site with this patch applied.
- See if errors/warnings are generated when trying to render pages using migrated remote files (or during the migration imports)
- Check to see if the remote file entities exist in the database / media library

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
