### PR TITLE
Closes #1505: Enable errorexit for ProboCI migration tests.

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -104,6 +104,7 @@ steps:
   - name: Migration Tests
     plugin: Script
     script:
+      - set -e
       - source ${ASSET_DIR}/migration.sh
       - terminus connection:info ${MIGRATION_SOURCE_SITE_NAME}.dev --fields 'mysql_host,mysql_password,mysql_port,mysql_database,mysql_username' --format=json > /tmp/migration_config.json
       - mkdir -p /var/www/html/sites/migration && cd /var/www/html/sites


### PR DESCRIPTION
## Description
Fixes issue preventing migration test failures from being properly reflected by ProboCI.

## Related issues
Closes #1505

## How to test
Review https://github.com/az-digital/az_quickstart/pull/1504

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
