### PR TITLE
Fixes #1340 Drupal 9.3 Permissions Updates

### DIFF
--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -94,7 +94,7 @@ function az_core_modules_installed($modules, $is_syncing) {
 function az_core_modules_uninstalled($modules) {
 
   // Import overrides that exist for the enabled modules.
-  $overrider = Drupal::service('az_core.override_import');
+  $overrider = \Drupal::service('az_core.override_import');
   if ($overrider) {
     $overrider->importOverrides([]);
   }

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -89,6 +89,18 @@ function az_core_modules_installed($modules, $is_syncing) {
 }
 
 /**
+ * Implements hook_modules_uninstalled().
+ */
+function az_core_modules_uninstalled($modules) {
+
+  // Import overrides that exist for the enabled modules.
+  $overrider = Drupal::service('az_core.override_import');
+  if ($overrider) {
+    $overrider->importOverrides([]);
+  }
+}
+
+/**
  * Implements hook_block_access().
  */
 function az_core_block_access(Block $block, $operation, AccountInterface $account) {

--- a/modules/custom/az_core/src/AZConfigOverride.php
+++ b/modules/custom/az_core/src/AZConfigOverride.php
@@ -98,6 +98,7 @@ class AZConfigOverride {
         $permissions = $provider->findProfilePermissions($extensions);
         $overrides = $permissions + $overrides;
 
+        $snapshots = [];
         // Edit active configuration for each explicit override.
         foreach ($overrides as $name => $data) {
           $config = $this->configFactory->getEditable($name);
@@ -110,10 +111,15 @@ class AZConfigOverride {
             $type = $provided_by[0];
             $owner = $provided_by[1];
 
-            // Update the config_snapshot of the module that owns the config.
-            $this->configSyncSnapshotter->refreshExtensionSnapshot($type, [$owner],
-              ConfigSyncSnapshotterInterface::SNAPSHOT_MODE_IMPORT);
+            // Record we need to do a snapshot.
+            $snapshots[$type][] = $owner;
           }
+        }
+
+        // Update the config_snapshot of the modules that owned the config.
+        foreach ($snapshots as $type => $owners) {
+          $this->configSyncSnapshotter->refreshExtensionSnapshot($type, $owners,
+            ConfigSyncSnapshotterInterface::SNAPSHOT_MODE_IMPORT);
         }
       }
     }

--- a/modules/custom/az_core/src/AZConfigOverride.php
+++ b/modules/custom/az_core/src/AZConfigOverride.php
@@ -95,6 +95,8 @@ class AZConfigOverride {
       // Only query config for the Quickstart provider.
       if ($provider instanceof QuickstartConfigProvider) {
         $overrides = $provider->getOverrideConfig($extensions, $old_extensions);
+        $permissions = $provider->findProfilePermissions($extensions);
+        $overrides = $permissions + $overrides;
 
         // Edit active configuration for each explicit override.
         foreach ($overrides as $name => $data) {

--- a/modules/custom/az_core/src/AZConfigOverride.php
+++ b/modules/custom/az_core/src/AZConfigOverride.php
@@ -118,8 +118,11 @@ class AZConfigOverride {
 
         // Update the config_snapshot of the modules that owned the config.
         foreach ($snapshots as $type => $owners) {
-          $this->configSyncSnapshotter->refreshExtensionSnapshot($type, $owners,
-            ConfigSyncSnapshotterInterface::SNAPSHOT_MODE_IMPORT);
+          $owners = array_unique($owners);
+          foreach ($owners as $owner) {
+            $this->configSyncSnapshotter->refreshExtensionSnapshot($type, [$owner],
+              ConfigSyncSnapshotterInterface::SNAPSHOT_MODE_IMPORT);
+          }
         }
       }
     }

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -42,14 +42,6 @@ class QuickstartConfigProvider extends ConfigProviderBase {
    */
   public function findProfilePermissions(array $extensions = []) {
 
-    // Get active configuration to look for roles.
-    $existing_config = $this->getActiveStorages()->listAll();
-    // phpcs:ignore
-    $existing_roles = array_filter($existing_config, function ($name) {
-      return (strpos($name, 'user.role.') === 0);
-    });
-    $role_config = $this->getActiveStorages()->readMultiple($existing_roles);
-
     // Build list of permissions by providers (eg. module)
     // @todo Use injection on user.permissions.
     // @phpstan-ignore-next-line
@@ -68,6 +60,14 @@ class QuickstartConfigProvider extends ConfigProviderBase {
       return [];
     }
     sort($new_perms);
+
+    // Get active configuration to look for roles.
+    $existing_config = $this->getActiveStorages()->listAll();
+    // phpcs:ignore
+    $existing_roles = array_filter($existing_config, function ($name) {
+      return (strpos($name, 'user.role.') === 0);
+    });
+    $role_config = $this->getActiveStorages()->readMultiple($existing_roles);
 
     $profile_storages = $this->getProfileStorages();
     // Check to see if the corresponding profile storage has any overrides.

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -24,6 +24,13 @@ class QuickstartConfigProvider extends ConfigProviderBase {
   const ID = 'config/quickstart';
 
   /**
+   * List of permissions defined.
+   *
+   * @var array
+   */
+  protected $permissionDefinitions = [];
+
+  /**
    * {@inheritdoc}
    */
   public function addConfigToCreate(array &$config_to_create, StorageInterface $storage, $collection, $prefix = '', array $profile_storages = []) {
@@ -151,12 +158,6 @@ class QuickstartConfigProvider extends ConfigProviderBase {
 
     return $config;
   }
-  /**
-   * List of permissions defined.
-   *
-   * @var array
-   */
-  protected $permissionDefinitions = [];
 
   /**
    * Get permissions defined.
@@ -171,7 +172,6 @@ class QuickstartConfigProvider extends ConfigProviderBase {
       $this->permissionDefinitions = \Drupal::service('user.permissions')->getPermissions();
     }
     return $this->permissionDefinitions;
-  }
   }
 
   /**

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -150,6 +150,7 @@ class QuickstartConfigProvider extends ConfigProviderBase {
           $dependencies = array_values(array_unique($dependencies));
           sort($dependencies);
         }
+        ksort($value['dependencies']);
       }
 
       // Add transformed config hash.

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -153,11 +153,6 @@ class QuickstartConfigProvider extends ConfigProviderBase {
       $data = $profile_storage->readMultiple(array_keys($data)) + $data;
     }
 
-    // Get permissions defined.
-    // @phpstan-ignore-next-line
-    $permission_definitions = \Drupal::service('user.permissions')->getPermissions();
-    $permissions = array_keys($permission_definitions);
-
     // Remove permission that don't exist.
     $data = $this->trimPermissions($data);
 

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -42,13 +42,13 @@ class QuickstartConfigProvider extends ConfigProviderBase {
    */
   public function findProfilePermissions(array $extensions = []) {
 
-    // Get active configuration to look for users.
+    // Get active configuration to look for roles.
     $existing_config = $this->getActiveStorages()->listAll();
     // phpcs:ignore
-    $existing_users = array_filter($existing_config, function ($name) {
+    $existing_roles = array_filter($existing_config, function ($name) {
       return (strpos($name, 'user.role.') === 0);
     });
-    $user_config = $this->getActiveStorages()->readMultiple($existing_users);
+    $role_config = $this->getActiveStorages()->readMultiple($existing_roles);
 
     // Build list of permissions by providers (eg. module)
     // @todo Use injection on user.permissions.
@@ -68,7 +68,7 @@ class QuickstartConfigProvider extends ConfigProviderBase {
 
     $profile_storages = $this->getProfileStorages();
     // Check to see if the corresponding profile storage has any overrides.
-    foreach ($user_config as $key => $data) {
+    foreach ($role_config as $key => $data) {
       $current_perms = $data['permissions'] ?? [];
       $label = $data['label'] ?? 'Unnamed Role';
       foreach ($profile_storages as $profile_storage) {
@@ -91,13 +91,13 @@ class QuickstartConfigProvider extends ConfigProviderBase {
             ]));
           }
           if (!empty($profile_perms)) {
-            $user_config[$key]['permissions'] = array_unique(array_merge($current_perms, $profile_perms));
+            $role_config[$key]['permissions'] = array_unique(array_merge($current_perms, $profile_perms));
           }
         }
       }
     }
 
-    return $this->trimPermissions($user_config);
+    return $this->trimPermissions($role_config);
   }
 
   /**

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -27,7 +27,7 @@ class QuickstartConfigProvider extends ConfigProviderBase {
    * {@inheritdoc}
    */
   public function addConfigToCreate(array &$config_to_create, StorageInterface $storage, $collection, $prefix = '', array $profile_storages = []) {
-    // Remove permission that don't exist.
+    // Remove permissions that don't exist.
     $config_to_create = $this->trimPermissions($config_to_create);
   }
 
@@ -153,7 +153,7 @@ class QuickstartConfigProvider extends ConfigProviderBase {
       $data = $profile_storage->readMultiple(array_keys($data)) + $data;
     }
 
-    // Remove permission that don't exist.
+    // Remove permissions that don't exist.
     $data = $this->trimPermissions($data);
 
     // Add the configuration changes.

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -123,10 +123,28 @@ class QuickstartConfigProvider extends ConfigProviderBase {
     foreach ($config as $name => &$value) {
       // Is this a permission configuration file?
       if (strpos($name, 'user.role.') === 0) {
+        // Dependencies TBD based on permissions.
+        $value['dependencies'] = [];
         // Trim active permissions list to what's expected.
         if (!empty($value['permissions'])) {
           $value['permissions'] = array_intersect($permissions, $value['permissions']);
           sort($value['permissions']);
+        }
+
+        // Add dependencies based on permissions.
+        foreach ($value['permissions'] as $perm) {
+          $value['dependencies']['module'][] = $permission_definitions[$perm]['provider'];
+          if (!empty($permission_definitions[$perm]['dependencies'])) {
+            foreach ($permission_definitions[$perm]['dependencies'] as $dependency_type => $list) {
+              foreach ($list as $dependency) {
+                $value['dependencies'][$dependency_type][] = $dependency;
+              }
+            }
+          }
+        }
+        // Make sure dependencies are unique.
+        foreach ($value['dependencies'] as $dependency_type => &$dependencies) {
+          $dependencies = array_values(array_unique($dependencies));
         }
       }
 

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -145,6 +145,7 @@ class QuickstartConfigProvider extends ConfigProviderBase {
         // Make sure dependencies are unique.
         foreach ($value['dependencies'] as $dependency_type => &$dependencies) {
           $dependencies = array_values(array_unique($dependencies));
+          sort($dependencies);
         }
       }
 

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -64,6 +64,9 @@ class QuickstartConfigProvider extends ConfigProviderBase {
     foreach ($permissions_by_provider as $perms) {
       $new_perms = $new_perms + $perms;
     }
+    if (empty($new_perms)) {
+      return [];
+    }
     sort($new_perms);
 
     $profile_storages = $this->getProfileStorages();

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -43,9 +43,7 @@ class QuickstartConfigProvider extends ConfigProviderBase {
   public function findProfilePermissions(array $extensions = []) {
 
     // Build list of permissions by providers (eg. module)
-    // @todo Use injection on user.permissions.
-    // @phpstan-ignore-next-line
-    $permissions_definitions = \Drupal::service('user.permissions')->getPermissions();
+    $permission_definitions = $this->getPermissionDefinitions();
     $permissions_by_provider = [];
     foreach ($permissions_definitions as $key => $permission) {
       $permissions_by_provider[$permission['provider']][] = $key;
@@ -114,9 +112,7 @@ class QuickstartConfigProvider extends ConfigProviderBase {
    */
   protected function trimPermissions(array $config) {
     // Get permissions defined.
-    // @todo Use injection on user.permissions.
-    // @phpstan-ignore-next-line
-    $permission_definitions = \Drupal::service('user.permissions')->getPermissions();
+    $permission_definitions = $this->getPermissionDefinitions();
     $permissions = array_keys($permission_definitions);
 
     // Add the configuration changes.
@@ -154,6 +150,28 @@ class QuickstartConfigProvider extends ConfigProviderBase {
     }
 
     return $config;
+  }
+  /**
+   * List of permissions defined.
+   *
+   * @var array
+   */
+  protected $permissionDefinitions = [];
+
+  /**
+   * Get permissions defined.
+   *
+   * @return array
+   *   An array of permission definitions.
+   */
+  protected function getPermissionDefinitions() {
+    if (empty($this->permissionDefinitions)) {
+      // @todo Use injection on user.permissions.
+      // @phpstan-ignore-next-line
+      $this->permissionDefinitions = \Drupal::service('user.permissions')->getPermissions();
+    }
+    return $this->permissionDefinitions;
+  }
   }
 
   /**

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -50,7 +50,7 @@ class QuickstartConfigProvider extends ConfigProviderBase {
   public function findProfilePermissions(array $extensions = []) {
 
     // Build list of permissions by providers (eg. module)
-    $permission_definitions = $this->getPermissionDefinitions();
+    $permissions_definitions = $this->getPermissionDefinitions();
     $permissions_by_provider = [];
     foreach ($permissions_definitions as $key => $permission) {
       $permissions_by_provider[$permission['provider']][] = $key;


### PR DESCRIPTION
This PR alters our distribution configuration handler to transparently remove permission that do not exist, to be compatible with [a Drupal 9.3 change](https://www.drupal.org/node/3193348)

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

## Related issues
#1340 
#1180 

## How to test
WIP
Verify that permissions are removed if they belong to not enabled modules.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [x] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [x] New internal API or API improvement with backwards compatibility
   - [x] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
