### PR TITLE
Closes #1559: 2.2.x Backport of minor entity view display fixes from #1181.

### DIFF
--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_card.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_card.yml
@@ -182,7 +182,7 @@ third_party_settings:
         effect: none
         speed: fast
         id: ''
-        classes: 'card card-borderless card-clickable bg-gray-100 mb-0 mt-0 mb-4 p-0'
+        classes: 'card card-borderless card-clickable bg-gray-100 mt-0 mb-4 p-0'
       label: 'Card Clickable'
     group_link:
       children:

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_marquee.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_marquee.yml
@@ -56,7 +56,7 @@ third_party_settings:
         effect: none
         speed: fast
         id: ''
-        classes: ' border-bottom align-text-top mb-4'
+        classes: 'border-bottom align-text-top mb-4'
       label: 'Title Block'
     group_text_muted:
       children:
@@ -126,7 +126,7 @@ third_party_settings:
         speed: fast
         id: ''
         classes: lead
-      label: lead
+      label: Lead
     group_body_row:
       children: {  }
       parent_name: ''

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
@@ -61,7 +61,7 @@ third_party_settings:
         effect: none
         speed: fast
         id: ''
-        classes: ' border-bottom align-text-top mb-4'
+        classes: 'border-bottom align-text-top mb-4'
       label: 'Title Block'
     group_text_muted:
       children:
@@ -137,7 +137,7 @@ third_party_settings:
         speed: fast
         id: ''
         classes: lead
-      label: lead
+      label: Lead
     group_body_row:
       children:
         - group_text_column


### PR DESCRIPTION
## Description
Backport of minor entity view display changes identified by @bberndt-uaz and included in #1181.  Needs to be manually backported due to all the config changes happening for 9.3.x.

## Related issues
Closes #1559 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
