### PR TITLE
#1561: Update composer branch alias for dev-main to 2.4.x-dev.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.3.x-dev"
+            "dev-main": "2.4.x-dev"
         },
         "patches": {
             "drupal/antibot": {


### PR DESCRIPTION
## Description
The [2.3.x branch](https://github.com/az-digital/az_quickstart/tree/2.3.x) has been created.  Before we can create any `2.3.x` releases, we need to update the composer branch alias for `dev-main` from `2.3.x-dev` to `2.4.x-dev` (see https://github.com/az-digital/az_quickstart/wiki/Steps-to-create-minor-release).

This change will need to be merged into main and backported into _all_ existing release branches.

## Related issues
#1561 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Shouldn't break anything.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [x] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
