### PR TITLE
Closes #1570: Ensure better_exposed_filters module is installed.

### DIFF
--- a/modules/custom/az_news/az_news.install
+++ b/modules/custom/az_news/az_news.install
@@ -104,3 +104,18 @@ function az_news_update_9203() {
       ->addMessage($field_name . ' not found on az_news content type.');
   }
 }
+
+/**
+ * Ensure the better_exposed_filters module is installed.
+ */
+function az_news_update_920301() {
+    try {
+      \Drupal::service('module_installer')->install(['better_exposed_filters']);
+    }
+    catch (MissingDependencyException $e) {
+      return t('Better Exposed Filters module not available to install.');
+    }
+
+    return t('Better Exposed Filters module installed.');
+  }
+}

--- a/modules/custom/az_news/az_news.install
+++ b/modules/custom/az_news/az_news.install
@@ -109,13 +109,12 @@ function az_news_update_9203() {
  * Ensure the better_exposed_filters module is installed.
  */
 function az_news_update_920301() {
-    try {
-      \Drupal::service('module_installer')->install(['better_exposed_filters']);
-    }
-    catch (MissingDependencyException $e) {
-      return t('Better Exposed Filters module not available to install.');
-    }
-
-    return t('Better Exposed Filters module installed.');
+  try {
+    \Drupal::service('module_installer')->install(['better_exposed_filters']);
   }
+  catch (MissingDependencyException $e) {
+    return t('Better Exposed Filters module not available to install.');
+  }
+
+  return t('Better Exposed Filters module installed.');
 }

--- a/modules/custom/az_news/az_news.install
+++ b/modules/custom/az_news/az_news.install
@@ -109,12 +109,6 @@ function az_news_update_9203() {
  * Ensure the better_exposed_filters module is installed.
  */
 function az_news_update_920301() {
-  try {
-    \Drupal::service('module_installer')->install(['better_exposed_filters']);
-  }
-  catch (MissingDependencyException $e) {
-    return t('Better Exposed Filters module not available to install.');
-  }
-
+  \Drupal::service('module_installer')->install(['better_exposed_filters']);
   return t('Better Exposed Filters module installed.');
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

## Related issues
Closes #1570 
Introduced in #1539

## How to test
- Add PR diff as composer patch to existing site
- Run drush updatedb

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
