### PR TITLE
Fixes #1583 Downgrading menu_block module from 1.8.0 to 1.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "drupal/media_library_form_element": "2.0.3",
         "drupal/media_library_theme_reset": "1.1.0",
         "drupal/media_migration": "1.0.0-alpha14",
-        "drupal/menu_block": "1.8.0",
+        "drupal/menu_block": "1.7.0",
         "drupal/menu_link_attributes": "1.2",
         "drupal/metatag": "1.19.0",
         "drupal/migrate_plus": "5.3.0",


### PR DESCRIPTION
## Description
Upgrading menu_block caused blocks to suddenly appear, when they hadn't previously.

## Related issues
Closes #1583

## How to test
Download uxua or campus-rec sites from the 2-3-0 multidev
See footer menu blocks with empty menus
Downgrade menu_block module
Don't see footer blocks with empty menus

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [x] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
