### PR TITLE
#1600: Drupal core to 9.3.14 for SA-CORE-2022-010/CVE-2022-29248.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,7 @@
         "drupal/viewsreference": "2.0-beta2",
         "drupal/webform": "6.1.3",
         "drupal/xmlsitemap": "1.2.0",
+        "guzzle/guzzle": "6.5.6 as 6.5.5",
         "npm-asset/blazy": "1.8.2",
         "npm-asset/jquery-ui-touch-punch": "0.2.3",
         "npm-asset/slick-carousel": "1.8.0"

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "drupal/config_snapshot": "1.0-rc2",
         "drupal/config_sync": "2.0-beta7",
         "drupal/config_update": "1.7",
-        "drupal/core-recommended": "9.3.13",
+        "drupal/core-recommended": "9.3.14",
         "drupal/crop": "2.2.0",
         "drupal/ctools": "3.7",
         "drupal/date_ap_style": "1.4",
@@ -99,7 +99,6 @@
         "drupal/viewsreference": "2.0-beta2",
         "drupal/webform": "6.1.3",
         "drupal/xmlsitemap": "1.2.0",
-        "guzzlehttp/guzzle": "6.5.6 as 6.5.5",
         "npm-asset/blazy": "1.8.2",
         "npm-asset/jquery-ui-touch-punch": "0.2.3",
         "npm-asset/slick-carousel": "1.8.0"

--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,7 @@
         "drupal/viewsreference": "2.0-beta2",
         "drupal/webform": "6.1.3",
         "drupal/xmlsitemap": "1.2.0",
-        "guzzle/guzzle": "6.5.6 as 6.5.5",
+        "guzzlehttp/guzzle": "6.5.6 as 6.5.5",
         "npm-asset/blazy": "1.8.2",
         "npm-asset/jquery-ui-touch-punch": "0.2.3",
         "npm-asset/slick-carousel": "1.8.0"


### PR DESCRIPTION
## Description
This is a workaround that updates `guzzlehttp/guzzle` (a Drupal core dependency) until a new Drupal core release is created that includes Guzzle 6.5.6.  Might be worth waiting to see if any plans for a core release are announced today before merging this...

## Related issues
Closes #1600

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
- General QA/testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [x] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [x] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
