### PR TITLE
Closes #1611: Refine access for Quickstart 2 admin toolbar links.

### DIFF
--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -49,50 +49,37 @@ function az_core_toolbar() {
         ],
       ],
     ],
+    'tray' => [
+      '#heading' => t('Quickstart links'),
+      'az_links' => [
+        '#theme' => 'links__toolbar_az_core',
+        '#links' => [
+          'docs' => [
+            'title' => t('Documentation'),
+            'url' => Url::fromUri('https://quickstart.arizona.edu'),
+            'attributes' => [
+              'title' => t('Arizona Quickstart 2 Documentation'),
+              'target' => t('_blank'),
+            ],
+          ],
+        ],
+        '#attributes' => [
+          'class' => ['toolbar-menu'],
+        ],
+      ],
+    ],
     '#weight' => 101,
   ];
 
-  $siteurl = \Drupal::request()->getHost();
-
-  $items['az_quickstart']['tray'] = [
-    '#heading' => t('Quickstart links'),
-    'az_links' => [
-      '#theme' => 'links__toolbar_az_core',
-      '#links' => [
-        'docs' => [
-          'title' => t('Documentation'),
-          'url' => Url::fromUri('https://quickstart.arizona.edu'),
-          'attributes' => [
-            'title' => t('Arizona Quickstart 2 Documentation'),
-            'target' => t('_blank'),
-          ],
-        ],
-        'settings' => [
-          'title' => t('Settings'),
-          'url' => Url::fromRoute('az_core.az_settings'),
-          'attributes' => [
-            'title' => t('Arizona Quickstart 2 Settings'),
-          ],
-        ],
-        'analytics' => [
-          'title' => t('Analytics Dashboard'),
-          'url' => Url::fromUri('https://datastudio.google.com/u/0/reporting/938c3f2a-6dbf-4968-9edd-8963450b4200/page/kTLWB', [
-            'query' => [
-              'params' => '{"df62":"include%EE%80%800%EE%80%80IN%EE%80%80' . $siteurl . '/"}',
-            ],
-            'absolute' => TRUE,
-          ]),
-          'attributes' => [
-            'title' => t('Site Analytics Dashboard'),
-            'target' => t('_blank'),
-          ],
-        ],
+  if (\Drupal::currentUser()->hasPermission('administer quickstart configuration')) {
+    $items['az_quickstart']['tray']['az_links']['#links']['settings'] = [
+      'title' => t('Settings'),
+      'url' => Url::fromRoute('az_core.az_settings'),
+      'attributes' => [
+        'title' => t('Arizona Quickstart 2 Settings'),
       ],
-      '#attributes' => [
-        'class' => ['toolbar-menu'],
-      ],
-    ],
-  ];
+    ];
+  }
 
   return $items;
 }

--- a/modules/custom/az_google_tag/az_google_tag.module
+++ b/modules/custom/az_google_tag/az_google_tag.module
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Contains az_google_tag.module.
+ */
+
+use Drupal\Core\Url;
+
+/**
+ * Implements hook_toolbar_alter().
+ */
+function az_google_tag_toolbar_alter(&$items) {
+  if (\Drupal::service('module_handler')->moduleExists('az_core')) {
+    $site_url = \Drupal::request()->getHost();
+    $items['az_quickstart']['tray']['az_links']['#links']['analytics'] = [
+      'title' => t('Analytics Dashboard'),
+      'url' => Url::fromUri('https://datastudio.google.com/u/0/reporting/938c3f2a-6dbf-4968-9edd-8963450b4200/page/kTLWB', [
+        'query' => [
+          'params' => '{"df62":"include%EE%80%800%EE%80%80IN%EE%80%80' . $site_url . '/"}',
+        ],
+        'absolute' => TRUE,
+      ]),
+      'attributes' => [
+        'title' => t('Site Analytics Dashboard'),
+        'target' => t('_blank'),
+      ],
+    ];
+  }
+}

--- a/modules/custom/az_google_tag/az_google_tag.module.php
+++ b/modules/custom/az_google_tag/az_google_tag.module.php
@@ -1,6 +1,0 @@
-<?php
-
-/**
- * @file
- * Contains az_google_tag.module.
- */


### PR DESCRIPTION
## Description
- Only display `Settings` link if current user has `administer quickstart configuration` permission.
- Only display `Site Analytics Dashboard` link if `az_google_tag` module is installed.

## Related issues
Closes #1611 

## How to test
- Login to Probo site with different roles (admin, content admin, content editor)
- Inspect list under `Quicsktart 2` item in admin toolbar

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [x] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
