### PR TITLE
Closes #1634: Fix invalid count comparisons in existing hook_update_N() implementations.

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs_text_background/az_paragraphs_text_background.install
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_background/az_paragraphs_text_background.install
@@ -48,7 +48,7 @@ function az_paragraphs_text_background_update_9201() {
     $sandbox['current']++;
   }
 
-  $sandbox['#finished'] = ($sandbox['total'] === 0) ? 1 : ($sandbox['current'] / $sandbox['total']);
+  $sandbox['#finished'] = ($sandbox['total'] === '0') ? 1 : ($sandbox['current'] / $sandbox['total']);
 
   return t('Default padding setting added to %count Text with Background paragraphs.', ['%count' => $sandbox['updated_count']]);
 }

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/az_paragraphs_text_media.install
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/az_paragraphs_text_media.install
@@ -44,7 +44,7 @@ function az_paragraphs_text_media_update_9201() {
     $sandbox['current']++;
   }
 
-  $sandbox['#finished'] = ($sandbox['total'] === 0) ? 1 : ($sandbox['current'] / $sandbox['total']);
+  $sandbox['#finished'] = ($sandbox['total'] === '0') ? 1 : ($sandbox['current'] / $sandbox['total']);
 
   return t('Default padding/margin setting added to %count Text on Media paragraphs.', ['%count' => $sandbox['updated_count']]);
 }


### PR DESCRIPTION
## Description
Applied fix from #1629 to existing `hook_update_N()` implementations.  This is to prevent the same kind of situation we saw yesterday when trying to apply the new DB update to existing sites in case anyone is still running an old enough version of Quickstart and still needs to apply these old updates.

## Related issues
Closes #1634
See #1627 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Would require building an older version of AZ Quickstart and then applying DB updates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
