### PR TITLE
Fixes #1626 Add calendar category filter

### DIFF
--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -8,6 +8,7 @@
 use Drupal\node\Entity\NodeType;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Render\Element;
 
@@ -164,4 +165,49 @@ function az_event_preprocess_views_view(&$variables) {
     }
   }
 
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Hide the event view category search if there are no options.
+ */
+function az_event_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  $view = $form_state->get('view');
+  if (($view->id() === 'az_events') && ($view->current_display === 'page_1')) {
+
+    // Check to see if the event category filter seems to exist in this display.
+    if (isset($form['term_node_tid_depth'])) {
+      if (isset($form['term_node_tid_depth']['#options']) &&
+        is_array($form['term_node_tid_depth']['#options'])) {
+        // We will only show the category filter in some cases.
+        $keep_filter = TRUE;
+
+        // Get the arguments statically, as this hook is called multiple times.
+        // At some points in the request, the arguments disappear.
+        $view_args = &drupal_static(__FUNCTION__);
+        if (!isset($view_args)) {
+          $view_args = $view->args;
+        }
+
+        // Check if our event category filter doesn't contain multiple terms.
+        // The implication is this site probably doesn't use this vocabulary.
+        if (count($form['term_node_tid_depth']['#options']) <= 1) {
+          $keep_filter = FALSE;
+        }
+
+        // Check if we seem to have contextual filter arguments.
+        if (isset($view_args) && is_array($view_args) && !empty($view_args)) {
+          $keep_filter = FALSE;
+        }
+
+        // Hide the category filter if either of the above were the case.
+        // Our goal is to hide the filter if it conflicts or has no terms.
+        if (!$keep_filter) {
+          $form['term_node_tid_depth']['#access'] = FALSE;
+        }
+      }
+    }
+  }
 }

--- a/modules/custom/az_event/config/install/views.view.az_events.yml
+++ b/modules/custom/az_event/config/install/views.view.az_events.yml
@@ -21,65 +21,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: default
-        options:
-          row_class: ''
-          default_row_class: false
-          uses_fields: true
-      row:
-        type: 'entity:node'
-        options:
-          relationship: none
-          view_mode: az_card
+      title: Calendar
       fields:
         delta:
           id: delta
@@ -88,6 +35,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: numeric
           label: ''
           exclude: false
           alter:
@@ -137,30 +85,136 @@ display:
           format_plural_string: !!binary MQNAY291bnQ=
           prefix: ''
           suffix: ''
-          plugin_id: numeric
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: '<em>There are no upcoming events listed.</em>'
+            format: az_standard
+          tokenize: false
+      sorts:
+        field_az_event_date_value:
+          id: field_az_event_date_value
+          table: node__field_az_event_date
+          field: field_az_event_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: date
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: field_az_event_date_value
+          exposed: false
+          granularity: second
+      arguments:
+        term_node_tid_depth:
+          id: term_node_tid_depth
+          table: node_field_data
+          field: term_node_tid_depth
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: taxonomy_index_tid_depth
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:taxonomy_term'
+            fail: 'not found'
+          validate_options:
+            bundles:
+              az_event_categories: az_event_categories
+            access: false
+            operation: view
+            multiple: 1
+          break_phrase: false
+          depth: 0
+          use_taxonomy_term_path: false
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            az_event: az_event
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            az_event: az_event
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -171,6 +225,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: date
           operator: '>='
           value:
             min: ''
@@ -193,9 +248,9 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -208,85 +263,30 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: date
-      sorts:
-        field_az_event_date_value:
-          id: field_az_event_date_value
-          table: node__field_az_event_date
-          field: field_az_event_date_value
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: false
+          uses_fields: true
+      row:
+        type: 'entity:node'
+        options:
           relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-            field_identifier: field_az_event_date_value
-          granularity: second
-          plugin_id: date
-      title: Calendar
+          view_mode: az_card
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: ''
       header: {  }
       footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: '<em>There are no upcoming events listed.</em>'
-            format: az_standard
-          plugin_id: text
-      relationships: {  }
-      arguments:
-        term_node_tid_depth:
-          id: term_node_tid_depth
-          table: node_field_data
-          field: term_node_tid_depth
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: ignore
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: fixed
-          default_argument_options:
-            argument: ''
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: true
-          validate:
-            type: 'entity:taxonomy_term'
-            fail: 'not found'
-          validate_options:
-            bundles:
-              az_event_categories: az_event_categories
-            operation: view
-            multiple: 1
-            access: false
-          depth: 0
-          break_phrase: false
-          use_taxonomy_term_path: false
-          entity_type: node
-          plugin_id: taxonomy_index_tid_depth
       display_extenders: {  }
-      css_class: ''
     cache_metadata:
       max-age: -1
       contexts:
@@ -297,22 +297,17 @@ display:
         - user.permissions
       tags: {  }
   az_grid:
-    display_plugin: block
     id: az_grid
     display_title: 'Grid View'
+    display_plugin: block
     position: 2
     display_options:
-      display_extenders: {  }
       title: Events
-      defaults:
-        title: false
-        style: false
-        row: false
-        style_options: false
-        pager: false
-        pager_options: false
-        footer: false
-      display_description: 'Use in a region that spans at least 12 columns.'
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 3
       style:
         type: views_bootstrap_grid
         options:
@@ -329,15 +324,17 @@ display:
         options:
           relationship: none
           view_mode: az_card
-      style_options: null
-      allow:
-        items_per_page: false
-      pager:
-        type: some
-        options:
-          items_per_page: 3
-          offset: 0
+      defaults:
+        title: false
+        pager: false
+        style: false
+        style_options: false
+        row: false
+        pager_options: false
+        footer: false
+      display_description: 'Use in a region that spans at least 12 columns.'
       pager_options: null
+      style_options: null
       footer:
         area_text_custom:
           id: area_text_custom
@@ -346,10 +343,13 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: true
-          tokenize: false
-          content: "<div class=\"text-align-center\">\r\n<a title=\"View all events on the calendar\" class=\"btn btn-outline-blue\" href=\"/calendar\">View all events on the calendar</a>\r\n</div>"
           plugin_id: text_custom
+          empty: true
+          content: "<div class=\"text-align-center\">\r\n<a title=\"View all events on the calendar\" class=\"btn btn-outline-blue\" href=\"/calendar\">View all events on the calendar</a>\r\n</div>"
+          tokenize: false
+      display_extenders: {  }
+      allow:
+        items_per_page: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -359,55 +359,18 @@ display:
         - user.permissions
       tags: {  }
   az_sidebar:
-    display_plugin: block
     id: az_sidebar
     display_title: 'Grid Sidebar'
+    display_plugin: block
     position: 3
     display_options:
-      display_extenders: {  }
-      display_description: 'Use in first or second sidebar regions'
       title: ''
-      defaults:
-        title: false
-        footer: false
-        pager: false
-        pager_options: false
-        header: false
-        arguments: false
-        empty: false
-      allow:
-        items_per_page: false
-      footer:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content: "<div class=\"text-align-center\">\r\n<a title=\"View all events\" class=\"btn btn-outline-blue\" href=\"/calendar\">View all events</a>\r\n</div>"
-          plugin_id: text_custom
       pager:
         type: some
         options:
-          items_per_page: 3
           offset: 0
-      pager_options: null
-      block_description: 'Sidebar Events Block'
-      header:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content: '<h2 class="h5 margin-align-middle text-uppercase">Upcoming Events</h2>'
-          plugin_id: text_custom
+          items_per_page: 3
+      empty: {  }
       arguments:
         term_node_tid_depth:
           id: term_node_tid_depth
@@ -416,6 +379,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: taxonomy_index_tid_depth
           default_action: ignore
           exception:
             value: all
@@ -430,8 +395,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -443,14 +408,12 @@ display:
           validate_options:
             bundles:
               az_event_categories: az_event_categories
+            access: false
             operation: view
             multiple: 1
-            access: false
-          depth: 0
           break_phrase: false
+          depth: 0
           use_taxonomy_term_path: false
-          entity_type: node
-          plugin_id: taxonomy_index_tid_depth
         nid:
           id: nid
           table: node_field_data
@@ -458,6 +421,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
           default_action: default
           exception:
             value: all
@@ -471,8 +437,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -484,15 +450,49 @@ display:
           validate_options:
             bundles:
               az_event: az_event
+            access: false
             operation: view
             multiple: 0
-            access: false
           break_phrase: false
           not: true
-          entity_type: node
-          entity_field: nid
-          plugin_id: node_nid
-      empty: {  }
+      defaults:
+        empty: false
+        title: false
+        pager: false
+        arguments: false
+        pager_options: false
+        header: false
+        footer: false
+      display_description: 'Use in first or second sidebar regions'
+      pager_options: null
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: false
+          content: '<h2 class="h5 margin-align-middle text-uppercase">Upcoming Events</h2>'
+          tokenize: false
+      footer:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: false
+          content: "<div class=\"text-align-center\">\r\n<a title=\"View all events\" class=\"btn btn-outline-blue\" href=\"/calendar\">View all events</a>\r\n</div>"
+          tokenize: false
+      display_extenders: {  }
+      block_description: 'Sidebar Events Block'
+      allow:
+        items_per_page: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -502,59 +502,34 @@ display:
         - user.permissions
       tags: {  }
   page_1:
-    display_plugin: page
     id: page_1
     display_title: 'Full Calendar'
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: calendar
-      css_class: ''
-      defaults:
-        css_class: false
-        style: false
-        row: false
-        style_options: false
-        filters: false
-        filter_groups: false
-        use_ajax: false
-      display_description: ''
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          uses_fields: true
-      row:
-        type: 'entity:node'
-        options:
-          relationship: none
-          view_mode: az_row
-      style_options: null
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            az_event: az_event
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            az_event: az_event
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -565,6 +540,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: az_calendar_filter
           operator: overlaps
           value:
             min: today
@@ -591,9 +567,9 @@ display:
               az_content_editor: '0'
               az_content_admin: '0'
               administrator: '0'
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -606,19 +582,96 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: az_calendar_filter
+        term_node_tid_depth:
+          id: term_node_tid_depth
+          table: node_field_data
+          field: term_node_tid_depth
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: taxonomy_index_tid_depth
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: term_node_tid_depth_op
+            label: Category
+            description: ''
+            use_operator: false
+            operator: term_node_tid_depth_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: term_node_tid_depth
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              az_content_editor: '0'
+              az_content_admin: '0'
+              az_user_admin: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: az_event_categories
+          type: select
+          hierarchy: true
+          limit: true
+          error_message: true
+          depth: 0
       filter_groups:
         operator: AND
         groups:
           1: AND
-      exposed_block: true
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: true
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: az_row
+      defaults:
+        css_class: false
+        use_ajax: false
+        style: false
+        style_options: false
+        row: false
+        filters: false
+        filter_groups: false
+      css_class: ''
       use_ajax: true
+      display_description: ''
+      style_options: null
+      exposed_block: true
+      display_extenders: {  }
+      path: calendar
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/modules/custom/az_event/css/az_calendar_filter.css
+++ b/modules/custom/az_event/css/az_calendar_filter.css
@@ -141,3 +141,35 @@
 .az-calendar-filter-calendar .ui-icon-circle-triangle-w {
   background-position: -96px -16px;
 }
+
+.block-views-exposed-filter-blockaz-events-page-1 .form-type-select {
+  margin-bottom: 0.5em;
+}
+
+.block-views-exposed-filter-blockaz-events-page-1 .form-type-select label {
+  font-weight: bold;
+  display: block;
+}
+
+.block-views-exposed-filter-blockaz-events-page-1 .form-type-select select {
+  color: #001c48;
+  font-weight: 500;
+  text-decoration: none;
+  letter-spacing: .04em;
+  white-space: normal;
+  border-width: 2px;
+  background-color: #dee2e6;
+  border-color: #dee2e6;
+  display: inline-block;
+  text-align: center;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border-radius: 0;
+  transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+}

--- a/modules/custom/az_event/js/az_calendar_filter.es6.js
+++ b/modules/custom/az_event/js/az_calendar_filter.es6.js
@@ -80,7 +80,6 @@
           }
 
           // Handle dropdown, if present.
-          $dropDown.addClass('d-block');
           $dropDown.on('change', () => {
             const $ancestor = $wrapper.closest(
               '.views-widget-az-calendar-filter',

--- a/modules/custom/az_event/js/az_calendar_filter.es6.js
+++ b/modules/custom/az_event/js/az_calendar_filter.es6.js
@@ -59,15 +59,6 @@
             .find('.form-select');
           let task = null;
 
-          $dropDown.addClass('d-block');
-          $dropDown
-            .on('change', (e) => {
-              const $ancestor = $wrapper.closest(
-                '.views-widget-az-calendar-filter',
-              );
-              triggerFilterChange($ancestor, 0);
-            });
-
           // Set task to trigger filter element change.
           function triggerFilterChange($ancestor, delay) {
             if (task != null) {
@@ -87,6 +78,15 @@
               }
             }, delay);
           }
+
+          // Handle dropdown, if present.
+          $dropDown.addClass('d-block');
+          $dropDown.on('change', () => {
+            const $ancestor = $wrapper.closest(
+              '.views-widget-az-calendar-filter',
+            );
+            triggerFilterChange($ancestor, 0);
+          });
 
           // Function to update a filter's internal date fields from datepicker.
           function updateCalendarFilters(startDate, endDate) {

--- a/modules/custom/az_event/js/az_calendar_filter.es6.js
+++ b/modules/custom/az_event/js/az_calendar_filter.es6.js
@@ -54,7 +54,19 @@
           const $submitButton = $wrapper
             .closest('.views-exposed-form')
             .find('button.form-submit');
+          const $dropDown = $wrapper
+            .closest('.views-exposed-form')
+            .find('.form-select');
           let task = null;
+
+          $dropDown.addClass('d-block');
+          $dropDown
+            .on('change', (e) => {
+              const $ancestor = $wrapper.closest(
+                '.views-widget-az-calendar-filter',
+              );
+              triggerFilterChange($ancestor, 0);
+            });
 
           // Set task to trigger filter element change.
           function triggerFilterChange($ancestor, delay) {

--- a/modules/custom/az_event/js/az_calendar_filter.js
+++ b/modules/custom/az_event/js/az_calendar_filter.js
@@ -38,11 +38,6 @@
         var $submitButton = $wrapper.closest('.views-exposed-form').find('button.form-submit');
         var $dropDown = $wrapper.closest('.views-exposed-form').find('.form-select');
         var task = null;
-        $dropDown.addClass('d-block');
-        $dropDown.on('change', function (e) {
-          var $ancestor = $wrapper.closest('.views-widget-az-calendar-filter');
-          triggerFilterChange($ancestor, 0);
-        });
 
         function triggerFilterChange($ancestor, delay) {
           if (task != null) {
@@ -59,6 +54,12 @@
             }
           }, delay);
         }
+
+        $dropDown.addClass('d-block');
+        $dropDown.on('change', function () {
+          var $ancestor = $wrapper.closest('.views-widget-az-calendar-filter');
+          triggerFilterChange($ancestor, 0);
+        });
 
         function updateCalendarFilters(startDate, endDate) {
           var $ancestor = $wrapper.closest('.views-widget-az-calendar-filter');

--- a/modules/custom/az_event/js/az_calendar_filter.js
+++ b/modules/custom/az_event/js/az_calendar_filter.js
@@ -55,7 +55,6 @@
           }, delay);
         }
 
-        $dropDown.addClass('d-block');
         $dropDown.on('change', function () {
           var $ancestor = $wrapper.closest('.views-widget-az-calendar-filter');
           triggerFilterChange($ancestor, 0);

--- a/modules/custom/az_event/js/az_calendar_filter.js
+++ b/modules/custom/az_event/js/az_calendar_filter.js
@@ -36,7 +36,13 @@
         var $buttonWrapper = $wrapper.children('.az-calendar-filter-buttons');
         var $calendar = $wrapper.children('.az-calendar-filter-calendar');
         var $submitButton = $wrapper.closest('.views-exposed-form').find('button.form-submit');
+        var $dropDown = $wrapper.closest('.views-exposed-form').find('.form-select');
         var task = null;
+        $dropDown.addClass('d-block');
+        $dropDown.on('change', function (e) {
+          var $ancestor = $wrapper.closest('.views-widget-az-calendar-filter');
+          triggerFilterChange($ancestor, 0);
+        });
 
         function triggerFilterChange($ancestor, delay) {
           if (task != null) {


### PR DESCRIPTION
Adds a category filter to the calendar. Additionally, since the vocabulary may not be used on a given site, the filter is disabled if doesn't contain options.

## Related issues
#1626 

## How to test
- enable demo content
- clear cache
- verify category filter does not appear on calendar
- add terms to event taxonomy
- clear cache
- verify category filter DOES appear on calendar
- assign terms to some events
- verify category filter works as expected and in conjuction with dates chosen by calendar
- Clear cache after ANY change to taxonomy - exposed filter blocks are heavily cached.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [x] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [x] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [x] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
