### PR TITLE
Closes #1643 Ensure Migrate Magician is enabled

### DIFF
--- a/modules/custom/az_migration/az_migration.install
+++ b/modules/custom/az_migration/az_migration.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for az_migration module.
+ */
+
+/**
+ * Ensure the (Migrate Magician) migmag module is installed.
+ */
+function az_migration_update_920301() {
+  \Drupal::service('module_installer')->install(['migmag']);
+  return t('Migrate Magician module installed.');
+}

--- a/modules/custom/az_migration/az_migration.install
+++ b/modules/custom/az_migration/az_migration.install
@@ -6,7 +6,7 @@
  */
 
 /**
- * Ensure the (Migrate Magician) migmag module is installed.
+ * Ensure the migmag (Migrate Magician) module is installed.
  */
 function az_migration_update_920301() {
   \Drupal::service('module_installer')->install(['migmag']);


### PR DESCRIPTION
## Description
media migration alpha14 has a new dependency on migmag, and not update to enable it, so we are enabling it for az_migration.

## Related issues
Closes #1643
Related #1640 
Related #1639 

## How to test
Add this pr to an existing site with az_migration enabled.
Run database updates.
See if it works.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
