### PR TITLE
Closes #746: Adds bottom margin to Person, News, Events

### DIFF
--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
@@ -28,9 +28,9 @@ third_party_settings:
       children:
         - field_az_subheading
       label: 'span subtitle'
-      parent_name: group_margin_bottom
+      parent_name: group_wrapper
       region: content
-      weight: 3
+      weight: 8
       format_type: html_element
       format_settings:
         classes: 'lead mb-3'
@@ -46,9 +46,9 @@ third_party_settings:
       children:
         - field_az_event_category
       label: 'Category Div'
-      parent_name: group_margin_bottom
+      parent_name: group_wrapper
       region: content
-      weight: 5
+      weight: 10
       format_type: html_element
       format_settings:
         classes: clearfix
@@ -65,9 +65,9 @@ third_party_settings:
         - group_col_1
         - group_col_2
       label: 'row 1'
-      parent_name: group_margin_bottom
+      parent_name: group_wrapper
       region: content
-      weight: 6
+      weight: 11
       format_type: html_element
       format_settings:
         classes: row
@@ -84,9 +84,9 @@ third_party_settings:
         - group_col_3
         - group_col_4
       label: 'row 2'
-      parent_name: group_margin_bottom
+      parent_name: group_wrapper
       region: content
-      weight: 7
+      weight: 12
       format_type: html_element
       format_settings:
         classes: row
@@ -171,7 +171,7 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-    group_margin_bottom:
+    group_wrapper:
       children:
         - links
         - field_az_photos
@@ -180,7 +180,7 @@ third_party_settings:
         - group_category
         - group_row_1
         - group_row_2
-      label: 'Margin bottom'
+      label: Wrapper
       parent_name: ''
       region: content
       weight: 0
@@ -216,7 +216,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 4
+    weight: 9
     region: content
   field_az_contacts:
     type: entity_reference_revisions_entity_view
@@ -272,7 +272,7 @@ content:
       view_mode: az_large
       link: false
     third_party_settings: {  }
-    weight: 2
+    weight: 7
     region: content
   field_az_subheading:
     type: text_default
@@ -284,7 +284,7 @@ content:
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 6
     region: content
 hidden:
   az_event_day: true

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_link
     - field.field.node.az_event.field_az_location
+    - field.field.node.az_event.field_az_metatag
     - field.field.node.az_event.field_az_photos
     - field.field.node.az_event.field_az_subheading
     - field.field.node.az_event.field_az_summary
@@ -28,9 +29,9 @@ third_party_settings:
       children:
         - field_az_subheading
       label: 'span subtitle'
-      parent_name: ''
+      parent_name: group_margin_bottom
       region: content
-      weight: 2
+      weight: 3
       format_type: html_element
       format_settings:
         classes: 'lead mb-3'
@@ -46,9 +47,9 @@ third_party_settings:
       children:
         - field_az_event_category
       label: 'Category Div'
-      parent_name: ''
+      parent_name: group_margin_bottom
       region: content
-      weight: 4
+      weight: 5
       format_type: html_element
       format_settings:
         classes: clearfix
@@ -65,9 +66,9 @@ third_party_settings:
         - group_col_1
         - group_col_2
       label: 'row 1'
-      parent_name: ''
+      parent_name: group_margin_bottom
       region: content
-      weight: 5
+      weight: 6
       format_type: html_element
       format_settings:
         classes: row
@@ -84,12 +85,13 @@ third_party_settings:
         - group_col_3
         - group_col_4
       label: 'row 2'
-      parent_name: ''
+      parent_name: group_margin_bottom
       region: content
-      weight: 6
+      weight: 7
       format_type: html_element
       format_settings:
         classes: row
+        show_empty_fields: false
         id: ''
         element: div
         show_label: false
@@ -170,6 +172,31 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
+    group_margin_bottom:
+      children:
+        - links
+        - field_az_photos
+        - group_span_subtitle
+        - field_az_body
+        - group_category
+        - group_row_1
+        - group_row_2
+      label: 'Margin bottom'
+      parent_name: ''
+      region: content
+      weight: 0
+      format_type: html_element
+      format_settings:
+        classes: mb-5
+        show_empty_fields: false
+        id: ''
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
   smart_title:
     enabled: false
 id: node.az_event.default
@@ -190,7 +217,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
   field_az_contacts:
     type: entity_reference_revisions_entity_view
@@ -246,7 +273,7 @@ content:
       view_mode: az_large
       link: false
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   field_az_subheading:
     type: text_default
@@ -258,11 +285,12 @@ content:
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
 hidden:
   az_event_day: true
   az_event_month: true
   field_az_link: true
+  field_az_metatag: true
   field_az_summary: true
   smart_title: true

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_link
     - field.field.node.az_event.field_az_location
-    - field.field.node.az_event.field_az_metatag
     - field.field.node.az_event.field_az_photos
     - field.field.node.az_event.field_az_subheading
     - field.field.node.az_event.field_az_summary
@@ -291,6 +290,5 @@ hidden:
   az_event_day: true
   az_event_month: true
   field_az_link: true
-  field_az_metatag: true
   field_az_summary: true
   smart_title: true

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
@@ -10,7 +10,6 @@ dependencies:
     - field.field.node.az_news.field_az_link
     - field.field.node.az_news.field_az_main_content
     - field.field.node.az_news.field_az_media_image
-    - field.field.node.az_news.field_az_metatag
     - field.field.node.az_news.field_az_news_tags
     - field.field.node.az_news.field_az_published
     - field.field.node.az_news.field_az_short_title
@@ -37,7 +36,6 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: row
-        show_empty_fields: false
         id: ''
         element: div
         show_label: false
@@ -151,7 +149,6 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: 'row mb-5'
-        show_empty_fields: false
         id: ''
         element: div
         show_label: false
@@ -277,7 +274,6 @@ content:
 hidden:
   field_az_expiration_date: true
   field_az_link: true
-  field_az_metatag: true
   field_az_news_tags: true
   field_az_short_title: true
   field_az_summary: true

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
@@ -25,7 +25,7 @@ dependencies:
     - text
     - user
 third_party_settings:
-  field_group: 
+  field_group:
     group_row:
       children:
         - group_title_column

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.az_news.field_az_link
     - field.field.node.az_news.field_az_main_content
     - field.field.node.az_news.field_az_media_image
+    - field.field.node.az_news.field_az_metatag
     - field.field.node.az_news.field_az_news_tags
     - field.field.node.az_news.field_az_published
     - field.field.node.az_news.field_az_short_title
@@ -36,6 +37,7 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: row
+        show_empty_fields: false
         id: ''
         element: div
         show_label: false
@@ -148,7 +150,8 @@ third_party_settings:
       weight: 1
       format_type: html_element
       format_settings:
-        classes: row
+        classes: 'row mb-5'
+        show_empty_fields: false
         id: ''
         element: div
         show_label: false
@@ -274,6 +277,7 @@ content:
 hidden:
   field_az_expiration_date: true
   field_az_link: true
+  field_az_metatag: true
   field_az_news_tags: true
   field_az_short_title: true
   field_az_summary: true

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.default.yml
@@ -25,7 +25,7 @@ dependencies:
     - text
     - user
 third_party_settings:
-  field_group:
+  field_group: 
     group_row:
       children:
         - group_title_column

--- a/themes/custom/az_barrio/templates/content/node--az-person--full.html.twig
+++ b/themes/custom/az_barrio/templates/content/node--az-person--full.html.twig
@@ -109,7 +109,7 @@
         {% endif %}
       </div>
     </div>
-    <div class="row">
+    <div class="row mb-5">
       <div class="col-12 col-md-8 order-2">
 
         <div class="d-none d-md-block">


### PR DESCRIPTION
Person, News, Events need some bottom margin on the body so they don't stack directly on top of the footer. 

## Description
I added mb-5 to the row or container/wrapper on each display type or twig.

## Related issues
#1648 directly references this issue, as I spent a little time trying to dig up how to complete Person (it sits in a twig)

## How to test
-Add content to Person, News, and Event. 
-Scroll down to the footer and see if there's adequate spacing between the body content and the footer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
