### PR TITLE
Closes #1569 Disabled honeypot module by default.

### DIFF
--- a/modules/custom/az_security/az_security.info.yml
+++ b/modules/custom/az_security/az_security.info.yml
@@ -5,4 +5,3 @@ core_version_requirement: ^9
 package: The University of Arizona
 dependencies:
   - az_core
-  - honeypot:honeypot


### PR DESCRIPTION
## Description
Disabled honeypot module from being installed by default since it's not used by any forms on a standard AZQS install.

AZQS-provided permissions and settings are still applied properly if Honeypot is manually enabled.

## Related issues
Closes #1569.

## How to test
Install AZQS and check to see that Honeypot module is not enabled.

Tested locally on DDEV.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [x] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
