### PR TITLE
Closes #1607 Enabled WebAuth login link on login form.

### DIFF
--- a/modules/custom/az_cas/az_cas.module
+++ b/modules/custom/az_cas/az_cas.module
@@ -109,7 +109,7 @@ function az_cas_form_user_login_form_alter(&$form, FormStateInterface $form_stat
  * Modify the hook load order.
  */
 function az_cas_module_implements_alter(&$implementations, $hook) {
-  if ($hook == 'form_alter' && isset($implementations['az_cas'])) {
+  if ($hook === 'form_alter' && isset($implementations['az_cas'])) {
 
     // Move az_cas_form_alter() to the end of the list.
     // \Drupal::moduleHandler()->getImplementations()
@@ -121,4 +121,3 @@ function az_cas_module_implements_alter(&$implementations, $hook) {
     $implementations['az_cas'] = $group;
   }
 }
-

--- a/modules/custom/az_cas/az_cas.module
+++ b/modules/custom/az_cas/az_cas.module
@@ -9,6 +9,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\user\RoleInterface;
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_help().
@@ -69,3 +70,55 @@ function az_cas_validate_roles(array &$form, FormStateInterface $form_state) {
     );
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Modify the user login form to put CAS login below Drupal login.
+ */
+function az_cas_form_user_login_form_alter(&$form, FormStateInterface $form_state) {
+  $config = Drupal::config('cas.settings');
+
+  // Cached form must be busted if we alter CAS settings.
+  $form['#cache']['tags'] = array_merge($form['#cache']['tags'], $config->getCacheTags());
+
+  // Add a link to login via CAS on the user login form.
+  $enabled = $config->get('login_link_enabled');
+  if ($enabled) {
+    unset($form['cas_login_link']);
+    $url = new Url('cas.login', [], [
+      'attributes' => [
+        'class' => ['cas-login-link'],
+      ],
+    ]);
+
+    $form['cas_login_link'] = [
+      '#type' => 'link',
+      '#url' => $url,
+      '#title' => $config->get('login_link_label'),
+      '#weight' => 100,
+    ];
+  }
+
+  $form['#validate'][] = '_cas_user_login_validate';
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ *
+ * Modify the hook load order.
+ */
+function az_cas_module_implements_alter(&$implementations, $hook) {
+  if ($hook == 'form_alter' && isset($implementations['az_cas'])) {
+
+    // Move az_cas_form_alter() to the end of the list.
+    // \Drupal::moduleHandler()->getImplementations()
+    // iterates through $implementations with a foreach loop which PHP iterates
+    // in the order that the items were added, so to move an item to the end of
+    // the array, we remove it and then add it.
+    $group = $implementations['az_cas'];
+    unset($implementations['az_cas']);
+    $implementations['az_cas'] = $group;
+  }
+}
+

--- a/modules/custom/az_cas/config/quickstart/cas.settings.yml
+++ b/modules/custom/az_cas/config/quickstart/cas.settings.yml
@@ -1,4 +1,4 @@
-login_link_enabled: false
+login_link_enabled: true
 login_link_label: 'Log in using University of Arizona WebAuth'
 login_success_message: 'Logged in via University of Arizona WebAuth as [cas:username].'
 server:


### PR DESCRIPTION
## Description
Adds the WebAuth login link on the user login form since CAS WebAuth is installed and enabled by default. This change makes it a bit easier for a user to understand how to log in with their NetID when the login form is available, which it is by default.

Optionally, another issue could be created to change the AZ CAS disable_login_form behavior to make /user/login redirect to /cas instead of making it an access denied page. Doing so would better match user expectations and training from the UAQS era and improve the user experience.

## Related issues
Closes #1607.

## How to test
Install AZQS and view the login form at /user or /user/login to see the link "Log in using University of Arizona WebAuth" above the form. The link destination may not work on demo/dev sites since UA's WebAuth limits domain access.

Visual change tested locally on DDEV.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [x] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
