### PR TITLE
Closes #1607, Closes #1678: Change disable_login_form functionality, disable login form by default, add link to webauth to login form.

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -55,6 +55,7 @@ steps:
       - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush user:role:add az_content_editor azuseradmin
       - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush user:role:add az_content_admin azuseradmin
       - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush user:role:add az_user_admin azuseradmin
+      - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush config:set -y az_cas.settings disable_login_form 0
       - chown www-data:www-data -R /var/www/html/sites/default/files
       - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -y -n pm:enable environment_indicator
       - chmod 777 /var/www/html/sites/default/settings.php
@@ -120,5 +121,6 @@ steps:
       - drush -y cset az_migration.settings migrate_d7_protocol "https"
       - drush -y cset az_migration.settings migrate_d7_filebasepath "dev-${MIGRATION_SOURCE_SITE_NAME}.pantheonsite.io/"
       - drush -y cset az_migration.settings migrate_d7_public_path "sites/default/files"
+      - drush -y cset az_cas.settings disable_login_form 0
       - drush mim --group=az_migration
       - echo "https://${BUILD_ID}--site-migration.probo.build/"

--- a/modules/custom/az_cas/az_cas.module
+++ b/modules/custom/az_cas/az_cas.module
@@ -109,7 +109,7 @@ function az_cas_form_user_login_form_alter(&$form, FormStateInterface $form_stat
  * Modify the hook load order.
  */
 function az_cas_module_implements_alter(&$implementations, $hook) {
-  if ($hook == 'form_alter' && isset($implementations['az_cas'])) {
+  if ($hook === 'form_alter' && isset($implementations['az_cas'])) {
 
     // Move az_cas_form_alter() to the end of the list.
     // \Drupal::moduleHandler()->getImplementations()
@@ -121,4 +121,3 @@ function az_cas_module_implements_alter(&$implementations, $hook) {
     $implementations['az_cas'] = $group;
   }
 }
-

--- a/modules/custom/az_cas/az_cas.module
+++ b/modules/custom/az_cas/az_cas.module
@@ -9,6 +9,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\user\RoleInterface;
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_help().
@@ -69,3 +70,55 @@ function az_cas_validate_roles(array &$form, FormStateInterface $form_state) {
     );
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Modify the user login form to put CAS login below Drupal login.
+ */
+function az_cas_form_user_login_form_alter(&$form, FormStateInterface $form_state) {
+  $config = Drupal::config('cas.settings');
+
+  // Cached form must be busted if we alter CAS settings.
+  $form['#cache']['tags'] = array_merge($form['#cache']['tags'], $config->getCacheTags());
+
+  // Add a link to login via CAS on the user login form.
+  $enabled = $config->get('login_link_enabled');
+  if ($enabled) {
+    unset($form['cas_login_link']);
+    $url = new Url('cas.login', [], [
+      'attributes' => [
+        'class' => ['cas-login-link'],
+      ],
+    ]);
+
+    $form['cas_login_link'] = [
+      '#type' => 'link',
+      '#url' => $url,
+      '#title' => $config->get('login_link_label'),
+      '#weight' => 100,
+    ];
+  }
+
+  $form['#validate'][] = '_cas_user_login_validate';
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ *
+ * Modify the hook load order.
+ */
+function az_cas_module_implements_alter(&$implementations, $hook) {
+  if ($hook == 'form_alter' && isset($implementations['az_cas'])) {
+
+    // Move az_cas_form_alter() to the end of the list.
+    // \Drupal::moduleHandler()->getImplementations()
+    // iterates through $implementations with a foreach loop which PHP iterates
+    // in the order that the items were added, so to move an item to the end of
+    // the array, we remove it and then add it.
+    $group = $implementations['az_cas'];
+    unset($implementations['az_cas']);
+    $implementations['az_cas'] = $group;
+  }
+}
+

--- a/modules/custom/az_cas/az_cas.module
+++ b/modules/custom/az_cas/az_cas.module
@@ -77,19 +77,19 @@ function az_cas_validate_roles(array &$form, FormStateInterface $form_state) {
  * Modify the user login form to put CAS login below Drupal login.
  */
 function az_cas_form_user_login_form_alter(&$form, FormStateInterface $form_state) {
-  $config = \Drupal::config('cas.settings');
-  $az_config = \Drupal::config('az_cas.settings');
+  $cas_config = \Drupal::config('cas.settings');
+  $az_cas_config = \Drupal::config('az_cas.settings');
 
   // Cached form must be busted if we alter AZ CAS settings.
-  $form['#cache']['tags'] = array_merge($form['#cache']['tags'], $az_config->getCacheTags());
+  $form['#cache']['tags'] = array_merge($form['#cache']['tags'], $az_cas_config->getCacheTags());
 
   // Add a link to login via CAS on the user login form.
-  $login_link_enabled = $config->get('login_link_enabled');
+  $login_link_enabled = $cas_config->get('login_link_enabled');
   if ($login_link_enabled) {
     $form['cas_login_link']['#weight'] = 100;
   }
 
-  $disable_login_form = $az_config->get('disable_login_form');
+  $disable_login_form = $az_cas_config->get('disable_login_form');
   if ($disable_login_form) {
     $form_elements = ['name', 'pass', 'actions'];
     foreach ($form_elements as $element) {

--- a/modules/custom/az_cas/az_cas.module
+++ b/modules/custom/az_cas/az_cas.module
@@ -77,30 +77,25 @@ function az_cas_validate_roles(array &$form, FormStateInterface $form_state) {
  * Modify the user login form to put CAS login below Drupal login.
  */
 function az_cas_form_user_login_form_alter(&$form, FormStateInterface $form_state) {
-  $config = Drupal::config('cas.settings');
+  $config = \Drupal::config('cas.settings');
+  $az_config = \Drupal::config('az_cas.settings');
 
-  // Cached form must be busted if we alter CAS settings.
-  $form['#cache']['tags'] = array_merge($form['#cache']['tags'], $config->getCacheTags());
+  // Cached form must be busted if we alter AZ CAS settings.
+  $form['#cache']['tags'] = array_merge($form['#cache']['tags'], $az_config->getCacheTags());
 
   // Add a link to login via CAS on the user login form.
-  $enabled = $config->get('login_link_enabled');
-  if ($enabled) {
-    unset($form['cas_login_link']);
-    $url = new Url('cas.login', [], [
-      'attributes' => [
-        'class' => ['cas-login-link'],
-      ],
-    ]);
-
-    $form['cas_login_link'] = [
-      '#type' => 'link',
-      '#url' => $url,
-      '#title' => $config->get('login_link_label'),
-      '#weight' => 100,
-    ];
+  $login_link_enabled = $config->get('login_link_enabled');
+  if ($login_link_enabled) {
+    $form['cas_login_link']['#weight'] = 100;
   }
 
-  $form['#validate'][] = '_cas_user_login_validate';
+  $disable_login_form = $az_config->get('disable_login_form');
+  if ($disable_login_form) {
+    $form_elements = ['name', 'pass', 'actions'];
+    foreach ($form_elements as $element) {
+      $form[$element]['#access'] = FALSE;
+    }
+  }
 }
 
 /**

--- a/modules/custom/az_cas/az_cas.module
+++ b/modules/custom/az_cas/az_cas.module
@@ -83,7 +83,7 @@ function az_cas_form_user_login_form_alter(&$form, FormStateInterface $form_stat
   // Cached form must be busted if we alter AZ CAS settings.
   $form['#cache']['tags'] = array_merge($form['#cache']['tags'], $az_cas_config->getCacheTags());
 
-  // Add a link to login via CAS on the user login form.
+  // Adjust the weight of the CAS login link (if enabled). 
   $login_link_enabled = $cas_config->get('login_link_enabled');
   if ($login_link_enabled) {
     $form['cas_login_link']['#weight'] = 100;

--- a/modules/custom/az_cas/az_cas.module
+++ b/modules/custom/az_cas/az_cas.module
@@ -9,7 +9,6 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\user\RoleInterface;
 use Drupal\Component\Utility\Html;
-use Drupal\Core\Url;
 
 /**
  * Implements hook_help().
@@ -83,7 +82,7 @@ function az_cas_form_user_login_form_alter(&$form, FormStateInterface $form_stat
   // Cached form must be busted if we alter AZ CAS settings.
   $form['#cache']['tags'] = array_merge($form['#cache']['tags'], $az_cas_config->getCacheTags());
 
-  // Adjust the weight of the CAS login link (if enabled). 
+  // Adjust the weight of the CAS login link (if enabled).
   $login_link_enabled = $cas_config->get('login_link_enabled');
   if ($login_link_enabled) {
     $form['cas_login_link']['#weight'] = 100;

--- a/modules/custom/az_cas/config/install/az_cas.settings.yml
+++ b/modules/custom/az_cas/config/install/az_cas.settings.yml
@@ -1,2 +1,2 @@
-disable_login_form: false
+disable_login_form: true
 disable_password_recovery_link: true

--- a/modules/custom/az_cas/config/quickstart/cas.settings.yml
+++ b/modules/custom/az_cas/config/quickstart/cas.settings.yml
@@ -1,4 +1,4 @@
-login_link_enabled: false
+login_link_enabled: true
 login_link_label: 'Log in using University of Arizona WebAuth'
 login_success_message: 'Logged in via University of Arizona WebAuth as [cas:username].'
 server:

--- a/modules/custom/az_cas/src/Routing/AzCasRouteSubscriber.php
+++ b/modules/custom/az_cas/src/Routing/AzCasRouteSubscriber.php
@@ -32,11 +32,6 @@ class AzCasRouteSubscriber extends RouteSubscriberBase {
    * {@inheritdoc}
    */
   protected function alterRoutes(RouteCollection $collection) {
-    if ($this->configFactory->get('az_cas.settings')->get('disable_login_form')) {
-      $collection->get('user.login')->setRequirement('_access', 'FALSE');
-      $collection->get('user.login.http')->setRequirement('_access', 'FALSE');
-    }
-
     if ($this->configFactory->get('az_cas.settings')->get('disable_password_recovery_link')) {
       $collection->get('user.pass')->setRequirement('_access', 'FALSE');
       $collection->get('user.pass.http')->setRequirement('_access', 'FALSE');

--- a/modules/custom/az_cas/tests/src/Functional/AzCasAdminSettingsTest.php
+++ b/modules/custom/az_cas/tests/src/Functional/AzCasAdminSettingsTest.php
@@ -74,12 +74,12 @@ class AzCasAdminSettingsTest extends QuickstartFunctionalTestBase {
     if ($disable_login_form) {
       $this->assertSession()->pageTextNotContains('Username');
       $this->assertSession()->pageTextNotContains('Password');
-      $this->assertSession()->buttonExists('Log in');
+      $this->assertSession()->buttonNotExists('Log in');
     }
     else {
       $this->assertSession()->pageTextContains('Username');
       $this->assertSession()->pageTextContains('Password');
-      $this->assertSession()->buttonNotExists('Log in');
+      $this->assertSession()->buttonExists('Log in');
     }
   }
 

--- a/modules/custom/az_cas/tests/src/Functional/AzCasAdminSettingsTest.php
+++ b/modules/custom/az_cas/tests/src/Functional/AzCasAdminSettingsTest.php
@@ -3,14 +3,14 @@
 namespace Drupal\Tests\az_cas\Functional;
 
 use Drupal\Core\Url;
-use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\az_core\Functional\QuickstartFunctionalTestBase;
 
 /**
  * Tests AZ CAS admin settings form.
  *
  * @group az_cas
  */
-class AzCasAdminSettingsTest extends BrowserTestBase {
+class AzCasAdminSettingsTest extends QuickstartFunctionalTestBase {
 
   /**
    * The profile to install as a basis for testing.

--- a/modules/custom/az_cas/tests/src/Functional/AzCasAdminSettingsTest.php
+++ b/modules/custom/az_cas/tests/src/Functional/AzCasAdminSettingsTest.php
@@ -74,12 +74,12 @@ class AzCasAdminSettingsTest extends QuickstartFunctionalTestBase {
     if ($disable_login_form) {
       $this->assertSession()->pageTextNotContains('Username');
       $this->assertSession()->pageTextNotContains('Password');
-      $this->assertSession()->pageTextNotContains('Log in');
+      $this->assertSession()->buttonExists('Log in');
     }
     else {
       $this->assertSession()->pageTextContains('Username');
       $this->assertSession()->pageTextContains('Password');
-      $this->assertSession()->pageTextContains('Log in');
+      $this->assertSession()->buttonNotExists('Log in');
     }
   }
 

--- a/modules/custom/az_cas/tests/src/Functional/AzCasAdminSettingsTest.php
+++ b/modules/custom/az_cas/tests/src/Functional/AzCasAdminSettingsTest.php
@@ -72,11 +72,13 @@ class AzCasAdminSettingsTest extends QuickstartFunctionalTestBase {
 
     $this->drupalGet('user/login');
     if ($disable_login_form) {
-      $this->assertSession()->pageTextContains('Access denied');
+      $this->assertSession()->pageTextNotContains('Username');
+      $this->assertSession()->pageTextNotContains('Password');
       $this->assertSession()->pageTextNotContains('Log in');
     }
     else {
-      $this->assertSession()->pageTextNotContains('Access denied');
+      $this->assertSession()->pageTextContains('Username');
+      $this->assertSession()->pageTextContains('Password');
       $this->assertSession()->pageTextContains('Log in');
     }
   }

--- a/modules/custom/az_cas/tests/src/Functional/AzCasTest.php
+++ b/modules/custom/az_cas/tests/src/Functional/AzCasTest.php
@@ -3,14 +3,14 @@
 namespace Drupal\Tests\az_cas\Functional;
 
 use Drupal\Core\Url;
-use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\az_core\Functional\QuickstartFunctionalTestBase;
 
 /**
  * Tests for the AZ CAS module.
  *
  * @group az_cas
  */
-class AzCasTest extends BrowserTestBase {
+class AzCasTest extends QuickstartFunctionalTestBase {
 
   /**
    * The profile to install as a basis for testing.

--- a/modules/custom/az_core/tests/src/Functional/ClearCacheTest.php
+++ b/modules/custom/az_core/tests/src/Functional/ClearCacheTest.php
@@ -3,14 +3,13 @@
 namespace Drupal\Tests\az_core\Functional;
 
 use Drupal\Core\Url;
-use Drupal\Tests\BrowserTestBase;
 
 /**
  * Test to ensure the Quickstart settings clear cache button works correctly.
  *
  * @group az_core
  */
-class ClearCacheTest extends BrowserTestBase {
+class ClearCacheTest extends QuickstartFunctionalTestBase {
 
   /**
    * The profile to install as a basis for testing.

--- a/modules/custom/az_core/tests/src/Functional/MonitoringPageTest.php
+++ b/modules/custom/az_core/tests/src/Functional/MonitoringPageTest.php
@@ -3,14 +3,13 @@
 namespace Drupal\Tests\az_core\Functional;
 
 use Drupal\Core\Url;
-use Drupal\Tests\BrowserTestBase;
 
 /**
  * Test to ensure that monitoring page works correctly.
  *
  * @group az_core
  */
-class MonitoringPageTest extends BrowserTestBase {
+class MonitoringPageTest extends QuickstartFunctionalTestBase {
 
   /**
    * The profile to install as a basis for testing.

--- a/modules/custom/az_core/tests/src/Functional/QuickstartFunctionalTestBase.php
+++ b/modules/custom/az_core/tests/src/Functional/QuickstartFunctionalTestBase.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\az_core\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\az_core\Traits\AllowDrupalLoginSetupTrait;
+
+/**
+ * Provides helper methods for Quickstart tests.
+ */
+abstract class QuickstartFunctionalTestBase extends BrowserTestBase {
+  use AllowDrupalLoginSetupTrait;
+
+}

--- a/modules/custom/az_core/tests/src/FunctionalJavascript/QuickstartFunctionalJavascriptTestBase.php
+++ b/modules/custom/az_core/tests/src/FunctionalJavascript/QuickstartFunctionalJavascriptTestBase.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\az_core\FunctionalJavascript;
+
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\Tests\az_core\Traits\AllowDrupalLoginSetupTrait;
+
+/**
+ * Provides helper methods for Quickstart tests.
+ */
+abstract class QuickstartFunctionalJavascriptTestBase extends WebDriverTestBase {
+  use AllowDrupalLoginSetupTrait;
+
+}

--- a/modules/custom/az_core/tests/src/Traits/AllowDrupalLoginSetupTrait.php
+++ b/modules/custom/az_core/tests/src/Traits/AllowDrupalLoginSetupTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\Tests\az_core\Traits;
+
+/**
+ * Turns off az_cas disable_login_form setting.
+ */
+trait AllowDrupalLoginSetupTrait {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Turn off az_cas disable_login_form setting.
+    $config = $this
+      ->config('az_cas.settings');
+    $config
+      ->set('disable_login_form', FALSE)
+      ->save();
+
+    // The menu router info needs to be rebuilt after updating this setting so
+    // the routeSubscriber runs again.
+    $this->container->get('router.builder')->rebuild();
+  }
+
+}

--- a/modules/custom/az_demo/tests/src/Functional/AZDemoContentTest.php
+++ b/modules/custom/az_demo/tests/src/Functional/AZDemoContentTest.php
@@ -3,14 +3,14 @@
 namespace Drupal\Tests\az_demo\Functional;
 
 use Drupal\Core\Url;
-use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\az_core\Functional\QuickstartFunctionalTestBase;
 
 /**
  * Verify successful importing of demo content.
  *
  * @group az_demo
  */
-class AZDemoContentTest extends BrowserTestBase {
+class AZDemoContentTest extends QuickstartFunctionalTestBase {
 
   /**
    * The profile to install as a basis for testing.

--- a/modules/custom/az_paragraphs/az_paragraphs.info.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs.info.yml
@@ -6,6 +6,7 @@ package: 'The University of Arizona'
 dependencies:
   - paragraphs:paragraphs
   - az_card
+  - az_core
   - az_media
   - drupal:text
   - drupal:telephone

--- a/modules/custom/az_paragraphs/tests/src/Functional/AZParagraphsTest.php
+++ b/modules/custom/az_paragraphs/tests/src/Functional/AZParagraphsTest.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\Tests\az_paragraphs\Functional;
 
-use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\az_core\Functional\QuickstartFunctionalTestBase;
 
 /**
  * Run tests of paragraph bundles.
@@ -11,7 +11,7 @@ use Drupal\Tests\BrowserTestBase;
  *
  * @group az_paragraphs
  */
-class AZParagraphsTest extends BrowserTestBase {
+class AZParagraphsTest extends QuickstartFunctionalTestBase {
 
   /**
    * The profile to install as a basis for testing.

--- a/modules/custom/az_paragraphs/tests/src/FunctionalJavascript/AZParagraphsJavascriptTest.php
+++ b/modules/custom/az_paragraphs/tests/src/FunctionalJavascript/AZParagraphsJavascriptTest.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\Tests\az_paragraphs\FunctionalJavascript;
 
-use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+use Drupal\Tests\az_core\FunctionalJavascript\QuickstartFunctionalJavascriptTestBase;
 
 /**
  * Run tests of paragraph bundles.
@@ -11,7 +11,7 @@ use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
  *
  * @group az_paragraphs_js
  */
-class AZParagraphsJavascriptTest extends WebDriverTestBase {
+class AZParagraphsJavascriptTest extends QuickstartFunctionalJavascriptTestBase {
 
   /**
    * The profile to install as a basis for testing.

--- a/themes/custom/az_barrio/az_barrio.info.yml
+++ b/themes/custom/az_barrio/az_barrio.info.yml
@@ -2,6 +2,8 @@ name: Arizona Barrio
 type: theme
 description: 'Basic structure for a Bootstrap Barrio SubTheme.'
 core_version_requirement: ^9
+dependencies:
+  - az_core
 base theme: bootstrap_barrio
 block_default_region: 'content'
 

--- a/themes/custom/az_barrio/tests/src/Functional/AzBarrioTest.php
+++ b/themes/custom/az_barrio/tests/src/Functional/AzBarrioTest.php
@@ -2,14 +2,14 @@
 
 namespace Drupal\Tests\az_barrio\Functional;
 
-use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\az_core\Functional\QuickstartFunctionalTestBase;
 
 /**
  * Tests the Arizona Barrio theme.
  *
  * @group az_barrio
  */
-class AzBarrioTest extends BrowserTestBase {
+class AzBarrioTest extends QuickstartFunctionalTestBase {
 
   /**
    * The profile to install as a basis for testing.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

Alternate PR for addressing both #1607 and #1678 together.  Replaces and combines #1667 and #1679:

- Moved `disable_login_form` implementation from route subscriber to `az_cas_form_user_login_form_alter()` (per suggestions from @trackleft and @joshuasosa). 
- Simplified existing code in `az_cas_form_user_login_form_alter()` (from #1667) to only set the weight of the login link.
- Turn on `disable_login_form` setting by default (from #1679).
- Updates existing tests to prevent failures caused by new default disable_login_form setting (from #1679)
- These needed to be combined because both use `az_cas_form_user_login_form_alter()`.
- Updates existing AZ CAS settings test to work with new `disable_login_form` implementation.

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Closes #1607 
- Closes #1678

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [x] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
