### PR TITLE
Closes #1557: Removed id hash from CSS selector for Search submit button

### DIFF
--- a/themes/custom/az_barrio/css/style.css
+++ b/themes/custom/az_barrio/css/style.css
@@ -399,7 +399,7 @@ padding: 0.625rem .75rem;
   height: 43px;
 }
 
-.search-block-form .input-group-append .az-search-block button {
+.search-block-form .input-group-append button {
   font-size: 20px;
   color: #8B0015;
   background-color: #ffffff;

--- a/themes/custom/az_barrio/templates/forms/form--search-block-form.html.twig
+++ b/themes/custom/az_barrio/templates/forms/form--search-block-form.html.twig
@@ -10,7 +10,7 @@
  * @see template_preprocess_form()
  */
 #}
-<form{{ attributes.addClass('search-form', 'search-block-form', 'az-search-block').removeClass('form-row') }}>
+<form{{ attributes.addClass('search-form', 'search-block-form').removeClass('form-row') }}>
   <div class="input-group">
     {{ children }}
   </div>


### PR DESCRIPTION
## Description
The background color on the search submit button behaves erratically. It appears to depend on the ID (#edit-submit), which can change. So I removed the ID from the selector (.input-group-append button#edit-submit) in the main style.css

## Related issues
Closes #1557 

## How to test
This should impact the applied style each time the search appears in the nav bar. 
- Add a search term to the top search bar, click Submit. 
- Background should be white on initial load, and turn red on hover & click

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
