### PR TITLE
Fixes #1576 Add Course Content Type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,7 @@
         "drupal/smart_date": "3.5.1",
         "drupal/smart_title": "1.0-beta1",
         "drupal/smtp": "1.0",
+        "drupal/time_picker": "5.3.0",
         "drupal/token": "1.10.0",
         "drupal/views_bootstrap": "4.3",
         "drupal/viewsreference": "2.0-beta2",
@@ -154,6 +155,9 @@
             },
             "drupal/media_migration": {
                 "Catch migrate RequirementsExceptions (3268480)": "https://www.drupal.org/files/issues/2022-03-08/3268480-2.patch"
+            },
+            "drupal/migrate_plus": {
+                "XML namespacing issue": "https://www.drupal.org/files/issues/2019-08-22/register_namespaces-2933531-7.patch"
             },
             "drupal/paragraphs": {
                 "Paragraph Migrations broken by archived flag (3268555)": "https://www.drupal.org/files/issues/2022-05-31/3268555-6-workaround.patch"

--- a/modules/custom/az_course/az_course.info.yml
+++ b/modules/custom/az_course/az_course.info.yml
@@ -1,0 +1,26 @@
+name: 'Quickstart Course'
+type: module
+description: 'Imports courses from the schedule of classes service.'
+core_version_requirement: ^8.8 || ^9
+package: 'The University of Arizona'
+dependencies:
+  - auto_entitylabel
+  - comment
+  - datetime_range
+  - field
+  - field_group
+  - image
+  - cas
+  - time_picker
+  - menu_ui
+  - migrate
+  - migrate_plus
+  - migrate_tools
+  - node
+  - path
+  - search
+  - taxonomy
+  - token
+  - text
+  - user
+  - views

--- a/modules/custom/az_course/az_course.info.yml
+++ b/modules/custom/az_course/az_course.info.yml
@@ -5,7 +5,6 @@ core_version_requirement: ^8.8 || ^9
 package: 'The University of Arizona'
 dependencies:
   - auto_entitylabel
-  - comment
   - datetime_range
   - field
   - field_group

--- a/modules/custom/az_course/az_course.links.menu.yml
+++ b/modules/custom/az_course/az_course.links.menu.yml
@@ -1,0 +1,5 @@
+az_course.import_form_link:
+  route_name: az_course.course_import_form
+  parent: system.admin_config_system
+  title: 'Import Courses'
+  description: 'Import courses from The University of Arizona courses API.'

--- a/modules/custom/az_course/az_course.module
+++ b/modules/custom/az_course/az_course.module
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @file
+ * Contains az_course.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Component\Utility\Html;
+
+/**
+ * Implements hook_help().
+ */
+function az_course_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the az_course module.
+    case 'help.page.az_course':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Imports courses from the schedule of classes service.') . '</p>';
+      return $output;
+
+    default:
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function az_course_preprocess_views_view_table(array &$variables) {
+
+  if (isset($variables['view'])) {
+    $view = $variables['view'];
+    if ($view->id() === 'az_courses') {
+      $variables['course_table'] = Html::getUniqueId('course_table');
+    }
+  }
+}
+
+/**
+ * Implements hook_migration_plugins_alter().
+ */
+function az_course_migration_plugins_alter(array &$migrations) {
+
+  if (!empty($migrations['az_courses'])) {
+    $courses = \Drupal::config('az_course.settings')->get('courses');
+    if (!empty($courses)) {
+      $matches = [];
+      $course_urls = [];
+      // Convert courses listed into actual URLs to migrate.
+      foreach ($courses as $course) {
+        if (preg_match("/^[[:space:]]*([[:alpha:]]+)[[:space:]]+([[:alnum:]]+)[[:space:]]*$/", $course, $matches)) {
+          $urls = \Drupal::service('az_course.search')->fetchUrls($matches[1], $matches[2]);
+          foreach ($urls as $url) {
+            $course_urls[] = $url;
+          }
+        }
+        elseif (preg_match("/^[[:space:]]*([[:alpha:]]+)[[:space:]]*$/", $course, $matches)) {
+          $options = \Drupal::service('az_course.search')->fetchOptions($matches[1]);
+          foreach ($options as $o) {
+            $course_urls[] = $o;
+          }
+        }
+      }
+      \Drupal::logger('az_course')->notice(print_r($course_urls, TRUE));
+      if (!empty($migrations['az_courses']['source']) && empty($migrations['az_courses']['source']['urls'])) {
+        $migrations['az_courses']['source']['urls'] = $course_urls;
+      }
+    }
+  }
+}

--- a/modules/custom/az_course/az_course.routing.yml
+++ b/modules/custom/az_course/az_course.routing.yml
@@ -1,0 +1,7 @@
+az_course.course_import_form:
+  path: '/admin/config/az-quickstart/courses'
+  defaults:
+    _form: '\Drupal\az_course\Form\CourseImportForm'
+    _title: 'Import UA Courses'
+  requirements:
+    _permission: 'access administration pages'

--- a/modules/custom/az_course/az_course.services.yml
+++ b/modules/custom/az_course/az_course.services.yml
@@ -1,0 +1,4 @@
+services:
+  az_course.search:
+    class: Drupal\az_course\CourseSearch
+    arguments: ['@http_client']

--- a/modules/custom/az_course/config/install/auto_entitylabel.settings.node.az_course.yml
+++ b/modules/custom/az_course/config/install/auto_entitylabel.settings.node.az_course.yml
@@ -1,0 +1,9 @@
+status: 1
+pattern: '[node:field_az_subject_code] [node:field_az_catalog_number] [node:field_az_course_title]'
+escape: false
+preserve_titles: false
+dependencies:
+  config:
+    - node.type.az_course
+save: 0
+chunk: '50'

--- a/modules/custom/az_course/config/install/az_course.settings.yml
+++ b/modules/custom/az_course/config/install/az_course.settings.yml
@@ -1,0 +1,1 @@
+courses:

--- a/modules/custom/az_course/config/install/core.base_field_override.node.az_course.promote.yml
+++ b/modules/custom/az_course/config/install/core.base_field_override.node.az_course.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.az_course
+id: node.az_course.promote
+field_name: promote
+entity_type: node
+bundle: az_course
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/modules/custom/az_course/config/install/core.entity_form_display.node.az_course.default.yml
+++ b/modules/custom/az_course/config/install/core.entity_form_display.node.az_course.default.yml
@@ -1,0 +1,234 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.az_course.field_az_catalog_number
+    - field.field.node.az_course.field_az_course_attributes
+    - field.field.node.az_course.field_az_course_dates
+    - field.field.node.az_course.field_az_course_days
+    - field.field.node.az_course.field_az_course_description
+    - field.field.node.az_course.field_az_course_instructor
+    - field.field.node.az_course.field_az_course_location
+    - field.field.node.az_course.field_az_course_term
+    - field.field.node.az_course.field_az_course_times
+    - field.field.node.az_course.field_az_course_title
+    - field.field.node.az_course.field_az_course_types
+    - field.field.node.az_course.field_az_course_units
+    - field.field.node.az_course.field_az_enrollment
+    - field.field.node.az_course.field_az_enrollment_cap
+    - field.field.node.az_course.field_az_enrollment_status
+    - field.field.node.az_course.field_az_section_code
+    - field.field.node.az_course.field_az_subject_and_catalog
+    - field.field.node.az_course.field_az_subject_code
+    - node.type.az_course
+  module:
+    - datetime_range
+    - link
+    - path
+    - text
+    - time_picker
+id: node.az_course.default
+targetEntityType: node
+bundle: az_course
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_az_catalog_number:
+    type: string_textfield
+    weight: 123
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_course_attributes:
+    type: entity_reference_autocomplete
+    weight: 136
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_course_dates:
+    type: daterange_default
+    weight: 134
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_az_course_days:
+    type: string_textfield
+    weight: 132
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_course_description:
+    type: text_textarea
+    weight: 121
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_course_instructor:
+    type: link_default
+    weight: 138
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  field_az_course_location:
+    type: string_textfield
+    weight: 126
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_course_term:
+    type: entity_reference_autocomplete
+    weight: 137
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_course_times:
+    type: time_range_picker_widget
+    weight: 133
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_az_course_title:
+    type: string_textfield
+    weight: 122
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_course_types:
+    type: entity_reference_autocomplete
+    weight: 135
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_course_units:
+    type: number
+    weight: 131
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_enrollment:
+    type: number
+    weight: 128
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_enrollment_cap:
+    type: number
+    weight: 129
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_enrollment_status:
+    type: string_textfield
+    weight: 130
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_section_code:
+    type: string_textfield
+    weight: 124
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_subject_and_catalog:
+    type: string_textfield
+    weight: 139
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_az_subject_code:
+    type: string_textfield
+    weight: 125
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 120
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/custom/az_course/config/install/core.entity_view_display.node.az_course.default.yml
+++ b/modules/custom/az_course/config/install/core.entity_view_display.node.az_course.default.yml
@@ -1,0 +1,87 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.az_course.field_az_catalog_number
+    - field.field.node.az_course.field_az_course_attributes
+    - field.field.node.az_course.field_az_course_dates
+    - field.field.node.az_course.field_az_course_days
+    - field.field.node.az_course.field_az_course_description
+    - field.field.node.az_course.field_az_course_instructor
+    - field.field.node.az_course.field_az_course_location
+    - field.field.node.az_course.field_az_course_term
+    - field.field.node.az_course.field_az_course_times
+    - field.field.node.az_course.field_az_course_title
+    - field.field.node.az_course.field_az_course_types
+    - field.field.node.az_course.field_az_course_units
+    - field.field.node.az_course.field_az_enrollment
+    - field.field.node.az_course.field_az_enrollment_cap
+    - field.field.node.az_course.field_az_enrollment_status
+    - field.field.node.az_course.field_az_section_code
+    - field.field.node.az_course.field_az_subject_and_catalog
+    - field.field.node.az_course.field_az_subject_code
+    - node.type.az_course
+  module:
+    - link
+    - text
+    - user
+id: node.az_course.default
+targetEntityType: node
+bundle: az_course
+mode: default
+content:
+  field_az_course_description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_az_course_instructor:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_az_course_location:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_az_section_code:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_az_catalog_number: true
+  field_az_course_attributes: true
+  field_az_course_dates: true
+  field_az_course_days: true
+  field_az_course_term: true
+  field_az_course_times: true
+  field_az_course_title: true
+  field_az_course_types: true
+  field_az_course_units: true
+  field_az_enrollment: true
+  field_az_enrollment_cap: true
+  field_az_enrollment_status: true
+  field_az_subject_and_catalog: true
+  field_az_subject_code: true

--- a/modules/custom/az_course/config/install/core.entity_view_display.node.az_course.teaser.yml
+++ b/modules/custom/az_course/config/install/core.entity_view_display.node.az_course.teaser.yml
@@ -1,0 +1,55 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.az_course.field_az_catalog_number
+    - field.field.node.az_course.field_az_course_attributes
+    - field.field.node.az_course.field_az_course_dates
+    - field.field.node.az_course.field_az_course_days
+    - field.field.node.az_course.field_az_course_description
+    - field.field.node.az_course.field_az_course_instructor
+    - field.field.node.az_course.field_az_course_location
+    - field.field.node.az_course.field_az_course_term
+    - field.field.node.az_course.field_az_course_times
+    - field.field.node.az_course.field_az_course_title
+    - field.field.node.az_course.field_az_course_types
+    - field.field.node.az_course.field_az_course_units
+    - field.field.node.az_course.field_az_enrollment
+    - field.field.node.az_course.field_az_enrollment_cap
+    - field.field.node.az_course.field_az_enrollment_status
+    - field.field.node.az_course.field_az_section_code
+    - field.field.node.az_course.field_az_subject_and_catalog
+    - field.field.node.az_course.field_az_subject_code
+    - node.type.az_course
+  module:
+    - user
+id: node.az_course.teaser
+targetEntityType: node
+bundle: az_course
+mode: teaser
+content:
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_az_catalog_number: true
+  field_az_course_attributes: true
+  field_az_course_dates: true
+  field_az_course_days: true
+  field_az_course_description: true
+  field_az_course_instructor: true
+  field_az_course_location: true
+  field_az_course_term: true
+  field_az_course_times: true
+  field_az_course_title: true
+  field_az_course_types: true
+  field_az_course_units: true
+  field_az_enrollment: true
+  field_az_enrollment_cap: true
+  field_az_enrollment_status: true
+  field_az_section_code: true
+  field_az_subject_and_catalog: true
+  field_az_subject_code: true

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_catalog_number.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_catalog_number.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_catalog_number
+    - node.type.az_course
+id: node.az_course.field_az_catalog_number
+field_name: field_az_catalog_number
+entity_type: node
+bundle: az_course
+label: 'Catalog Number'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_attributes.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_attributes.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_course_attributes
+    - node.type.az_course
+    - taxonomy.vocabulary.az_course_attributes
+id: node.az_course.field_az_course_attributes
+field_name: field_az_course_attributes
+entity_type: node
+bundle: az_course
+label: 'Course Attributes'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      az_course_attributes: az_course_attributes
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_dates.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_dates.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_course_dates
+    - node.type.az_course
+  module:
+    - datetime_range
+id: node.az_course.field_az_course_dates
+field_name: field_az_course_dates
+entity_type: node
+bundle: az_course
+label: 'Course Dates'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: daterange

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_days.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_days.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_course_days
+    - node.type.az_course
+id: node.az_course.field_az_course_days
+field_name: field_az_course_days
+entity_type: node
+bundle: az_course
+label: Days
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_description.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_description.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_course_description
+    - filter.format.az_standard
+    - node.type.az_course
+  module:
+    - text
+id: node.az_course.field_az_course_description
+field_name: field_az_course_description
+entity_type: node
+bundle: az_course
+label: 'Course Description'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  allowed_formats:
+    - az_standard
+field_type: text_long

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_instructor.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_instructor.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_course_instructor
+    - node.type.az_course
+  module:
+    - link
+id: node.az_course.field_az_course_instructor
+field_name: field_az_course_instructor
+entity_type: node
+bundle: az_course
+label: 'Course Instructor'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 1
+  link_type: 17
+field_type: link

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_location.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_location.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_course_location
+    - node.type.az_course
+id: node.az_course.field_az_course_location
+field_name: field_az_course_location
+entity_type: node
+bundle: az_course
+label: 'Course Location'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_term.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_term.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_course_term
+    - node.type.az_course
+    - taxonomy.vocabulary.az_course_terms
+id: node.az_course.field_az_course_term
+field_name: field_az_course_term
+entity_type: node
+bundle: az_course
+label: 'Course Term'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      az_course_terms: az_course_terms
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_times.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_times.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_course_times
+    - node.type.az_course
+  module:
+    - time_picker
+id: node.az_course.field_az_course_times
+field_name: field_az_course_times
+entity_type: node
+bundle: az_course
+label: 'Course Time'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: time_range_picker

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_title.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_course_title
+    - node.type.az_course
+id: node.az_course.field_az_course_title
+field_name: field_az_course_title
+entity_type: node
+bundle: az_course
+label: 'Course TItle'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_types.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_types.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_course_types
+    - node.type.az_course
+    - taxonomy.vocabulary.az_course_types
+id: node.az_course.field_az_course_types
+field_name: field_az_course_types
+entity_type: node
+bundle: az_course
+label: 'Course Types'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      az_course_types: az_course_types
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_units.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_course_units.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_course_units
+    - node.type.az_course
+id: node.az_course.field_az_course_units
+field_name: field_az_course_units
+entity_type: node
+bundle: az_course
+label: Units
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_enrollment.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_enrollment.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_enrollment
+    - node.type.az_course
+id: node.az_course.field_az_enrollment
+field_name: field_az_enrollment
+entity_type: node
+bundle: az_course
+label: Enrollment
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_enrollment_cap.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_enrollment_cap.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_enrollment_cap
+    - node.type.az_course
+id: node.az_course.field_az_enrollment_cap
+field_name: field_az_enrollment_cap
+entity_type: node
+bundle: az_course
+label: 'Enrollment Cap'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_enrollment_status.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_enrollment_status.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_enrollment_status
+    - node.type.az_course
+id: node.az_course.field_az_enrollment_status
+field_name: field_az_enrollment_status
+entity_type: node
+bundle: az_course
+label: 'Enrollment Status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_section_code.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_section_code.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_section_code
+    - node.type.az_course
+id: node.az_course.field_az_section_code
+field_name: field_az_section_code
+entity_type: node
+bundle: az_course
+label: 'Section Code'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_subject_and_catalog.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_subject_and_catalog.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_subject_and_catalog
+    - node.type.az_course
+id: node.az_course.field_az_subject_and_catalog
+field_name: field_az_subject_and_catalog
+entity_type: node
+bundle: az_course
+label: 'Subject and Catalog'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/az_course/config/install/field.field.node.az_course.field_az_subject_code.yml
+++ b/modules/custom/az_course/config/install/field.field.node.az_course.field_az_subject_code.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_subject_code
+    - node.type.az_course
+id: node.az_course.field_az_subject_code
+field_name: field_az_subject_code
+entity_type: node
+bundle: az_course
+label: 'Subject Code'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_catalog_number.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_catalog_number.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_az_catalog_number
+field_name: field_az_catalog_number
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_course_attributes.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_course_attributes.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_az_course_attributes
+field_name: field_az_course_attributes
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_course_dates.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_course_dates.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime_range
+    - node
+id: node.field_az_course_dates
+field_name: field_az_course_dates
+entity_type: node
+type: daterange
+settings:
+  datetime_type: date
+module: datetime_range
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_course_days.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_course_days.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_az_course_days
+field_name: field_az_course_days
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_course_description.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_course_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_az_course_description
+field_name: field_az_course_description
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_course_instructor.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_course_instructor.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_az_course_instructor
+field_name: field_az_course_instructor
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_course_location.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_course_location.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_az_course_location
+field_name: field_az_course_location
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_course_term.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_course_term.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_az_course_term
+field_name: field_az_course_term
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_course_times.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_course_times.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - time_picker
+id: node.field_az_course_times
+field_name: field_az_course_times
+entity_type: node
+type: time_range_picker
+settings:
+  time_picker_theme: theme_default
+  hour_format: 12h
+  is_ascii: false
+  case_sensitive: false
+module: time_picker
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_course_title.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_course_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_az_course_title
+field_name: field_az_course_title
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_course_types.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_course_types.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_az_course_types
+field_name: field_az_course_types
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_course_units.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_course_units.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_az_course_units
+field_name: field_az_course_units
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_enrollment.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_enrollment.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_az_enrollment
+field_name: field_az_enrollment
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_enrollment_cap.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_enrollment_cap.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_az_enrollment_cap
+field_name: field_az_enrollment_cap
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_enrollment_status.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_enrollment_status.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_az_enrollment_status
+field_name: field_az_enrollment_status
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_section_code.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_section_code.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_az_section_code
+field_name: field_az_section_code
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_subject_and_catalog.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_subject_and_catalog.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_az_subject_and_catalog
+field_name: field_az_subject_and_catalog
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/field.storage.node.field_az_subject_code.yml
+++ b/modules/custom/az_course/config/install/field.storage.node.field_az_subject_code.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_az_subject_code
+field_name: field_az_subject_code
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_course/config/install/node.type.az_course.yml
+++ b/modules/custom/az_course/config/install/node.type.az_course.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Course
+type: az_course
+description: 'Contains course information.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false

--- a/modules/custom/az_course/config/install/pathauto.pattern.courses_content_type.yml
+++ b/modules/custom/az_course/config/install/pathauto.pattern.courses_content_type.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: az_course_url_pattern
+label: 'Course Content Type'
+type: 'canonical_entities:node'
+pattern: 'course/[node:title]'
+selection_criteria:
+  a6f9d5af-06ec-416a-96c7-56df1b950d44:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: a6f9d5af-06ec-416a-96c7-56df1b950d44
+    context_mapping:
+      node: node
+    bundles:
+      az_course: az_course
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/modules/custom/az_course/config/install/taxonomy.vocabulary.az_course_attributes.yml
+++ b/modules/custom/az_course/config/install/taxonomy.vocabulary.az_course_attributes.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Course Attributes'
+vid: az_course_attributes
+description: ''
+weight: 0

--- a/modules/custom/az_course/config/install/taxonomy.vocabulary.az_course_terms.yml
+++ b/modules/custom/az_course/config/install/taxonomy.vocabulary.az_course_terms.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Course Terms'
+vid: az_course_terms
+description: ''
+weight: 0

--- a/modules/custom/az_course/config/install/taxonomy.vocabulary.az_course_types.yml
+++ b/modules/custom/az_course/config/install/taxonomy.vocabulary.az_course_types.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Course Types'
+vid: az_course_types
+description: ''
+weight: 0

--- a/modules/custom/az_course/config/install/views.view.az_courses.yml
+++ b/modules/custom/az_course/config/install/views.view.az_courses.yml
@@ -1,0 +1,1359 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_az_catalog_number
+    - field.storage.node.field_az_course_dates
+    - field.storage.node.field_az_course_days
+    - field.storage.node.field_az_course_description
+    - field.storage.node.field_az_course_instructor
+    - field.storage.node.field_az_course_location
+    - field.storage.node.field_az_course_term
+    - field.storage.node.field_az_course_times
+    - field.storage.node.field_az_enrollment
+    - field.storage.node.field_az_enrollment_cap
+    - field.storage.node.field_az_enrollment_status
+    - field.storage.node.field_az_section_code
+    - field.storage.node.field_az_subject_code
+    - node.type.az_course
+  module:
+    - datetime_range
+    - link
+    - node
+    - taxonomy
+    - text
+    - time_picker
+    - user
+id: az_courses
+label: Courses
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'AZ Courses'
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_course_term:
+          id: field_az_course_term
+          table: node__field_az_course_term
+          field: field_az_course_term
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_subject_code:
+          id: field_az_subject_code
+          table: node__field_az_subject_code
+          field: field_az_subject_code
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_catalog_number:
+          id: field_az_catalog_number
+          table: node__field_az_catalog_number
+          field: field_az_catalog_number
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_section_code:
+          id: field_az_section_code
+          table: node__field_az_section_code
+          field: field_az_section_code
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_course_days:
+          id: field_az_course_days
+          table: node__field_az_course_days
+          field: field_az_course_days
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_course_location:
+          id: field_az_course_location
+          table: node__field_az_course_location
+          field: field_az_course_location
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_course_times:
+          id: field_az_course_times
+          table: node__field_az_course_times
+          field: field_az_course_times
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: start
+          type: time_range_picker_formatter
+          settings: {  }
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_course_dates:
+          id: field_az_course_dates
+          table: node__field_az_course_dates
+          field: field_az_course_dates
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: daterange_custom
+          settings:
+            timezone_override: ''
+            date_format: n/j/Y
+            separator: '-'
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 1
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_course_instructor:
+          id: field_az_course_instructor
+          table: node__field_az_course_instructor
+          field: field_az_course_instructor
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_course_description:
+          id: field_az_course_description
+          table: node__field_az_course_description
+          field: field_az_course_description
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_enrollment_status:
+          id: field_az_enrollment_status
+          table: node__field_az_enrollment_status
+          field: field_az_enrollment_status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_enrollment:
+          id: field_az_enrollment
+          table: node__field_az_enrollment
+          field: field_az_enrollment
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_az_enrollment_cap:
+          id: field_az_enrollment_cap
+          table: node__field_az_enrollment_cap
+          field: field_az_enrollment_cap
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ field_az_enrollment }}/{{ field_az_enrollment_cap }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: "<h5 class=\"card-title mt-0\">{{ title }}</h5>\r\n<p>{{ field_az_course_description }}</p>"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 0
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        field_az_subject_code_value:
+          id: field_az_subject_code_value
+          table: node__field_az_subject_code
+          field: field_az_subject_code_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        field_az_catalog_number_value:
+          id: field_az_catalog_number_value
+          table: node__field_az_catalog_number
+          field: field_az_catalog_number_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        weight:
+          id: weight
+          table: taxonomy_term_field_data
+          field: weight
+          relationship: field_az_course_term
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: weight
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        field_az_section_code_value:
+          id: field_az_section_code_value
+          table: node__field_az_section_code
+          field: field_az_section_code_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments:
+        field_az_subject_code_value:
+          id: field_az_subject_code_value
+          table: node__field_az_subject_code
+          field: field_az_subject_code_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: true
+        field_az_subject_and_catalog_value:
+          id: field_az_subject_and_catalog_value
+          table: node__field_az_subject_and_catalog
+          field: field_az_subject_and_catalog_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: true
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            az_course: az_course
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: table
+        options:
+          grouping:
+            -
+              field: nothing
+              rendered: true
+              rendered_strip: false
+          row_class: ''
+          default_row_class: true
+          columns:
+            field_az_course_term: field_az_course_term
+            field_az_subject_code: field_az_subject_code
+            field_az_catalog_number: field_az_catalog_number
+            field_az_section_code: field_az_section_code
+            field_az_course_days: field_az_course_days
+            field_az_course_location: field_az_course_location
+            field_az_course_times: field_az_course_times
+            field_az_course_dates: field_az_course_dates
+            field_az_course_instructor: field_az_course_instructor
+            field_az_course_description: field_az_course_description
+            field_az_enrollment_status: field_az_enrollment_status
+            nothing: nothing
+          default: '-1'
+          info:
+            field_az_course_term:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_az_subject_code:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_az_catalog_number:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_az_section_code:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_az_course_days:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_az_course_location:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_az_course_times:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_az_course_dates:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_az_course_instructor:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_az_course_description:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_az_enrollment_status:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            nothing:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: false
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        field_az_course_term:
+          id: field_az_course_term
+          table: node__field_az_course_term
+          field: field_az_course_term
+          relationship: none
+          group_type: group
+          admin_label: 'field_az_course_term: Taxonomy term'
+          plugin_id: standard
+          required: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_az_catalog_number'
+        - 'config:field.storage.node.field_az_course_dates'
+        - 'config:field.storage.node.field_az_course_days'
+        - 'config:field.storage.node.field_az_course_description'
+        - 'config:field.storage.node.field_az_course_instructor'
+        - 'config:field.storage.node.field_az_course_location'
+        - 'config:field.storage.node.field_az_course_term'
+        - 'config:field.storage.node.field_az_course_times'
+        - 'config:field.storage.node.field_az_enrollment'
+        - 'config:field.storage.node.field_az_enrollment_cap'
+        - 'config:field.storage.node.field_az_enrollment_status'
+        - 'config:field.storage.node.field_az_section_code'
+        - 'config:field.storage.node.field_az_subject_code'
+  page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: courses
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_az_catalog_number'
+        - 'config:field.storage.node.field_az_course_dates'
+        - 'config:field.storage.node.field_az_course_days'
+        - 'config:field.storage.node.field_az_course_description'
+        - 'config:field.storage.node.field_az_course_instructor'
+        - 'config:field.storage.node.field_az_course_location'
+        - 'config:field.storage.node.field_az_course_term'
+        - 'config:field.storage.node.field_az_course_times'
+        - 'config:field.storage.node.field_az_enrollment'
+        - 'config:field.storage.node.field_az_enrollment_cap'
+        - 'config:field.storage.node.field_az_enrollment_status'
+        - 'config:field.storage.node.field_az_section_code'
+        - 'config:field.storage.node.field_az_subject_code'

--- a/modules/custom/az_course/migrations/az_courses.yml
+++ b/modules/custom/az_course/migrations/az_courses.yml
@@ -109,6 +109,11 @@ process:
   field_az_course_description/value: description
   field_az_subject_code: subject_code
   field_az_catalog_number: catalog_number
+  field_az_subject_and_catalog:
+    plugin: concat
+    source:
+      - subject_code
+      - catalog_number
   field_az_section_code: section_code
   field_az_course_location: locations
   field_az_course_instructor:

--- a/modules/custom/az_course/migrations/az_courses.yml
+++ b/modules/custom/az_course/migrations/az_courses.yml
@@ -1,0 +1,206 @@
+id: az_courses
+label: Courses
+migration_tags:
+  - Courses
+source:
+  plugin: url
+  data_fetcher_plugin: retry_http
+  data_parser_plugin: simple_xml
+  skip_count: True
+  namespaces:
+    n: "http://uamobile.arizona.edu/schema/UA_Courses"
+    ns1: "http://uamobile.arizona.edu/schema/UA_Courses"
+  constants:
+    space: ' '
+  urls: [ ]
+  item_selector: '//*[local-name()="CourseDetail"]'
+  fields:
+     -
+      name: class_number
+      label: Class Number
+      selector: ns1:class_nbr
+     -
+      name: title
+      label: Title
+      selector: ns1:title
+     -
+      name: description
+      label: Description
+      selector: ns1:descrLong
+     -
+      name: subject_code
+      label: Subject Code
+      selector: ns1:subject_code
+     -
+      name: section_code
+      label: Section Code
+      selector: ns1:section
+     -
+      name: catalog_number
+      label: Catalog Number
+      selector: ns1:catalog_nbr
+     -
+      name: course_type
+      label: Course Type
+      selector: ns1:course_type_descr
+     -
+      name: enrollment_current
+      label: Enrollment Current
+      selector: ns1:enroll_cur
+     -
+      name: enrollment_cap
+      label: Enrollment Cap
+      selector: ns1:enroll_cap
+     -
+      name: enrollment_status
+      label: Enrollment Status
+      selector: ns1:enroll_stat_descr
+     -
+      name: course_attributes
+      label: Course Attributes
+      selector: ns1:CourseAttrPropsCollection/ns1:CourseAttrProps/ns1:course_attr_value_descr_formal
+     -
+      name: locations
+      label: Locations
+      selector: ns1:MeetingCollection/ns1:Meeting/ns1:location
+     -
+      name: instructors
+      label: Instructors
+      selector: ns1:MeetingCollection/ns1:Meeting/ns1:InstructorCollection/ns1:Instructor/ns1:netid
+     -
+      name: days
+      label: Days of the Week
+      selector: ns1:MeetingCollection/ns1:Meeting/ns1:days_of_week
+     -
+      name: start_time
+      label: Start Time
+      selector: ns1:MeetingCollection/ns1:Meeting/ns1:start_time
+     -
+      name: end_time
+      label: End Time
+      selector: ns1:MeetingCollection/ns1:Meeting/ns1:end_time
+     -
+      name: start_date
+      label: Start Date
+      selector: ns1:MeetingCollection/ns1:Meeting/ns1:start_date
+     -
+      name: end_date
+      label: End Date
+      selector: ns1:MeetingCollection/ns1:Meeting/ns1:end_date
+     -
+      name: units
+      label: Units
+      selector: ns1:units
+     -
+      name: term_code
+      label: Term Code
+      selector: ../ns1:term_code
+  ids:
+    subject_code:
+      type: string
+    catalog_number:
+      type: string
+    section_code:
+      type: string
+    term_code:
+      type: string
+process:
+  field_az_course_title: title
+  field_az_course_description/value: description
+  field_az_subject_code: subject_code
+  field_az_catalog_number: catalog_number
+  field_az_section_code: section_code
+  field_az_course_location: locations
+  field_az_course_instructor:
+    source: instructors
+    plugin: instructor_link
+  field_az_course_type:
+    plugin: entity_generate
+    source: course_type
+    entity_type: taxonomy_term
+    bundle_key: vid
+    bundle: az_course_types
+    value_key: name
+    ignore_case: true
+  field_az_course_attributes:
+    plugin: entity_generate
+    source: course_attributes
+    entity_type: taxonomy_term
+    bundle_key: vid
+    bundle: az_course_attributes
+    value_key: name
+    ignore_case: true
+  field_az_course_term:
+    -
+      plugin: peoplesoft_year
+      source: term_code
+    -
+      plugin: entity_generate
+      entity_type: taxonomy_term
+      bundle_key: vid
+      bundle: az_course_terms
+      value_key: name
+      ignore_case: true
+  field_az_enrollment: enrollment_current
+  field_az_enrollment_cap: enrollment_cap
+  field_az_enrollment_status: enrollment_status
+  field_az_course_units: units
+  field_az_course_days: days
+  field_az_course_times:
+    -
+      plugin: course_transpose
+      source:
+        - start_time
+        - end_time
+    -
+      plugin: sub_process
+      process:
+        start:
+          plugin: extract
+          source:
+            - 0
+          index:
+            - 0
+        end:
+          plugin: extract
+          source:
+            - 1
+          index:
+            - 0
+  field_az_course_dates:
+    -
+      plugin: course_transpose
+      source:
+        - start_date
+        - end_date
+    -
+      plugin: sub_process
+      process:
+        value:
+          -
+            plugin: extract
+            source:
+              - 0
+            index:
+              - 0
+          -
+            plugin: format_date
+            from_format: 'm/d/Y'
+            to_format: 'Y-m-d'
+        end_value:
+          -
+            plugin: extract
+            source:
+              - 1
+            index:
+              - 0
+          -
+            plugin: format_date
+            from_format: 'm/d/Y'
+            to_format: 'Y-m-d'
+
+
+destination:
+  plugin: entity:node
+  default_bundle: az_course
+migration_dependencies:

--- a/modules/custom/az_course/src/CourseSearch.php
+++ b/modules/custom/az_course/src/CourseSearch.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Drupal\az_course;
+
+use GuzzleHttp\ClientInterface;
+use Drupal\Core\Url;
+use GuzzleHttp\Exception\RequestException;
+
+/**
+ * Contructs URLs for Courses API and performs subject-wide queries.
+ */
+class CourseSearch {
+
+  /**
+   * GuzzleHttp\ClientInterface definition.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected $httpClient;
+
+  /**
+   * The source URLs to retrieve.
+   *
+   * @var string
+   */
+  protected $courseDetailsUrl = "https://uacourses-api.uaccess.arizona.edu/crsdetail";
+
+  /**
+   * Constructs a CourseSearch service.
+   *
+   * @param GuzzleHttp\ClientInterface $http_client
+   *   A guzzle client for making http requests.
+   */
+  public function __construct(ClientInterface $http_client) {
+    $this->httpClient = $http_client;
+  }
+
+  /**
+   * Generate a URL for a known subject code and catalog number.
+   *
+   * @param string $subject
+   *   A subject code, e.g. MATH.
+   * @param string $catalog
+   *   A catalog number, e.g. 101.
+   *
+   * @return array
+   *   An array of urls to migrate.
+   */
+  public function fetchUrls($subject, $catalog) {
+
+    $urls = [];
+    $queryUrl = Url::fromUri($this->courseDetailsUrl, [
+      'query' => [
+        'subject_code' => strtoupper($subject),
+        'catalog_nbr' => strtoupper($catalog),
+      ],
+    ]);
+    $urls[] = $queryUrl->toString();
+
+    return $urls;
+  }
+
+  /**
+   * Find service URL options for a search string, typically a subject code..
+   *
+   * @param string $search
+   *   A search string, typically a subject code, e.g. MATH.
+   *
+   * @return array
+   *   An array of urls to migrate.
+   */
+  public function fetchOptions($search) {
+    $options = [];
+    $items = [];
+    $itemSelector = 'ns1:Course';
+    $subjectSelector = 'ns1:subject_code';
+    $catalogSelector = 'ns1:catalog_nbr';
+    $descriptionSelector = 'ns1:descr';
+
+    $search = strtoupper($search);
+    $queryUrl = Url::fromUri('https://uacourses-api.uaccess.arizona.edu/search', ['query' => ['search_text' => $search]]);
+    $queryUrl = $queryUrl->toString();
+    try {
+      $response = $this->httpClient->get($queryUrl);
+      if (empty($response)) {
+        \Drupal::logger('az_course')->error("No response.");
+      }
+      $body = $response->getBody();
+      $xml = new \XMLReader();
+      if ($xml->xml($body)) {
+        $item = [];
+        while ($xml->read()) {
+          if ($xml->nodeType === \XMLReader::ELEMENT) {
+            if ($xml->name === $itemSelector) {
+              $item = [];
+            }
+            if ($xml->name === $subjectSelector) {
+              $item['subject'] = $xml->readInnerXML();
+            }
+            if ($xml->name === $catalogSelector) {
+              $item['catalog'] = $xml->readInnerXML();
+            }
+            if ($xml->name === $descriptionSelector) {
+              $item['description'] = $xml->readInnerXML();
+            }
+          }
+          if ($xml->nodeType === \XMLReader::END_ELEMENT) {
+            if ($xml->name === $itemSelector) {
+              $items[] = $item;
+            }
+          }
+        }
+        $xml->close();
+      }
+    }
+    catch (RequestException $e) {
+      \Drupal::logger('az_course')->error("Request exception.");
+    }
+
+    foreach ($items as $item) {
+      if (!empty($item['subject']) && !empty($item['catalog']) && !empty($item['description'])) {
+        $queryUrl = Url::fromUri($this->courseDetailsUrl, [
+          'query' => [
+            'subject_code' => strtoupper($item['subject']),
+            'catalog_nbr' => strtoupper($item['catalog']),
+          ],
+        ]
+        );
+        $options[] = $queryUrl->toString();
+      }
+    }
+
+    return $options;
+  }
+
+}

--- a/modules/custom/az_course/src/Form/CourseImportForm.php
+++ b/modules/custom/az_course/src/Form/CourseImportForm.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Drupal\az_course\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\MigrateMessage;
+use Drupal\migrate\MigrateExecutable;
+use Drupal\migrate_tools\MigrateBatchExecutable;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class CourseImportForm to compute course links.
+ */
+class CourseImportForm extends ConfigFormBase {
+
+  /**
+   * Drupal\Core\Config\ConfigFactoryInterface definition.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Drupal\migrate\Plugin\MigrationPluginManagerInterface definition.
+   *
+   * @var \Drupal\migrate\Plugin\MigrationPluginManagerInterface
+   */
+  protected $pluginManagerMigration;
+
+  /**
+   * The cron service.
+   *
+   * @var \Drupal\Core\CronInterface
+   */
+  protected $cron;
+
+  /**
+   * The course search service.
+   *
+   * @var \Drupal\az_course\CourseSearch
+   */
+  protected $courseSearch;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $instance = parent::create($container);
+    $instance->configFactory = $container->get('config.factory');
+    $instance->pluginManagerMigration = $container->get('plugin.manager.migration');
+    $instance->courseSearch = $container->get('az_course.search');
+    $instance->cron = $container->get('cron');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'az_course.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'course_import_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+
+    $config = $this->config('az_course.settings');
+    $default = "";
+    if (!empty($config->get('courses'))) {
+      $default = implode("\n", $config->get('courses'));
+    }
+
+    $form['courses'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Courses to Import'),
+      '#description' => $this->t('Courses will be imported when Cron is run. List courses to import, one per line, in format e.g. "ENGL 101"'),
+      '#required' => FALSE,
+      '#default_value' => $default,
+      '#resizable' => 'vertical',
+      '#rows' => 10,
+      '#weight' => '2',
+    ];
+
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save Course List'),
+      '#button_type' => 'primary',
+      '#weight' => '3',
+    ];
+
+    $form['run'] = [
+      '#type' => 'submit',
+      '#value' => t('Import Courses'),
+      '#submit' => ['::runMigrate'],
+      '#weight' => '4',
+    ];
+
+    $form['rollback'] = [
+      '#type' => 'submit',
+      '#value' => t('Rollback'),
+      '#submit' => ['::rollback'],
+      '#weight' => '5',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+
+    $courses = $form_state->getValue('courses');
+
+    $courses = preg_split("/[\n\r]+/", $courses);
+    if ($courses === FALSE) {
+      $form_state->setErrorByName('courses', t('Enter search terms to locate a course to import.'));
+    }
+    else {
+      foreach ($courses as $course) {
+        if (empty($course)) {
+        }
+        elseif (preg_match("/^[[:space:]]*[[:alpha:]]+[[:space:]]+[[:alnum:]]+[[:space:]]*$/", $course)) {
+        }
+        elseif (preg_match("/^[[:space:]]*[[:alpha:]]+[[:space:]]*$/", $course)) {
+        }
+        else {
+          $form_state->setErrorByName('courses', t('Use format "MATH 123 or MATH" for courses.'));
+        }
+      }
+    }
+
+    parent::validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    $courses = $form_state->getValue('courses');
+    $courses = preg_split("/[\n\r]+/", $courses);
+
+    $this->config('az_course.settings')
+      ->set('courses', $courses)
+      ->save();
+
+    drupal_flush_all_caches();
+    $this->messenger()->addStatus($this->t('Updated Course Settings.'));
+  }
+
+  /**
+   * Form submission handler for running migration manually.
+   */
+  public function runMigrate(array &$form, FormStateInterface $form_state) {
+
+    $migration = $this->pluginManagerMigration->createInstance("az_courses");
+    if (!empty($migration)) {
+      $options = [
+        'limit' => 0,
+        'update' => 1,
+        'force' => 0,
+      ];
+      $executable = new MigrateBatchExecutable($migration, new MigrateMessage(), $options);
+      $executable->batchImport();
+    }
+  }
+
+  /**
+   * Form submission handler for running rollback.
+   */
+  public function rollback(array &$form, FormStateInterface $form_state) {
+
+    $migration = $this->pluginManagerMigration->createInstance('az_courses');
+
+    // Reset status.
+    $status = $migration->getStatus();
+    if ($status !== MigrationInterface::STATUS_IDLE) {
+      $migration->setStatus(MigrationInterface::STATUS_IDLE);
+    }
+
+    $executable = new MigrateExecutable($migration, new MigrateMessage());
+    $result = $executable->rollback();
+
+    if ($result === MigrationInterface::RESULT_COMPLETED) {
+      $this->messenger()->addStatus($this->t('Rolled back imported courses.'));
+    }
+    else {
+      $this->messenger()->addError($this->t('Failed to roll back imported courses.'));
+    }
+  }
+
+}

--- a/modules/custom/az_course/src/Form/CourseImportForm.php
+++ b/modules/custom/az_course/src/Form/CourseImportForm.php
@@ -85,7 +85,7 @@ class CourseImportForm extends ConfigFormBase {
     $form['courses'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Courses to Import'),
-      '#description' => $this->t('Courses will be imported when Cron is run. List courses to import, one per line, in format e.g. "ENGL 101"'),
+      '#description' => $this->t('Courses will be imported when az_courses migration is run. List courses to import, one per line, in format "ENGL 101" or "ENGL" for entire subject.'),
       '#required' => FALSE,
       '#default_value' => $default,
       '#resizable' => 'vertical',

--- a/modules/custom/az_course/src/Plugin/migrate/process/CourseTranspose.php
+++ b/modules/custom/az_course/src/Plugin/migrate/process/CourseTranspose.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\az_course\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+use Drupal\migrate\ProcessPluginBase;
+
+/**
+ *
+ * @MigrateProcessPlugin(
+ *   id = "course_transpose"
+ * )
+ */
+class CourseTranspose extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($table, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    // Make sure that $table is an array of arrays.
+    if (!is_array($table) || $table === []) {
+      return [];
+    }
+    foreach ($table as &$value) {
+      $value = (array) $value;
+    }
+
+    return array_map(NULL, ...$table);
+  }
+
+}

--- a/modules/custom/az_course/src/Plugin/migrate/process/InstructorLink.php
+++ b/modules/custom/az_course/src/Plugin/migrate/process/InstructorLink.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\az_course\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * Returns a link to a user, or a non-link.
+ *
+ * @see \Drupal\migrate\Plugin\MigrateProcessInterface
+ *
+ * @MigrateProcessPlugin(
+ *   id = "instructor_link",
+ * )
+ */
+class InstructorLink extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+
+    $nolink = ['uri' => 'route:<nolink>', 'title' => $value];
+
+    // Placeholder. Check for presence of instructor when field is available
+    // to create a link to faculty pages.
+    if ($value === 'netid-not-found') {
+      $nolink['title'] = 'unassigned';
+    }
+
+    return $nolink;
+  }
+
+}

--- a/modules/custom/az_course/src/Plugin/migrate/process/PeopleSoftYear.php
+++ b/modules/custom/az_course/src/Plugin/migrate/process/PeopleSoftYear.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\az_course\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * Tranforms a PeopleSoft year code into a text term name.
+ *
+ * @see \Drupal\migrate\Plugin\MigrateProcessInterface
+ *
+ * @MigrateProcessPlugin(
+ *   id = "peoplesoft_year",
+ * )
+ */
+class PeopleSoftYear extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+
+    // PeopleSoft uses CYYT, century, year year, term code.
+    // Summer II is no longer used.
+    $terms = [
+      '1' => 'Spring ',
+      '2' => 'Summer ',
+      '3' => 'Summer II ',
+      '4' => 'Fall ',
+      '5' => 'Winter ',
+    ];
+
+    $matches = [];
+    if (preg_match('/^(\d)(\d\d)(\d)$/', $value, $matches)) {
+      // Start with century.
+      $year = 1800 + ((int) $matches[1] * 100);
+      // Years.
+      $year += (int) $matches[2];
+      $code = (string) $matches[3];
+      $year = (string) $year;
+      // Term code.
+      if (!empty($terms[$code])) {
+        $year = $terms[$code] . $year;
+      }
+      $value = $year;
+    }
+
+    return $value;
+  }
+
+}

--- a/modules/custom/az_course/src/Plugin/migrate_plus/data_fetcher/RetryHttp.php
+++ b/modules/custom/az_course/src/Plugin/migrate_plus/data_fetcher/RetryHttp.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\az_course\Plugin\migrate_plus\data_fetcher;
+
+use Drupal\migrate_plus\Plugin\migrate_plus\data_fetcher\Http;
+use Drupal\migrate\MigrateException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
+
+/**
+ * Retrieve data over an HTTP connection for migration. Retry if necessary.
+ *
+ * Example:
+ *
+ * @code
+ * source:
+ *   plugin: url
+ *   data_fetcher_plugin: az_retry_http
+ *   headers:
+ *     Accept: application/json
+ *     User-Agent: Internet Explorer 6
+ *     Authorization-Key: secret
+ *     Arbitrary-Header: foobarbaz
+ * @endcode
+ *
+ * @DataFetcher(
+ *   id = "retry_http",
+ *   title = @Translation("AZ Retry HTTP")
+ * )
+ */
+class RetryHttp extends Http {
+
+  const MAX_REQUESTS = 5;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getResponse($url) {
+    // Schedule sometimes returns 500 during outages.
+    for ($i = 0; $i < self::MAX_REQUESTS; $i++) {
+      try {
+        $options = ['headers' => $this->getRequestHeaders()];
+        if (!empty($this->configuration['authentication'])) {
+          $options = array_merge($options, $this->getAuthenticationPlugin()->getAuthenticationOptions());
+        }
+        if (!empty($this->configuration['request_options'])) {
+          $options = array_merge($options, $this->configuration['request_options']);
+        }
+        $response = $this->httpClient->get($url, $options);
+        if (empty($response)) {
+          throw new MigrateException('No response at ' . $url . '.');
+        }
+        return $response;
+      }
+      catch (RequestException $e) {
+      }
+      catch (ClientException $e) {
+      }
+      catch (ServerException $e) {
+      }
+
+      sleep(1);
+    }
+    throw new MigrateException('No response at ' . $url . '.');
+  }
+
+}

--- a/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_view_reference.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_view/config/install/field.field.paragraph.az_view_reference.field_az_view_reference.yml
@@ -28,6 +28,7 @@ settings:
     attachment: 0
     feed: 0
   preselect_views:
+    az_courses: az_courses
     az_events: az_events
     az_news: az_news
     az_page_by_category: az_page_by_category

--- a/themes/custom/az_barrio/templates/views/views-view-table--az-courses.html.twig
+++ b/themes/custom/az_barrio/templates/views/views-view-table--az-courses.html.twig
@@ -1,0 +1,124 @@
+{#
+/**
+ * @file
+ * Theme override for displaying a view as a table.
+ *
+ * Available variables:
+ * - attributes: Remaining HTML attributes for the element.
+ *   - class: HTML classes that can be used to style contextually through CSS.
+ * - title : The title of this group of rows.
+ * - header: The table header columns.
+ *   - attributes: Remaining HTML attributes for the element.
+ *   - content: HTML classes to apply to each header cell, indexed by
+ *   the header's key.
+ *   - default_classes: A flag indicating whether default classes should be
+ *     used.
+ * - caption_needed: Is the caption tag needed.
+ * - caption: The caption for this table.
+ * - accessibility_description: Extended description for the table details.
+ * - accessibility_summary: Summary for the table details.
+ * - rows: Table row items. Rows are keyed by row number.
+ *   - attributes: HTML classes to apply to each row.
+ *   - columns: Row column items. Columns are keyed by column number.
+ *     - attributes: HTML classes to apply to each column.
+ *     - content: The column content.
+ *   - default_classes: A flag indicating whether default classes should be
+ *     used.
+ * - responsive: A flag indicating whether table is responsive.
+ * - sticky: A flag indicating whether table header is sticky.
+ *
+ * @see template_preprocess_views_view_table()
+ */
+#}
+{%
+  set classes = [
+    'table',
+    hover ? 'table-hover',
+    table_class,
+    'mt-4',
+    'table-striped',
+    'views-table',
+    'views-view-table',
+    'cols-' ~ header|length,
+    responsive ? 'responsive-enabled',
+    sticky ? 'sticky-enabled',
+  ]
+%}
+<div class="card mb-4">
+  <div class="card-body">
+  {% if caption %}
+    {{ caption }}
+  {% endif %}
+  <div class="az-course-button text-right">
+    <button type="button" class="btn btn-red btn-sm" data-toggle="collapse" data-target="#{{ course_table }}">Sections</button>
+  </div>
+    <div id={{ course_table }} class="table-responsive col collapse">
+    <table{{ attributes.addClass(classes) }}>
+      {% if header %}
+        <thead class='{{ thead_class }}'>
+          <tr>
+            {% for key, column in header %}
+              {% if column.default_classes %}
+                {%
+                  set column_classes = [
+                    'views-field',
+                    'views-field-' ~ fields[key],
+                  ]
+                %}
+              {% endif %}
+              <th{{ column.attributes.addClass(column_classes).setAttribute('scope', 'col') }}>
+                {%- if column.wrapper_element -%}
+                  <{{ column.wrapper_element }}>
+                    {%- if column.url -%}
+                      <a href="{{ column.url }}" title="{{ column.title }}">{{ column.content }}{{ column.sort_indicator }}</a>
+                    {%- else -%}
+                      {{ column.content }}{{ column.sort_indicator }}
+                    {%- endif -%}
+                  </{{ column.wrapper_element }}>
+                {%- else -%}
+                  {%- if column.url -%}
+                    <a href="{{ column.url }}" title="{{ column.title }}">{{ column.content }}{{ column.sort_indicator }}</a>
+                  {%- else -%}
+                    {{- column.content }}{{ column.sort_indicator }}
+                  {%- endif -%}
+                {%- endif -%}
+              </th>
+            {% endfor %}
+          </tr>
+        </thead>
+      {% endif %}
+      <tbody>
+        {% for row in rows %}
+          <tr{{ row.attributes }}>
+            {% for key, column in row.columns %}
+              {% if column.default_classes %}
+                {%
+                  set column_classes = [
+                    'views-field'
+                  ]
+                %}
+                {% for field in column.fields %}
+                  {% set column_classes = column_classes|merge(['views-field-' ~ field]) %}
+                {% endfor %}
+              {% endif %}
+              <td{{ column.attributes.addClass(column_classes) }}>
+                {%- if column.wrapper_element -%}
+                  <{{ column.wrapper_element }}>
+                  {% for content in column.content %}
+                    {{ content.separator }}{{ content.field_output }}
+                  {% endfor %}
+                  </{{ column.wrapper_element }}>
+                {%- else -%}
+                  {% for content in column.content %}
+                    {{- content.separator }}{{ content.field_output -}}
+                  {% endfor %}
+                {%- endif %}
+              </td>
+            {% endfor %}
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION


## Description
This PR provides a content type, view and migration path to migrate from the schedule of classes webservice.

## Related issues
#1576
#366

## How to test

- enable `az_course` module
- visit `/admin/config/az-quickstart/courses` as an administrator
- add a subject code or course to import to the text area
- e.g. `FCSC` or `FCSC 120`
- run drush migration `drush mim az_course --update`
- visit `/courses`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [x] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [x] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [x] Patch or minor level update
   - [x] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
