### PR TITLE
#1703 2.4.x release preparations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.4.x-dev"
+            "dev-main": "2.5.x-dev"
         },
         "patches": {
             "drupal/antibot": {


### PR DESCRIPTION
We need to change the composer branch alias for dev-main to now be 2.5.x-dev since main will effectively be 2.5.x once we release 2.4.0-beta1.

This should be merged after any remaining PRs that we still want to include in the 2.4.0-beta1 release.

This change should also be back-ported to the 2.3.x branch