### PR TITLE
Closes #1697: Fix JS error when Text with Background, Text on Media are not full-width

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
@@ -25,7 +25,6 @@ az_paragraphs.az_text_background:
     - az_barrio/global-styling
     - az_barrio/arizona-bootstrap
     - az_barrio/button-no-conflict
-    - az_paragraphs/az_paragraphs.az_paragraphs_full_width
 az_paragraphs.az_text_media:
   version: VERSION
   css:
@@ -35,7 +34,6 @@ az_paragraphs.az_text_media:
     - az_barrio/global-styling
     - az_barrio/arizona-bootstrap
     - az_barrio/button-no-conflict
-    - az_paragraphs/az_paragraphs.az_paragraphs_full_width
 az_paragraphs.az_photo_gallery:
   version: VERSION
   css:

--- a/modules/custom/az_paragraphs/js/az_paragraphs_full_width.es6.js
+++ b/modules/custom/az_paragraphs/js/az_paragraphs_full_width.es6.js
@@ -27,6 +27,9 @@
     const allFullWidthElements = contentRegion.querySelectorAll(
       '.paragraph.full-width-background',
     );
+    if (allFullWidthElements.length === 0) {
+      return;
+    }
     const lastFullWidthElement =
       allFullWidthElements[allFullWidthElements.length - 1];
     const contentRegionPosition = contentRegion.getBoundingClientRect();

--- a/modules/custom/az_paragraphs/js/az_paragraphs_full_width.js
+++ b/modules/custom/az_paragraphs/js/az_paragraphs_full_width.js
@@ -13,6 +13,11 @@
   function pushSidebarsDown() {
     var contentRegion = document.querySelector('main.main-content');
     var allFullWidthElements = contentRegion.querySelectorAll('.paragraph.full-width-background');
+
+    if (allFullWidthElements.length === 0) {
+      return;
+    }
+
     var lastFullWidthElement = allFullWidthElements[allFullWidthElements.length - 1];
     var contentRegionPosition = contentRegion.getBoundingClientRect();
     var style = allFullWidthElements[0].currentStyle || window.getComputedStyle(lastFullWidthElement, '');

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithBackgroundParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithBackgroundParagraphBehavior.php
@@ -121,7 +121,7 @@ class AZTextWithBackgroundParagraphBehavior extends AZDefaultParagraphsBehavior 
     $config = $this->getSettings($paragraph);
 
     // If this paragraph is full-width, add the full-width library.
-    if (isset($config['text_background_full_width'])) {
+    if (isset($config['text_background_full_width']) && $config['text_background_full_width'] === 'full-width-background') {
       $variables['#attached']['library'][] = 'az_paragraphs/az_paragraphs.az_paragraphs_full_width';
     }
 

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithBackgroundParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithBackgroundParagraphBehavior.php
@@ -116,7 +116,7 @@ class AZTextWithBackgroundParagraphBehavior extends AZDefaultParagraphsBehavior 
 
     /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
     $paragraph = $variables['paragraph'];
-    
+
     // Get plugin configuration and save in vars for twig to use.
     $config = $this->getSettings($paragraph);
 
@@ -124,7 +124,7 @@ class AZTextWithBackgroundParagraphBehavior extends AZDefaultParagraphsBehavior 
     if (isset($config['text_background_full_width'])) {
       $variables['#attached']['library'][] = 'az_paragraphs/az_paragraphs.az_paragraphs_full_width';
     }
-    
+
     // Add responsive padding classes.
     if (isset($config['text_background_padding'])) {
       $padding_classes = [];

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithBackgroundParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithBackgroundParagraphBehavior.php
@@ -116,10 +116,15 @@ class AZTextWithBackgroundParagraphBehavior extends AZDefaultParagraphsBehavior 
 
     /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
     $paragraph = $variables['paragraph'];
-
+    
     // Get plugin configuration and save in vars for twig to use.
     $config = $this->getSettings($paragraph);
 
+    // If this paragraph is full-width, add the full-width library.
+    if (isset($config['text_background_full_width'])) {
+      $variables['#attached']['library'][] = 'az_paragraphs/az_paragraphs.az_paragraphs_full_width';
+    }
+    
     // Add responsive padding classes.
     if (isset($config['text_background_padding'])) {
       $padding_classes = [];

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -237,7 +237,7 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
     ];
 
     // If this paragraph is full-width, add the full-width library.
-    if (isset($config['text_background_full_width'])) {
+    if (isset($config['text_background_full_width']) && $config['text_background_full_width'] === 'full-width-background') {
       $variables['#attached']['library'][] = 'az_paragraphs/az_paragraphs.az_paragraphs_full_width';
     }
 

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -236,6 +236,11 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
       HTML::getClass($config['style']),
     ];
 
+    // If this paragraph is full-width, add the full-width library.
+    if (isset($config['text_background_full_width'])) {
+      $variables['#attached']['library'][] = 'az_paragraphs/az_paragraphs.az_paragraphs_full_width';
+    }
+    
     // Add responsive spacing classes.
     if (!empty($config['style']) && $config['style'] !== 'bottom') {
       $spacing_prefix = '';

--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -240,7 +240,7 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
     if (isset($config['text_background_full_width'])) {
       $variables['#attached']['library'][] = 'az_paragraphs/az_paragraphs.az_paragraphs_full_width';
     }
-    
+
     // Add responsive spacing classes.
     if (!empty($config['style']) && $config['style'] !== 'bottom') {
       $spacing_prefix = '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
This PR fixes the JavaScript error that occurs when Text with Background or Text on Media paragraphs are added to a page but none are set to full width by doing the following:
- Remove the az_paragraphs.az_paragraphs_full_width library as a dependency for Text with Background and Text on Media
- Update the preprocess function for Text with Background and Text on Media to attach the az_paragraphs.az_paragraphs_full_width library only if the paragraph is set to be full-width.
- Add a test to az_paragraphs_full_width.js to exit the pushSidebarsDown function if there are no full-width elements in the content region.

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1697 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

1. Create a page with one or more Text with Background or Text on Media paragraphs. Make sure none of those paragraphs are set to full width.
2. Visit the page
3. Open Chrome DevTools and note that there are no more Uncaught TypeError message(s) regarding the currentStyle property

Tested locally and in Probo.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [X] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
