### PR TITLE
Fixes #1728 Fix course PHPstan errors.

### DIFF
--- a/modules/custom/az_course/src/CourseMigrateBatchExecutable.php
+++ b/modules/custom/az_course/src/CourseMigrateBatchExecutable.php
@@ -21,21 +21,16 @@ class CourseMigrateBatchExecutable extends MigrateBatchExecutable {
         $migration->getIdMap()->prepareUpdate();
       }
 
-      if (!empty($options['force'])) {
-        $migration->set('requirements', []);
-      }
-      else {
-        $dependencies = $migration->getMigrationDependencies();
-        if (!empty($dependencies['required'])) {
-          $required_migrations = $this->migrationPluginManager->createInstances($dependencies['required']);
-          // For dependent migrations will need to be migrate all items.
-          $operations = array_merge($operations, $this->batchOperations($required_migrations, $operation, [
-            'limit' => 0,
-            'update' => $options['update'],
-            'force' => $options['force'],
-            'sync' => $options['sync'],
-          ]));
-        }
+      $dependencies = $migration->getMigrationDependencies();
+      if (!empty($dependencies['required'])) {
+        $required_migrations = $this->migrationPluginManager->createInstances($dependencies['required']);
+        // For dependent migrations will need to be migrate all items.
+        $operations = array_merge($operations, $this->batchOperations($required_migrations, $operation, [
+          'limit' => 0,
+          'update' => $options['update'],
+          'force' => $options['force'],
+          'sync' => $options['sync'],
+        ]));
       }
 
       // Take expected source urls and run them one per batch. This is the

--- a/modules/custom/az_course/src/CourseSearch.php
+++ b/modules/custom/az_course/src/CourseSearch.php
@@ -28,7 +28,7 @@ class CourseSearch {
   /**
    * Constructs a CourseSearch service.
    *
-   * @param GuzzleHttp\ClientInterface $http_client
+   * @param \GuzzleHttp\ClientInterface $http_client
    *   A guzzle client for making http requests.
    */
   public function __construct(ClientInterface $http_client) {
@@ -81,10 +81,7 @@ class CourseSearch {
     $queryUrl = Url::fromUri('https://uacourses-api.uaccess.arizona.edu/search', ['query' => ['search_text' => $search]]);
     $queryUrl = $queryUrl->toString();
     try {
-      $response = $this->httpClient->get($queryUrl);
-      if (empty($response)) {
-        \Drupal::logger('az_course')->error("No response.");
-      }
+      $response = $this->httpClient->request('GET', $queryUrl);
       $body = $response->getBody();
       $xml = new \XMLReader();
       if ($xml->xml($body)) {

--- a/modules/custom/az_course/src/Form/CourseImportForm.php
+++ b/modules/custom/az_course/src/Form/CourseImportForm.php
@@ -174,9 +174,9 @@ class CourseImportForm extends ConfigFormBase {
       ->save();
 
     $courses = $this->config('az_course.settings')->get('courses');
+    $course_urls = [];
     if (!empty($courses)) {
       $matches = [];
-      $course_urls = [];
       // Convert courses listed into actual URLs to migrate.
       foreach ($courses as $course) {
         if (preg_match("/^[[:space:]]*([[:alpha:]]+)[[:space:]]+([[:alnum:]]+)[[:space:]]*$/", $course, $matches)) {
@@ -196,20 +196,18 @@ class CourseImportForm extends ConfigFormBase {
 
     // Pass expected urls to batched executable.
     $migration = $this->pluginManagerMigration->createInstance("az_courses");
-    if (!empty($migration)) {
-      $options = [
-        'limit' => 0,
-        'update' => 1,
-        'force' => 0,
-        'configuration' => [
-          'source' => [
-            'urls' => $course_urls,
-          ],
+    $options = [
+      'limit' => 0,
+      'update' => 1,
+      'force' => 0,
+      'configuration' => [
+        'source' => [
+          'urls' => $course_urls,
         ],
-      ];
-      $executable = new CourseMigrateBatchExecutable($migration, new MigrateMessage(), $options);
-      $executable->batchImport();
-    }
+      ],
+    ];
+    $executable = new CourseMigrateBatchExecutable($migration, new MigrateMessage(), $options);
+    $executable->batchImport();
   }
 
   /**

--- a/modules/custom/az_course/src/Plugin/migrate_plus/data_fetcher/RetryHttp.php
+++ b/modules/custom/az_course/src/Plugin/migrate_plus/data_fetcher/RetryHttp.php
@@ -48,9 +48,6 @@ class RetryHttp extends Http {
           $options = array_merge($options, $this->configuration['request_options']);
         }
         $response = $this->httpClient->get($url, $options);
-        if (empty($response)) {
-          throw new MigrateException('No response at ' . $url . '.');
-        }
         return $response;
       }
       catch (RequestException $e) {


### PR DESCRIPTION
## Description
This addresses a few PHPStan issues that popped up in courses after the new PHPstan PR was added.

## Related issues
#1728 

## How to test
- enable `az_course` module
- visit `/admin/config/az-quickstart/courses` as an administrator
- add a subject code or course to import to the text area
- e.g. `FCSC` or `FCSC 120`
- run drush migration `drush mim az_course --update`
- visit `/courses`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [x] New internal API or API improvement with backwards compatibility
   - [x] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
