### PR TITLE
Closes #1734: Add patch for known issue affecting field_group module on 9.4.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -151,6 +151,9 @@
             "drupal/date_ap_style": {
                 "All Day Setting hides time display (3272760)": "https://www.drupal.org/files/issues/2022-03-31/3272760-7.patch"
             },
+            "drupal/field_group": {
+                "Recursion tracker doesn't work on 9.4.x (3290992)": "https://www.drupal.org/files/issues/2022-06-17/3290992-fix-recursion-tracking.patch"
+            },
             "drupal/image_widget_crop": {
                 "Reset crop triggered when ENTER is pressed in the form": "https://www.drupal.org/files/issues/2020-03-04/image_widget_crop-3117828-2.patch"
             },


### PR DESCRIPTION
## Description
Adds patch for known issue affecting the field_group module on Drupal 9.4.x (referenced in the release notes for Drupal 9.4.2).

## Related issues
Closes #1734

## How to test
Ensure content displays that use field groups still function as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [x] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
