### PR TITLE
Closes #1742: Update references to removed light and dark classes in Text on Media Paragraphs Behavior.

### DIFF
--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -270,15 +270,15 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
       }
     }
     if ($config['style'] === 'bottom') {
-      if ($config['bg_color'] === 'light') {
-        $key = array_search('light', $content_classes);
+      if ($config['bg_color'] === 'bg-transparent-white') {
+        $key = array_search('bg-transparent-white', $content_classes);
         unset($content_classes[$key]);
         $content_classes[] = 'bg-white';
         $content_classes[] = 'shadow';
         $content_classes[] = 'mb-4';
       }
-      elseif ($config['bg_color'] === 'dark') {
-        $key = array_search('dark', $content_classes);
+      elseif ($config['bg_color'] === 'bg-transparent-black') {
+        $key = array_search('bg-transparent-black', $content_classes);
         unset($content_classes[$key]);
         $content_classes[] = 'bg-black';
         $content_classes[] = 'shadow';


### PR DESCRIPTION
## Description
Although we replaced the `light` and `dark` classes used by the Text on Media Paragraph behavior in #1713, more references to those classes were added by #1683.

## Related issues
Closes #1742 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Verify that the correct light and dark styles are applied to Text on Media paragraphs using the `bottom` style

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
