### PR TITLE
Closes #1743 Fix block embeds

### DIFF
--- a/modules/custom/az_paragraphs/js/az_paragraphs_full_width.es6.js
+++ b/modules/custom/az_paragraphs/js/az_paragraphs_full_width.es6.js
@@ -24,30 +24,32 @@
    */
   function pushSidebarsDown() {
     const contentRegion = document.querySelector('main.main-content');
-    const allFullWidthElements = contentRegion.querySelectorAll(
-      '.paragraph.full-width-background',
-    );
-    if (allFullWidthElements.length === 0) {
-      return;
-    }
-    const lastFullWidthElement =
-      allFullWidthElements[allFullWidthElements.length - 1];
-    const contentRegionPosition = contentRegion.getBoundingClientRect();
-    const style =
-      allFullWidthElements[0].currentStyle ||
-      window.getComputedStyle(lastFullWidthElement, '');
-    const bottomMargin = parseFloat(style.marginBottom);
-    const contentRegionTop = contentRegionPosition.top;
-    const lastFullWidthElementPosition =
-      lastFullWidthElement.getBoundingClientRect();
-    const lastFullWidthElementBottom = lastFullWidthElementPosition.bottom;
-    const sidebarTopMargin =
-      lastFullWidthElementBottom - contentRegionTop + bottomMargin;
-    if (sidebarTopMargin) {
-      document.documentElement.style.setProperty(
-        '--sidebar-top-margin',
-        `${sidebarTopMargin}px`,
+      if (contentRegion !== null) {
+      const allFullWidthElements = contentRegion.querySelectorAll(
+        '.paragraph.full-width-background',
       );
+      if (allFullWidthElements.length === 0) {
+        return;
+      }
+      const lastFullWidthElement =
+        allFullWidthElements[allFullWidthElements.length - 1];
+      const contentRegionPosition = contentRegion.getBoundingClientRect();
+      const style =
+        allFullWidthElements[0].currentStyle ||
+        window.getComputedStyle(lastFullWidthElement, '');
+      const bottomMargin = parseFloat(style.marginBottom);
+      const contentRegionTop = contentRegionPosition.top;
+      const lastFullWidthElementPosition =
+        lastFullWidthElement.getBoundingClientRect();
+      const lastFullWidthElementBottom = lastFullWidthElementPosition.bottom;
+      const sidebarTopMargin =
+        lastFullWidthElementBottom - contentRegionTop + bottomMargin;
+      if (sidebarTopMargin) {
+        document.documentElement.style.setProperty(
+          '--sidebar-top-margin',
+          `${sidebarTopMargin}px`,
+        );
+      }
     }
   }
 
@@ -59,19 +61,21 @@
    */
   function calculateFullWidthNegativeMargins() {
     const contentRegion = document.querySelectorAll('.block-system-main-block');
-    const contentRegionPosition = contentRegion[0].getBoundingClientRect();
-    const distanceFromLeft = contentRegionPosition.left;
-    const distanceFromRight = contentRegionPosition.right;
-    const negativeLeftMargin = 0 - distanceFromLeft;
-    const negativeRightMargin = 0 - distanceFromRight;
-    document.documentElement.style.setProperty(
-      '--full-width-left-distance',
-      `${negativeLeftMargin}px`,
-    );
-    document.documentElement.style.setProperty(
-      '--full-width-right-distance',
-      `${negativeRightMargin}px`,
-    );
+    if (contentRegion !== null) {
+      const contentRegionPosition = contentRegion[0].getBoundingClientRect();
+      const distanceFromLeft = contentRegionPosition.left;
+      const distanceFromRight = contentRegionPosition.right;
+      const negativeLeftMargin = 0 - distanceFromLeft;
+      const negativeRightMargin = 0 - distanceFromRight;
+      document.documentElement.style.setProperty(
+        '--full-width-left-distance',
+        `${negativeLeftMargin}px`,
+      );
+      document.documentElement.style.setProperty(
+        '--full-width-right-distance',
+        `${negativeRightMargin}px`,
+      );
+    }
   }
 
   /**

--- a/modules/custom/az_paragraphs/js/az_paragraphs_full_width.es6.js
+++ b/modules/custom/az_paragraphs/js/az_paragraphs_full_width.es6.js
@@ -24,7 +24,7 @@
    */
   function pushSidebarsDown() {
     const contentRegion = document.querySelector('main.main-content');
-      if (contentRegion !== null) {
+    if (contentRegion !== null) {
       const allFullWidthElements = contentRegion.querySelectorAll(
         '.paragraph.full-width-background',
       );

--- a/modules/custom/az_paragraphs/js/az_paragraphs_full_width.js
+++ b/modules/custom/az_paragraphs/js/az_paragraphs_full_width.js
@@ -12,35 +12,41 @@
 
   function pushSidebarsDown() {
     var contentRegion = document.querySelector('main.main-content');
-    var allFullWidthElements = contentRegion.querySelectorAll('.paragraph.full-width-background');
 
-    if (allFullWidthElements.length === 0) {
-      return;
-    }
+    if (contentRegion !== null) {
+      var allFullWidthElements = contentRegion.querySelectorAll('.paragraph.full-width-background');
 
-    var lastFullWidthElement = allFullWidthElements[allFullWidthElements.length - 1];
-    var contentRegionPosition = contentRegion.getBoundingClientRect();
-    var style = allFullWidthElements[0].currentStyle || window.getComputedStyle(lastFullWidthElement, '');
-    var bottomMargin = parseFloat(style.marginBottom);
-    var contentRegionTop = contentRegionPosition.top;
-    var lastFullWidthElementPosition = lastFullWidthElement.getBoundingClientRect();
-    var lastFullWidthElementBottom = lastFullWidthElementPosition.bottom;
-    var sidebarTopMargin = lastFullWidthElementBottom - contentRegionTop + bottomMargin;
+      if (allFullWidthElements.length === 0) {
+        return;
+      }
 
-    if (sidebarTopMargin) {
-      document.documentElement.style.setProperty('--sidebar-top-margin', "".concat(sidebarTopMargin, "px"));
+      var lastFullWidthElement = allFullWidthElements[allFullWidthElements.length - 1];
+      var contentRegionPosition = contentRegion.getBoundingClientRect();
+      var style = allFullWidthElements[0].currentStyle || window.getComputedStyle(lastFullWidthElement, '');
+      var bottomMargin = parseFloat(style.marginBottom);
+      var contentRegionTop = contentRegionPosition.top;
+      var lastFullWidthElementPosition = lastFullWidthElement.getBoundingClientRect();
+      var lastFullWidthElementBottom = lastFullWidthElementPosition.bottom;
+      var sidebarTopMargin = lastFullWidthElementBottom - contentRegionTop + bottomMargin;
+
+      if (sidebarTopMargin) {
+        document.documentElement.style.setProperty('--sidebar-top-margin', "".concat(sidebarTopMargin, "px"));
+      }
     }
   }
 
   function calculateFullWidthNegativeMargins() {
     var contentRegion = document.querySelectorAll('.block-system-main-block');
-    var contentRegionPosition = contentRegion[0].getBoundingClientRect();
-    var distanceFromLeft = contentRegionPosition.left;
-    var distanceFromRight = contentRegionPosition.right;
-    var negativeLeftMargin = 0 - distanceFromLeft;
-    var negativeRightMargin = 0 - distanceFromRight;
-    document.documentElement.style.setProperty('--full-width-left-distance', "".concat(negativeLeftMargin, "px"));
-    document.documentElement.style.setProperty('--full-width-right-distance', "".concat(negativeRightMargin, "px"));
+
+    if (contentRegion !== null) {
+      var contentRegionPosition = contentRegion[0].getBoundingClientRect();
+      var distanceFromLeft = contentRegionPosition.left;
+      var distanceFromRight = contentRegionPosition.right;
+      var negativeLeftMargin = 0 - distanceFromLeft;
+      var negativeRightMargin = 0 - distanceFromRight;
+      document.documentElement.style.setProperty('--full-width-left-distance', "".concat(negativeLeftMargin, "px"));
+      document.documentElement.style.setProperty('--full-width-right-distance', "".concat(negativeRightMargin, "px"));
+    }
   }
 
   Drupal.behaviors.azParagraphsFullWidthElements = {

--- a/themes/custom/az_barrio/js/button-no-conflict.es6.js
+++ b/themes/custom/az_barrio/js/button-no-conflict.es6.js
@@ -3,8 +3,10 @@
 (($, Drupal) => {
   Drupal.behaviors.azBarrioButtonNoConflict = {
     attach: () => {
-      const bootstrapButton = $.fn.button.noConflict();
-      $.fn.bootstrapBtn = bootstrapButton;
+      if ($.fn.button && $.fn.button.noConflict !== undefined) {
+        const bootstrapButton = $.fn.button.noConflict();
+        $.fn.bootstrapBtn = bootstrapButton;
+      }
     },
   };
 })(jQuery, Drupal);

--- a/themes/custom/az_barrio/js/button-no-conflict.js
+++ b/themes/custom/az_barrio/js/button-no-conflict.js
@@ -8,8 +8,10 @@
 (function ($, Drupal) {
   Drupal.behaviors.azBarrioButtonNoConflict = {
     attach: function attach() {
-      var bootstrapButton = $.fn.button.noConflict();
-      $.fn.bootstrapBtn = bootstrapButton;
+      if ($.fn.button && $.fn.button.noConflict !== undefined) {
+        var bootstrapButton = $.fn.button.noConflict();
+        $.fn.bootstrapBtn = bootstrapButton;
+      }
     }
   };
 })(jQuery, Drupal);


### PR DESCRIPTION
## Description
Best viewed while ignoring whitespace https://github.com/az-digital/az_quickstart/pull/1754/files?w=1

Now that we are attaching the full width js (even on the edit form) it is necessary to check whether the main content region exists.

The no-conflict fix is a dependency on the full-width js and also appears before it is possible to use.

## Related issues
Closes #1743 

## How to test
Edit page with a paragraph that has a full width checkbox.

## Types of changes
Javascript empty checking.

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
