### PR TITLE
Closes #1741 Hide default intelligenceBank Media Type.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -151,6 +151,9 @@
             "drupal/date_ap_style": {
                 "All Day Setting hides time display (3272760)": "https://www.drupal.org/files/issues/2022-03-31/3272760-7.patch"
             },
+            "drupal/field_group": {
+                "Recursion tracker doesn't work on 9.4.x (3290992)": "https://www.drupal.org/files/issues/2022-06-17/3290992-fix-recursion-tracking.patch"
+            },
             "drupal/image_widget_crop": {
                 "Reset crop triggered when ENTER is pressed in the form": "https://www.drupal.org/files/issues/2020-03-04/image_widget_crop-3117828-2.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -157,9 +157,6 @@
             "drupal/image_widget_crop": {
                 "Reset crop triggered when ENTER is pressed in the form": "https://www.drupal.org/files/issues/2020-03-04/image_widget_crop-3117828-2.patch"
             },
-            "drupal/intelligencebank": {
-                "Don't install a new media type by default. (3295615)": "https://git.drupalcode.org/project/intelligencebank/-/merge_requests/9.diff"
-            },
             "drupal/media_migration": {
                 "Catch migrate RequirementsExceptions (3268480)": "https://www.drupal.org/files/issues/2022-03-08/3268480-2.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -158,7 +158,7 @@
                 "Reset crop triggered when ENTER is pressed in the form": "https://www.drupal.org/files/issues/2020-03-04/image_widget_crop-3117828-2.patch"
             },
             "drupal/intelligencebank": {
-                "Don't install a new media type by default. (3295615)": "https://git.drupalcode.org/project/intelligencebank/-/merge_requests/9.diffq"
+                "Don't install a new media type by default. (3295615)": "https://git.drupalcode.org/project/intelligencebank/-/merge_requests/9.diff"
             },
             "drupal/media_migration": {
                 "Catch migrate RequirementsExceptions (3268480)": "https://www.drupal.org/files/issues/2022-03-08/3268480-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "drupal/google_tag": "1.5.0",
         "drupal/honeypot": "2.1.1",
         "drupal/image_widget_crop": "2.3",
-        "drupal/intelligencebank": "2.5",
+        "drupal/intelligencebank": "3.0.0-beta1",
         "drupal/jquery_ui": "1.4",
         "drupal/jquery_ui_datepicker": "1.2.0",
         "drupal/link_class": "2.0.0",
@@ -158,7 +158,8 @@
                 "Reset crop triggered when ENTER is pressed in the form": "https://www.drupal.org/files/issues/2020-03-04/image_widget_crop-3117828-2.patch"
             },
             "drupal/intelligencebank": {
-                "Disable thumbnail download. (3284562)": "https://www.drupal.org/files/issues/2022-06-20/3284562-5.patch"
+                "Disable thumbnail download. (3284562)": "https://www.drupal.org/files/issues/2022-06-20/3284562-5.patch",
+                "Don't install a new media type by default. (3295615)": "https://git.drupalcode.org/project/intelligencebank/-/merge_requests/9.diff",
             },
             "drupal/media_migration": {
                 "Catch migrate RequirementsExceptions (3268480)": "https://www.drupal.org/files/issues/2022-03-08/3268480-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "drupal/draggableviews": "2.0.1",
         "drupal/easy_breadcrumb": "2.0.3",
         "drupal/embed": "1.5.0",
-        "drupal/entity_browser": "2.6",
+        "drupal/entity_browser": "2.7.0",
         "drupal/entity_embed": "1.2",
         "drupal/environment_indicator": "4.0.6",
         "drupal/exclude_node_title": "1.3.0",

--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,7 @@
             },
             "drupal/intelligencebank": {
                 "Disable thumbnail download. (3284562)": "https://www.drupal.org/files/issues/2022-06-20/3284562-5.patch",
-                "Don't install a new media type by default. (3295615)": "https://git.drupalcode.org/project/intelligencebank/-/merge_requests/9.diffq",
+                "Don't install a new media type by default. (3295615)": "https://git.drupalcode.org/project/intelligencebank/-/merge_requests/9.diffq"
             },
             "drupal/media_migration": {
                 "Catch migrate RequirementsExceptions (3268480)": "https://www.drupal.org/files/issues/2022-03-08/3268480-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -158,7 +158,6 @@
                 "Reset crop triggered when ENTER is pressed in the form": "https://www.drupal.org/files/issues/2020-03-04/image_widget_crop-3117828-2.patch"
             },
             "drupal/intelligencebank": {
-                "Disable thumbnail download. (3284562)": "https://www.drupal.org/files/issues/2022-06-20/3284562-5.patch",
                 "Don't install a new media type by default. (3295615)": "https://git.drupalcode.org/project/intelligencebank/-/merge_requests/9.diffq"
             },
             "drupal/media_migration": {

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "drupal/google_tag": "1.5.0",
         "drupal/honeypot": "2.1.1",
         "drupal/image_widget_crop": "2.3",
-        "drupal/intelligencebank": "3.0.0-beta1",
+        "drupal/intelligencebank": "3.0-beta1",
         "drupal/jquery_ui": "1.4",
         "drupal/jquery_ui_datepicker": "1.2.0",
         "drupal/link_class": "2.0.0",
@@ -159,7 +159,7 @@
             },
             "drupal/intelligencebank": {
                 "Disable thumbnail download. (3284562)": "https://www.drupal.org/files/issues/2022-06-20/3284562-5.patch",
-                "Don't install a new media type by default. (3295615)": "https://git.drupalcode.org/project/intelligencebank/-/merge_requests/9.diff",
+                "Don't install a new media type by default. (3295615)": "https://git.drupalcode.org/project/intelligencebank/-/merge_requests/9.diffq",
             },
             "drupal/media_migration": {
                 "Catch migrate RequirementsExceptions (3268480)": "https://www.drupal.org/files/issues/2022-03-08/3268480-2.patch"

--- a/modules/custom/az_digital_asset_library/az_digital_asset_library.module
+++ b/modules/custom/az_digital_asset_library/az_digital_asset_library.module
@@ -36,11 +36,7 @@ function az_digital_asset_library_form_entity_browser_az_digital_asset_library_f
  * See @link https://github.com/az-digital/az_quickstart/issues/1741
  */
 function az_digital_asset_library_preprocess_links__media_library_menu(&$variables) {
-  if (
-    isset($variables['links']) &&
-    isset($variables['links']['media-library-menu-ib_dam_embed']) &&
-    isset($variables['links']['media-library-menu-ib_dam_embed']['link'])
-    ) {
+  if (isset($variables['links']['media-library-menu-ib_dam_embed']['link'])) {
     $variables['links']['media-library-menu-ib_dam_embed']['link']['#access'] = FALSE;
   }
 }
@@ -53,7 +49,7 @@ function az_digital_asset_library_preprocess_links__media_library_menu(&$variabl
  * See @link https://github.com/az-digital/az_quickstart/issues/1741
  */
 function az_digital_asset_library_preprocess_entity_add_list(&$variables) {
-  if (isset($variables['bundles']) && isset($variables['bundles']['ib_dam_embed'])) {
+  if (isset($variables['bundles']['ib_dam_embed'])) {
     unset($variables['bundles']['ib_dam_embed']);
   }
 }

--- a/modules/custom/az_digital_asset_library/az_digital_asset_library.module
+++ b/modules/custom/az_digital_asset_library/az_digital_asset_library.module
@@ -17,7 +17,7 @@ function az_digital_asset_library_form_submit(array $form, FormStateInterface $f
 }
 
 /**
- * Implements hook_form_ID_alter().
+ * Implements hook_FORM_ID_alter().
  *
  * Add custom submit handler to form.
  * Allow using remote media.

--- a/modules/custom/az_digital_asset_library/az_digital_asset_library.module
+++ b/modules/custom/az_digital_asset_library/az_digital_asset_library.module
@@ -17,7 +17,7 @@ function az_digital_asset_library_form_submit(array $form, FormStateInterface $f
 }
 
 /**
- * Implements hook_form_alter().
+ * Implements hook_form_ID_alter().
  *
  * Add custom submit handler to form.
  * Allow using remote media.
@@ -26,4 +26,34 @@ function az_digital_asset_library_form_submit(array $form, FormStateInterface $f
  */
 function az_digital_asset_library_form_entity_browser_az_digital_asset_library_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form['#submit'][] = 'az_digital_asset_library_form_submit';
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Hide default provided media type by IntelligenceBank from media select dialog.
+ *
+ * See @link https://github.com/az-digital/az_quickstart/issues/1741
+ */
+function az_digital_asset_library_preprocess_links__media_library_menu(&$variables) {
+  if (
+    isset($variables['links']) &&
+    isset($variables['links']['media-library-menu-ib_dam_embed']) &&
+    isset($variables['links']['media-library-menu-ib_dam_embed']['link'])
+    ) {
+    $variables['links']['media-library-menu-ib_dam_embed']['link']['#access'] = FALSE;
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Hide default provided media type by IntelligenceBank from media add page.
+ *
+ * See @link https://github.com/az-digital/az_quickstart/issues/1741
+ */
+function az_digital_asset_library_preprocess_entity_add_list(&$variables) {
+  if (isset($variables['bundles']) && isset($variables['bundles']['ib_dam_embed'])) {
+    unset($variables['bundles']['ib_dam_embed']);
+  }
 }

--- a/modules/custom/az_digital_asset_library/config/install/entity_browser.browser.az_digital_asset_library.yml
+++ b/modules/custom/az_digital_asset_library/config/install/entity_browser.browser.az_digital_asset_library.yml
@@ -18,10 +18,10 @@ widget_selector: single
 widget_selector_configuration: {  }
 widgets:
   e4f2bf7e-ce3f-499e-8d2b-698219735ccf:
-    id: ib_dam_search
-    uuid: e4f2bf7e-ce3f-499e-8d2b-698219735ccf
-    label: 'Search The University of Arizona Digital Asset Library'
-    weight: 1
     settings:
-      submit_text: 'Select Arizona Digital Asset'
       upload_location: 'public://az_digital_asset_library'
+      submit_text: 'Select Arizona Digital Asset'
+    uuid: e4f2bf7e-ce3f-499e-8d2b-698219735ccf
+    weight: 1
+    label: 'Search The University of Arizona Digital Asset Library'
+    id: ib_dam_search


### PR DESCRIPTION
## Description
Added preprocess functions to hide links for intelligence bank media types in both the media embed dialog and on the add/media page


## Related issues
Closes #1741 
Follow-up PR https://github.com/az-digital/az_quickstart/pull/1752 (Would need to remove changes from this PR)
Waiting on Drupal issue: https://www.drupal.org/project/intelligencebank/issues/3295615

## How to test
Go to any page content
Add text paragraph
Attempt to embed media
See no option for intelligence bank dam media type

Go to /media/add page
See no option for intelligence bank dam media type

Go to /media/add/ib_dam_embed
See available options (DO NOT USE THOUGH)

## Types of changes
### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
