### PR TITLE
Closes #1760: Allow cache metadata to bubble up in Card and Accordion body subfields.

### DIFF
--- a/modules/custom/az_accordion/src/Plugin/Field/FieldFormatter/AZAccordionDefaultFormatter.php
+++ b/modules/custom/az_accordion/src/Plugin/Field/FieldFormatter/AZAccordionDefaultFormatter.php
@@ -118,10 +118,17 @@ class AZAccordionDefaultFormatter extends FormatterBase implements ContainerFact
       $column_classes = explode(' ', $column_classes);
       $column_classes[] = 'pb-4';
 
-      $element[] = [
+      $element[$delta] = [
         '#theme' => 'az_accordion',
         '#title' => $title,
-        '#body' => check_markup($item->body, $item->body_format),
+        // The ProcessedText element handles cache context & tag bubbling.
+        // @see \Drupal\filter\Element\ProcessedText::preRenderText()
+        '#body' => [
+          '#type' => 'processed_text',
+          '#text' => $item->body,
+          '#format' => $item->body_format,
+          '#langcode' => $item->getLangcode(),
+        ],
         '#attributes' => ['class' => $accordion_classes],
         '#accordion_item_id' => Html::getUniqueId('az_accordion'),
         '#collapsed' => $item->collapsed ? 'collapse' : 'collapse show',

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -186,11 +186,18 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
         $card_classes .= ' ' . $item->options['class'];
       }
 
-      $element[] = [
+      $element[$delta] = [
         '#theme' => 'az_card',
         '#media' => $media_render_array,
         '#title' => $title,
-        '#body' => check_markup($item->body, $item->body_format),
+        // The ProcessedText element handles cache context & tag bubbling.
+        // @see \Drupal\filter\Element\ProcessedText::preRenderText()
+        '#body' => [
+          '#type' => 'processed_text',
+          '#text' => $item->body,
+          '#format' => $item->body_format,
+          '#langcode' => $item->getLangcode(),
+        ],
         '#link' => $link_render_array,
         '#title_style' => $title_style ?? 'default',
         '#attributes' => ['class' => $card_classes],


### PR DESCRIPTION
## Description
Fixes issue that was preventing cache metadata from embedded entities to be included in rendered in our custom AZ Card and AZ Accordion field elements.

Remaining tasks:
- [ ] Add test(s)

## Related issues
Closes $1760

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
- Create a content block
- Create a flexible page
- Add an Accordion or Card paragraph to the page
- Embed the block in the body field of the card or accordion paragraph
- Modify the content block
- Verify that the embedded block reflects the changes without requiring a manual Drupal cache clear 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
