### PR TITLE
Closes #1790, Closes #1792: Update Pathauto patterns for Drupal 9.3+ and use drupal/ctools:4.0.1.

### DIFF
--- a/az_quickstart.install
+++ b/az_quickstart.install
@@ -226,3 +226,29 @@ function az_quickstart_update_920103() {
     return t('Environment Indicator module installed.');
   }
 }
+
+/**
+ * Ensure Pathauto patterns have been properly updated for Drupal 9.3.0+.
+ *
+ * Duplicates pathauto_update_8108() to ensure that sites created since
+ * Quickstart 2.3.0 have their Pathauto pattern configuration entities  updated.
+ */
+function az_quickstart_update_920301() {
+  // Load all pattern configuration entities.
+  foreach (\Drupal::configFactory()->listAll('pathauto.pattern.') as $pattern_config_name) {
+    $pattern_config = \Drupal::configFactory()->getEditable($pattern_config_name);
+
+    // Loop patterns and swap the node_type plugin by the entity_bundle:node
+    // plugin.
+    if ($pattern_config->get('type') === 'canonical_entities:node') {
+      $selection_criteria = $pattern_config->get('selection_criteria');
+      foreach ($selection_criteria as $uuid => $condition) {
+        if ($condition['id'] === 'node_type') {
+          $pattern_config->set("selection_criteria.$uuid.id", 'entity_bundle:node');
+          $pattern_config->save();
+          break;
+        }
+      }
+    }
+  }
+}

--- a/az_quickstart.install
+++ b/az_quickstart.install
@@ -231,7 +231,7 @@ function az_quickstart_update_920103() {
  * Ensure Pathauto patterns have been properly updated for Drupal 9.3.0+.
  *
  * Duplicates pathauto_update_8108() to ensure that sites created since
- * Quickstart 2.3.0 have their Pathauto pattern configuration entities  updated.
+ * Quickstart 2.3.0 have their Pathauto pattern configuration entities updated.
  */
 function az_quickstart_update_920301() {
   // Load all pattern configuration entities.

--- a/az_quickstart.install
+++ b/az_quickstart.install
@@ -226,29 +226,3 @@ function az_quickstart_update_920103() {
     return t('Environment Indicator module installed.');
   }
 }
-
-/**
- * Ensure Pathauto patterns have been properly updated for Drupal 9.3.0+.
- *
- * Duplicates pathauto_update_8108() to ensure that sites created since
- * Quickstart 2.3.0 have their Pathauto pattern configuration entities updated.
- */
-function az_quickstart_update_920301() {
-  // Load all pattern configuration entities.
-  foreach (\Drupal::configFactory()->listAll('pathauto.pattern.') as $pattern_config_name) {
-    $pattern_config = \Drupal::configFactory()->getEditable($pattern_config_name);
-
-    // Loop patterns and swap the node_type plugin by the entity_bundle:node
-    // plugin.
-    if ($pattern_config->get('type') === 'canonical_entities:node') {
-      $selection_criteria = $pattern_config->get('selection_criteria');
-      foreach ($selection_criteria as $uuid => $condition) {
-        if ($condition['id'] === 'node_type') {
-          $pattern_config->set("selection_criteria.$uuid.id", 'entity_bundle:node');
-          $pattern_config->save();
-          break;
-        }
-      }
-    }
-  }
-}

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "drupal/config_update": "1.7",
         "drupal/core-recommended": "9.4.3",
         "drupal/crop": "2.2.0",
-        "drupal/ctools": "3.10.0",
+        "drupal/ctools": "3.9.0",
         "drupal/date_ap_style": "1.5.0",
         "drupal/draggableviews": "2.0.1",
         "drupal/easy_breadcrumb": "2.0.3",
@@ -168,10 +168,6 @@
             },
             "drupal/paragraphs": {
                 "Paragraph Migrations broken by archived flag (3268555)": "https://www.drupal.org/files/issues/2022-05-31/3268555-6-workaround.patch"
-            },
-            "drupal/pathauto": {
-                "Drupal 10 compatibility, require Drupal 9.3 (3266631)": "https://git.drupalcode.org/project/pathauto/-/commit/b71509771d9071a81d4a9bd99babb5df3d6f5db9.diff",
-                "Remove dependency on CTools (3222775)": "https://www.drupal.org/files/issues/2022-06-25/3222775-16.patch"
             },
             "drupal/role_delegation": {
                 "Restrict access to cancel/remove accounts with non-assignable roles (3299201)": "https://www.drupal.org/files/issues/2022-07-25/3299201-4.patch"

--- a/composer.json
+++ b/composer.json
@@ -169,6 +169,10 @@
             "drupal/paragraphs": {
                 "Paragraph Migrations broken by archived flag (3268555)": "https://www.drupal.org/files/issues/2022-05-31/3268555-6-workaround.patch"
             },
+            "drupal/pathauto": {
+                "Drupal 10 compatibility, require Drupal 9.3 (3266631)": "https://git.drupalcode.org/project/pathauto/-/commit/b71509771d9071a81d4a9bd99babb5df3d6f5db9.diff",
+                "Remove dependency on CTools (3222775)": "https://www.drupal.org/files/issues/2022-06-25/3222775-16.patch"
+            },
             "drupal/role_delegation": {
                 "Restrict access to cancel/remove accounts with non-assignable roles (3299201)": "https://www.drupal.org/files/issues/2022-07-25/3299201-4.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "drupal/config_update": "1.7",
         "drupal/core-recommended": "9.4.3",
         "drupal/crop": "2.2.0",
-        "drupal/ctools": "3.10.0",
+        "drupal/ctools": "4.0.1",
         "drupal/date_ap_style": "1.5.0",
         "drupal/draggableviews": "2.0.1",
         "drupal/easy_breadcrumb": "2.0.3",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "drupal/config_update": "1.7",
         "drupal/core-recommended": "9.4.3",
         "drupal/crop": "2.2.0",
-        "drupal/ctools": "3.9.0",
+        "drupal/ctools": "3.10.0",
         "drupal/date_ap_style": "1.5.0",
         "drupal/draggableviews": "2.0.1",
         "drupal/easy_breadcrumb": "2.0.3",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "drupal/config_update": "1.7",
         "drupal/core-recommended": "9.4.3",
         "drupal/crop": "2.2.0",
-        "drupal/ctools": "4.0.0",
+        "drupal/ctools": "3.10.0",
         "drupal/date_ap_style": "1.5.0",
         "drupal/draggableviews": "2.0.1",
         "drupal/easy_breadcrumb": "2.0.3",

--- a/modules/custom/az_event/config/install/pathauto.pattern.az_event_url_pattern.yml
+++ b/modules/custom/az_event/config/install/pathauto.pattern.az_event_url_pattern.yml
@@ -8,14 +8,14 @@ label: 'Event Content Type'
 type: 'canonical_entities:node'
 pattern: 'events/[node:title]'
 selection_criteria:
-  62829e66-f973-46f9-aa96-aa6372276a42:
-    id: node_type
-    bundles:
-      az_event: az_event
+  482f50b1-88f5-4345-9b04-5da2562a58b8:
+    id: 'entity_bundle:node'
     negate: false
+    uuid: 482f50b1-88f5-4345-9b04-5da2562a58b8
     context_mapping:
       node: node
-    uuid: 62829e66-f973-46f9-aa96-aa6372276a42
+    bundles:
+      az_event: az_event
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/modules/custom/az_event/config/install/pathauto.pattern.az_event_url_pattern.yml
+++ b/modules/custom/az_event/config/install/pathauto.pattern.az_event_url_pattern.yml
@@ -8,10 +8,10 @@ label: 'Event Content Type'
 type: 'canonical_entities:node'
 pattern: 'events/[node:title]'
 selection_criteria:
-  482f50b1-88f5-4345-9b04-5da2562a58b8:
+  62829e66-f973-46f9-aa96-aa6372276a42:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 482f50b1-88f5-4345-9b04-5da2562a58b8
+    uuid: 62829e66-f973-46f9-aa96-aa6372276a42
     context_mapping:
       node: node
     bundles:

--- a/modules/custom/az_news/config/install/pathauto.pattern.news_content_type.yml
+++ b/modules/custom/az_news/config/install/pathauto.pattern.news_content_type.yml
@@ -8,10 +8,10 @@ label: 'News Content Type'
 type: 'canonical_entities:node'
 pattern: 'news/[node:title]'
 selection_criteria:
-  f3ee6f89-c582-492f-b275-56899271f46d:
+  07e97b57-dc82-453f-8cc0-5495a8e14ceb:
     id: 'entity_bundle:node'
     negate: false
-    uuid: f3ee6f89-c582-492f-b275-56899271f46d
+    uuid: 07e97b57-dc82-453f-8cc0-5495a8e14ceb
     context_mapping:
       node: node
     bundles:

--- a/modules/custom/az_news/config/install/pathauto.pattern.news_content_type.yml
+++ b/modules/custom/az_news/config/install/pathauto.pattern.news_content_type.yml
@@ -8,14 +8,14 @@ label: 'News Content Type'
 type: 'canonical_entities:node'
 pattern: 'news/[node:title]'
 selection_criteria:
-  07e97b57-dc82-453f-8cc0-5495a8e14ceb:
-    id: node_type
-    bundles:
-      az_news: az_news
+  f3ee6f89-c582-492f-b275-56899271f46d:
+    id: 'entity_bundle:node'
     negate: false
+    uuid: f3ee6f89-c582-492f-b275-56899271f46d
     context_mapping:
       node: node
-    uuid: 07e97b57-dc82-453f-8cc0-5495a8e14ceb
+    bundles:
+      az_news: az_news
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/modules/custom/az_person/config/install/pathauto.pattern.az_person_url_pattern.yml
+++ b/modules/custom/az_person/config/install/pathauto.pattern.az_person_url_pattern.yml
@@ -8,10 +8,10 @@ label: 'Person Content Type'
 type: 'canonical_entities:node'
 pattern: 'person/[node:title]'
 selection_criteria:
-  ae526991-c3db-4048-97bd-91e8060f8958:
+  b204ad38-c993-453e-b9ba-4200941238f4:
     id: 'entity_bundle:node'
     negate: false
-    uuid: ae526991-c3db-4048-97bd-91e8060f8958
+    uuid: b204ad38-c993-453e-b9ba-4200941238f4
     context_mapping:
       node: node
     bundles:

--- a/modules/custom/az_person/config/install/pathauto.pattern.az_person_url_pattern.yml
+++ b/modules/custom/az_person/config/install/pathauto.pattern.az_person_url_pattern.yml
@@ -8,14 +8,14 @@ label: 'Person Content Type'
 type: 'canonical_entities:node'
 pattern: 'person/[node:title]'
 selection_criteria:
-  b204ad38-c993-453e-b9ba-4200941238f4:
-    id: node_type
-    bundles:
-      az_person: az_person
+  ae526991-c3db-4048-97bd-91e8060f8958:
+    id: 'entity_bundle:node'
     negate: false
+    uuid: ae526991-c3db-4048-97bd-91e8060f8958
     context_mapping:
       node: node
-    uuid: b204ad38-c993-453e-b9ba-4200941238f4
+    bundles:
+      az_person: az_person
 selection_logic: and
 weight: -5
 relationships: {  }


### PR DESCRIPTION
## Description
drupal/ctools 4.0.0 is no longer available (Drupal contrib module maintenance fail 🤦🏻‍♂️).
https://www.drupal.org/project/ctools/releases/8.x-3.10

While testing ctools 8.x-3.10 we also realized that our exported Pathauto pattern configs had not all been updated for Drupal 9.3+ and Pathauto 8.x-1.10 compatibility.

## Related issues
- Closes #1790
- Closes #1792 

## How to test
- Verify `composer install` works
- Verify PHPunit tests pass
- Apply patch to existing site, run DB updates and config distro update, ensure Pathauto patterns work

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [x] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
