### PR TITLE
Closes #1523 use az_entity_embed_process before passing to text_format_recognizer

### DIFF
--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_html.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_html.yml
@@ -15,26 +15,7 @@ process:
     method: row
     source: keep
     message: 'Could not determine parent entity. Skipping.'
-
-  destination_bundle:
-    plugin: text_format_recognizer
-    format: 'az_standard'
-    source: field_uaqs_html
-    required_module: 'az_paragraphs_html'
-    passed: 'az_text'
-    failed: 'az_html'
-    module_missing: 'az_text'
-
-  type:
-    -
-      plugin: array_shift
-      source: '@destination_bundle'
-    -
-      plugin: default_value
-      default_value: 'az_text'
-
-
-  field_az_full_html:
+  pseudo_processed_html_field:
     plugin: sub_process
     source: field_uaqs_html
     process:
@@ -42,10 +23,31 @@ process:
       value:
         plugin: az_entity_embed_process
         source: value
-      format:
-        plugin: default_value
-        default_value: full_html
-
+      format: format
+  destination_bundle:
+    - plugin: text_format_recognizer
+      format: 'az_standard'
+      source: '@pseudo_processed_html_field'
+      required_module: 'az_paragraphs_html'
+      passed: 'az_text'
+      failed: 'az_html'
+      module_missing: 'az_text'
+  type:
+    - plugin: array_shift
+      source: '@destination_bundle'
+    - plugin: default_value
+      default_value: 'az_text'
+  field_az_full_html:
+    - plugin: sub_process
+      source: field_uaqs_html
+      process:
+        delta: delta
+        value:
+          plugin: az_entity_embed_process
+          source: value
+        format:
+          plugin: default_value
+          default_value: full_html
   field_az_text_area:
     plugin: sub_process
     source: field_uaqs_html


### PR DESCRIPTION
## Description
text_format_recognizer determines if the value of a text field should be added as an html field or az_standard text area.
This works great until there are embedded entities in the source.


## Related issues
Closes #1523 

## How to test
QS1 Source site with html paragraphs with embedded content.
QS2 Destination site with az_paragraphs_html module enabled
Attempt to migrate az_migration group, see error(or not if this fix is enabled).

## Types of changes
Bug fix

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
