### PR TITLE
Closes #1816 Upgrade externalauth to 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "drupal/entity_embed": "1.2",
         "drupal/environment_indicator": "4.0.6",
         "drupal/exclude_node_title": "1.4.0",
-        "drupal/externalauth": "1.4.0",
+        "drupal/externalauth": "2.0.2",
         "drupal/field_group": "3.2.0",
         "drupal/field_group_link": "3.0.0",
         "drupal/google_tag": "1.5.0",


### PR DESCRIPTION
Closes #1816 

Release notes: 
- https://www.drupal.org/project/externalauth/releases/2.0.0
- https://www.drupal.org/project/externalauth/releases/2.0.1
- https://www.drupal.org/project/externalauth/releases/2.0.2

Diff
https://git.drupalcode.org/project/externalauth/-/compare/8.x-1.4...2.0.2?from_project_id=21032
