### PR TITLE
Closes 1825: Improve breadcrumb display

### DIFF
--- a/themes/custom/az_barrio/css/style.css
+++ b/themes/custom/az_barrio/css/style.css
@@ -368,6 +368,25 @@ td.menu-disabled {
   }
 }
 
+.breadcrumb-item+.breadcrumb-item:before {
+  float: left;
+  padding-right: 0.5rem;
+  color: #000000;
+  content: “\e5cc”;
+  font-family: ‘Material Icons Sharp’;
+}
+
+.breadcrumb {
+  font-size: small;
+  display: inline-flex;
+  padding: 2px 5px;
+  margin: 5px 0;
+  background-color: #e9ecef;
+}
+.breadcrumb-item.active {
+-/* color: #6c757d; */-
+}
+  
 a.btn.btn-redbar {
   padding: .5rem 0 0 0;
 }

--- a/themes/custom/az_barrio/templates/navigation/breadcrumb.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/breadcrumb.html.twig
@@ -7,13 +7,15 @@
  * - breadcrumb: Breadcrumb trail items.
  */
 #}
-
 {% if breadcrumb %}
   <nav role="navigation" aria-label="breadcrumb">
     <ol class="breadcrumb">
+      <span class="material-icons-sharp">
+        home
+      </span>
     {% for item in breadcrumb %}
       {% if item.url %}
-        <li class="breadcrumb-item">
+        <li class="breadcrumb-item ml-1">
           <a href="{{ item.url }}">{{ item.text }}</a>
         </li>
       {% else %}


### PR DESCRIPTION
First round of changes for the breadcrumb styling.

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR tackles several changes to the current breadcrumbs implementation. Adds styles to the style.css file, and puts a Google Material Icon Sharp at the start of the breadcrumb (twig file) for the Home icon. This icon placement might not be ideal so I'm open to feedback.

## Related issues
[Issue 1825](https://github.com/az-digital/az_quickstart/issues/1825)

## How to test
Add multi-level pages in order to activate breadcrumbs.

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [x] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
