### PR TITLE
Closes #1844 - Fix twig variable index for alt text on gallery images

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/templates/paragraph--az-photo-gallery.html.twig
+++ b/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/templates/paragraph--az-photo-gallery.html.twig
@@ -62,7 +62,7 @@
               '#theme':      'image_style',
               '#style_name': 'az_card_image',
               '#uri':        item.entity.field_media_az_image.0.entity.uri.value,
-              '#alt':        item.entity.field_media_az_image.0.entity.uri.alt,
+              '#alt':        item.entity.field_media_az_image.alt,
               '#attributes': { class: [ 'photo-gallery-grid-img' ] },
             } %}
             <div class="col-6 col-md-4 col-lg-3 px-min py-min" data-toggle="modal" data-target="#{{ modal }}">

--- a/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/templates/paragraph--az-photo-gallery.html.twig
+++ b/modules/custom/az_paragraphs/az_paragraphs_photo_gallery/templates/paragraph--az-photo-gallery.html.twig
@@ -92,7 +92,7 @@
                   '#theme':      'image_style',
                   '#style_name': 'az_large',
                   '#uri':        item.entity.field_media_az_image.0.entity.uri.value,
-                  '#alt':        item.entity.field_media_az_image.0.entity.uri.alt,
+                  '#alt':        item.entity.field_media_az_image.alt,
                   '#attributes': { class: [ 'd-block', not grid ? 'w-100' : 'az-gallery-img' ] },
                 } %}
 


### PR DESCRIPTION
## Description
This PR fixes the twig variable index to address the issue of alt text not rendering on gallery images.

## Related issues
Closes #1844

## How to test


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [x] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
