### PR TITLE
Closes #1856: Fix deprecation warning caused by empty card/accordion body fields on PHP 8.1+.

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -82,7 +82,7 @@ steps:
       - curl -sS -o /dev/null http://localhost/calendar
       - curl -sS -o /dev/null http://localhost/pages/annual-events
       # Check for PHP watchdog entries
-      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php)" ]; then echo "No PHP notices/errors logged."; else echo "PHP notices/errors found in log." >&2 && exit 1; fi
+      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:show --type=php)" ]; then echo "No PHP notices/errors logged."; else echo "PHP notices/errors found in log." >&2 && exit 1; fi
   - name: Run PHPUnit Tests
     plugin: Script
     script:

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -82,7 +82,7 @@ steps:
       - curl -sS -o /dev/null http://localhost/calendar
       - curl -sS -o /dev/null http://localhost/pages/annual-events
       # Check for PHP watchdog entries
-      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:show --type=php)" ]; then echo "No PHP notices/errors logged."; else echo "PHP notices/errors found in log." >&2 && exit 1; fi
+      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php)" ]; then echo "No PHP notices/errors logged."; else echo "PHP notices/errors found in log." >&2 && exit 1; fi
   - name: Run PHPUnit Tests
     plugin: Script
     script:

--- a/modules/custom/az_accordion/src/Plugin/Field/FieldFormatter/AZAccordionDefaultFormatter.php
+++ b/modules/custom/az_accordion/src/Plugin/Field/FieldFormatter/AZAccordionDefaultFormatter.php
@@ -125,7 +125,7 @@ class AZAccordionDefaultFormatter extends FormatterBase implements ContainerFact
         // @see \Drupal\filter\Element\ProcessedText::preRenderText()
         '#body' => [
           '#type' => 'processed_text',
-          '#text' => $item->body,
+          '#text' => $item->body ?? '',
           '#format' => $item->body_format,
           '#langcode' => $item->getLangcode(),
         ],

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -194,7 +194,7 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
         // @see \Drupal\filter\Element\ProcessedText::preRenderText()
         '#body' => [
           '#type' => 'processed_text',
-          '#text' => $item->body,
+          '#text' => $item->body ?? '',
           '#format' => $item->body_format,
           '#langcode' => $item->getLangcode(),
         ],


### PR DESCRIPTION
## Description
Fixes deprecation warnings generated by empty card/accordion body (sub)fields.

Related core issue:
https://www.drupal.org/project/drupal/issues/3294680

## Related issues
Closes #1856

## How to test
- Create a page with a card or accordion paragraph containing at least one card or accordion with an empty body field
- Verify that no warnings like this are shown / logged:
```
Deprecated function: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in Drupal\filter\Element\ProcessedText::preRenderText() (line 101 of core/modules/filter/src/Element/ProcessedText.php).
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
