### PR TITLE
Closes #1858: Fix broken ProboCI 'Check for PHP errors and notices' step.

### DIFF
--- a/.probo.yaml
+++ b/.probo.yaml
@@ -83,7 +83,7 @@ steps:
       - curl -sS -o /dev/null http://localhost/calendar
       - curl -sS -o /dev/null http://localhost/pages/annual-events
       # Check for PHP watchdog entries
-      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:show --count=100 --type=php)" ]; then echo "No PHP notices/errors logged."; else echo "PHP notices/errors found in log." >&2 && exit 1; fi
+      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:show --count=100 --type=php --extended)" ]; then echo "No PHP notices/errors logged."; else echo "PHP notices/errors found in log." >&2 && exit 1; fi
   - name: Run PHPUnit Tests
     plugin: Script
     script:

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -82,7 +82,7 @@ steps:
       - curl -sS -o /dev/null http://localhost/calendar
       - curl -sS -o /dev/null http://localhost/pages/annual-events
       # Check for PHP watchdog entries
-      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:list --type=php)" ]; then echo "No PHP notices/errors logged."; else echo "PHP notices/errors found in log." >&2 && exit 1; fi
+      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:show --count=100 --type=php)" ]; then echo "No PHP notices/errors logged."; else echo "PHP notices/errors found in log." >&2 && exit 1; fi
   - name: Run PHPUnit Tests
     plugin: Script
     script:

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -56,6 +56,7 @@ steps:
       - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush user:role:add az_content_admin azuseradmin
       - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush user:role:add az_user_admin azuseradmin
       - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush config:set -y az_cas.settings disable_login_form 0
+      - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush config:set -y system.logging error_level "verbose"
       - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush cache:rebuild
       - chown www-data:www-data -R /var/www/html/sites/default/files
       - $SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -y -n pm:enable environment_indicator

--- a/.probo.yaml
+++ b/.probo.yaml
@@ -83,7 +83,7 @@ steps:
       - curl -sS -o /dev/null http://localhost/calendar
       - curl -sS -o /dev/null http://localhost/pages/annual-events
       # Check for PHP watchdog entries
-      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:show --count=100 --type=php --extended)" ]; then echo "No PHP notices/errors logged."; else echo "PHP notices/errors found in log." >&2 && exit 1; fi
+      - if [ -z "$($SRC_DIR/az-quickstart-scaffolding/vendor/bin/drush -n watchdog:show --count=100 --type=php)" ]; then echo "No PHP notices/errors logged."; else echo "PHP notices/errors found in log." >&2 && exit 1; fi
   - name: Run PHPUnit Tests
     plugin: Script
     script:


### PR DESCRIPTION
## Description
Our `Check for PHP errors and notices` ProboCI step is not currently working (due to upgrading to Drush 11).

## Related issues
Closes #1858 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Look at output of ProboCI `Check for PHP errors and notices` in the ProboCI console.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
