### PR TITLE
Closes #1837: Update URL of Global Engagement link in global footer.

### DIFF
--- a/modules/custom/az_global_footer/az_global_footer.info.yml
+++ b/modules/custom/az_global_footer/az_global_footer.info.yml
@@ -1,6 +1,6 @@
 name: 'Quickstart Global Footer'
 type: module
-description: 'Provides gloabl footer content which links to UArizona social media accounts and resources.'
+description: 'Provides global footer content which links to UArizona social media accounts and resources.'
 core_version_requirement: ^9
 package: 'The University of Arizona'
 dependencies:

--- a/modules/custom/az_global_footer/az_global_footer.install
+++ b/modules/custom/az_global_footer/az_global_footer.install
@@ -53,6 +53,7 @@ function az_global_footer_update_920501() {
     $menu_link_content = MenuLinkContent::load($id);
     if ($menu_link_content !== NULL) {
       $menu_link_content->title = 'International Engagement';
+      /* @phpstan-ignore-next-line */
       $menu_link_content->link->uri = 'https://international.arizona.edu';
       $menu_link_content->save();
       $updated_count++;

--- a/modules/custom/az_global_footer/az_global_footer.install
+++ b/modules/custom/az_global_footer/az_global_footer.install
@@ -53,7 +53,7 @@ function az_global_footer_update_920501() {
     $menu_link_content = MenuLinkContent::load($id);
     if ($menu_link_content !== NULL) {
       $menu_link_content->title = 'International Engagement';
-      $menu_link_content->link__uri = 'https://international.arizona.edu';      
+      $menu_link_content->link__uri = 'https://international.arizona.edu';
       $menu_link_content->save();
       $updated_count++;
     }

--- a/modules/custom/az_global_footer/az_global_footer.install
+++ b/modules/custom/az_global_footer/az_global_footer.install
@@ -50,7 +50,7 @@ function az_global_footer_update_920501() {
   foreach ($menu_link_content_ids as $id) {
     /** @var \Drupal\menu_link_content\Entity\MenuLinkContent $menu_link_content */
     $menu_link_content = MenuLinkContent::load($id);
-    if (!empty($menu_link_content)) {
+    if ($menu_link_content !== NULL) {
       $menu_link_content->link__uri = 'https://international.arizona.edu';
       $menu_link_content->save();
       $updated_count++;

--- a/modules/custom/az_global_footer/az_global_footer.install
+++ b/modules/custom/az_global_footer/az_global_footer.install
@@ -59,5 +59,5 @@ function az_global_footer_update_920501() {
     }
   }
 
-  return t('Updated %count global footer menu link(s) with new Global Engagement URL (https://international.arizona.edu).', ['%count' => $updated_count]);
+  return t('Replaced %count Global Engagement menu link(s) in the global footer with International Engagement menu link(s).', ['%count' => $updated_count]);
 }

--- a/modules/custom/az_global_footer/az_global_footer.install
+++ b/modules/custom/az_global_footer/az_global_footer.install
@@ -5,6 +5,7 @@
  * Contains az_global_footer.install.
  */
 
+use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\migrate\MigrateExecutable;
 use Drupal\migrate\MigrateMessage;
 
@@ -34,4 +35,27 @@ function az_global_footer_uninstall() {
     $executable = new MigrateExecutable($migration, new MigrateMessage());
     $executable->rollback();
   }
+}
+
+/**
+ * Update URL for Global Engagement link(s) in the global footer.
+ */
+function az_global_footer_update_920501() {
+  $updated_count = 0;
+  $menu_link_content_ids = \Drupal::entityQuery('menu_link_content')
+    ->condition('menu_name', 'az-footer-topics')
+    ->condition('link__uri', 'https://global.arizona.edu')
+    ->execute();
+
+  foreach ($menu_link_content_ids as $id) {
+    /** @var \Drupal\menu_link_content\Entity\MenuLinkContent $menu_link_content */
+    $menu_link_content = MenuLinkContent::load($id);
+    if (!empty($menu_link_content)) {
+      $menu_link_content->link__uri = 'https://international.arizona.edu';
+      $menu_link_content->save();
+      $updated_count++;
+    }
+  }
+
+  return t('Updated %count global footer menu link(s) with new Global Engagement URL (https://international.arizona.edu).', ['%count' => $updated_count]);
 }

--- a/modules/custom/az_global_footer/az_global_footer.install
+++ b/modules/custom/az_global_footer/az_global_footer.install
@@ -38,12 +38,13 @@ function az_global_footer_uninstall() {
 }
 
 /**
- * Update URL for Global Engagement link(s) in the global footer.
+ * Replace Global Engagement link(s) in the global footer with International Engagement link(s).
  */
 function az_global_footer_update_920501() {
   $updated_count = 0;
   $menu_link_content_ids = \Drupal::entityQuery('menu_link_content')
     ->condition('menu_name', 'az-footer-topics')
+    ->condition('title', 'Global Engagement')
     ->condition('link__uri', 'https://global.arizona.edu')
     ->execute();
 
@@ -51,7 +52,8 @@ function az_global_footer_update_920501() {
     /** @var \Drupal\menu_link_content\Entity\MenuLinkContent $menu_link_content */
     $menu_link_content = MenuLinkContent::load($id);
     if ($menu_link_content !== NULL) {
-      $menu_link_content->link__uri = 'https://international.arizona.edu';
+      $menu_link_content->title = 'International Engagement';
+      $menu_link_content->link__uri = 'https://international.arizona.edu';      
       $menu_link_content->save();
       $updated_count++;
     }

--- a/modules/custom/az_global_footer/az_global_footer.install
+++ b/modules/custom/az_global_footer/az_global_footer.install
@@ -53,7 +53,7 @@ function az_global_footer_update_920501() {
     $menu_link_content = MenuLinkContent::load($id);
     if ($menu_link_content !== NULL) {
       $menu_link_content->title = 'International Engagement';
-      $menu_link_content->link__uri = 'https://international.arizona.edu';
+      $menu_link_content->link->uri = 'https://international.arizona.edu';
       $menu_link_content->save();
       $updated_count++;
     }

--- a/modules/custom/az_global_footer/data/az_global_footer.json
+++ b/modules/custom/az_global_footer/data/az_global_footer.json
@@ -246,7 +246,7 @@
       "link_id": "23",
       "parent_link_id": "0",
       "menu": "az-footer-topics",
-      "title": "Global Engagement",
+      "title": "International Engagement",
       "urlpath": "https://international.arizona.edu",
       "external": true,
       "expanded": false,

--- a/modules/custom/az_global_footer/data/az_global_footer.json
+++ b/modules/custom/az_global_footer/data/az_global_footer.json
@@ -247,7 +247,7 @@
       "parent_link_id": "0",
       "menu": "az-footer-topics",
       "title": "Global Engagement",
-      "urlpath": "https://global.arizona.edu",
+      "urlpath": "https://international.arizona.edu",
       "external": true,
       "expanded": false,
       "enabled": true,


### PR DESCRIPTION
## Description
Updates URL of "Global Engagement" link in `az_global_footer` topics menu.  (Changed from https://global.arizona.edu to https://international.arizona.edu).

Adds DB update to update link on existing sites.

## Related issues
Closes #1837

## How to test
- Verify that the Global Engagement link in the global footer points at https://international.arizona.edu after installing the `az_global_footer` module on a new site (e.g. on ProboCI)
- Apply PR as patch to existing Quickstart site already using the `az_global_footer` module and ensure Global Engagement link URL is updated after running DB updates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [x] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
