### PR TITLE
Closes #1888: Apply upstream config schema changes to easy_breadcrumb.settings.yml.

### DIFF
--- a/config/install/easy_breadcrumb.settings.yml
+++ b/config/install/easy_breadcrumb.settings.yml
@@ -1,26 +1,41 @@
 applies_admin_routes: false
 include_home_segment: false
+alternative_title_field: 'field_breadcrumb_title'
 home_segment_title: Home
 home_segment_keep: false
 include_title_segment: false
 language_path_prefix_as_segment: false
 use_menu_title_as_fallback: true
 use_page_title_as_menu_title_fallback: true
+menu_title_preferred_menu: ''
 remove_repeated_segments: true
 term_hierarchy: false
 absolute_paths: false
 hide_single_home_item: false
 title_from_page_when_available: false
 capitalizator_mode: ucwords
-capitalizator_ignored_words: 'of and or de del y o a'
-capitalizator_forced_words_first_letter: 0
-capitalizator_forced_words_case_sensitivity: 1
-add_structured_data_jsonld: false
+capitalizator_ignored_words:
+  - of
+  - and
+  - or
+  - de
+  - del
+  - 'y'
+  - o
+  - a
+capitalizator_forced_words: {  }
+capitalizator_forced_words_first_letter: false
+capitalizator_forced_words_case_sensitivity: true
+add_structured_data_json_ld: false
 use_site_title: false
 include_invalid_paths: false
-add_structured_data_json_ld: 0
 excluded_paths: ''
 replaced_titles: ''
 custom_paths: ''
 title_segment_as_link: false
-capitalizator_forced_words: ''
+follow_redirects: true
+limit_segment_display: FALSE
+segment_display_limit: 0
+truncator_mode: false
+truncator_length: 100
+truncator_dots: true


### PR DESCRIPTION
## Description
Fixes PHP error when loading Easy Breadcrumb module settings form being caused by out of date exported config in Quickstart.

## Related issues
Closes #1888 

## How to test
- Try to load the Easy breadcrumb module settings form at /admin/config/user-interface/easy-breadcrumb
- Verify that default Easy breadcrumb module settings are correct

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
