### PR TITLE
Fixes #1877 Snapshot only Necessary Config on Override

### DIFF
--- a/modules/custom/az_core/az_core.services.yml
+++ b/modules/custom/az_core/az_core.services.yml
@@ -4,6 +4,9 @@ services:
     arguments: ['@current_route_match']
     tags:
       - { name: page_cache_response_policy }
+  logger.channel.az_core:
+    parent: logger.channel_base
+    arguments: ['az_core']
   az_core.override_import:
     class: Drupal\az_core\AZConfigOverride
-    arguments: ['@config.factory', '@extension.list.module', '@config_provider.collector', '@config_sync.snapshotter', '@config_update.config_list', '@module_handler']
+    arguments: ['@config.factory', '@extension.list.module', '@config_provider.collector', '@config_sync.snapshotter', '@config_update.config_list', '@module_handler', '@logger.channel.az_core']


### PR DESCRIPTION
## Description
Under some rare circumstances, when using quickstart overrides, Quickstart may not understand that the same module contains non-overrides also, and snapshots them but does not apply them.

## Related issues
#1877 

## How to test
Verify quickstart overrides are applied to third-party module config without snap-shotting non-override config in the same module and leaving it unused.

Snapshots are stored in  `config_snapshot.snapshot.config_sync.module.my_module_name` collections in the `config` table of the database.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [x] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
