### PR TITLE
Closes #1911 Preprocess embedded entities before passing to text_format_recognizer

### DIFF
--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_node_uaqs_basic_page_to_az_page.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_node_uaqs_basic_page_to_az_page.yml
@@ -14,7 +14,7 @@ destination:
   bundle: az_flexible_page
 
 process:
-  type: 
+  type:
     plugin: default_value
     default_value: az_flexible_page
   langcode:
@@ -23,7 +23,7 @@ process:
     source: language
     map:
       und: en
-  
+
   title: title
   uid:
     -
@@ -42,7 +42,7 @@ process:
   sticky: sticky
 
   path/pathauto:
-    - 
+    -
       plugin: skip_on_empty
       source: alias
       method: process
@@ -51,7 +51,7 @@ process:
       default_value: 0
 
   path/alias:
-    - 
+    -
       plugin: skip_on_empty
       source: alias
       method: process

--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_uaqs_basic_page_to_az_page.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_uaqs_basic_page_to_az_page.yml
@@ -10,42 +10,57 @@ source:
   node_type: uaqs_page
 
 process:
-  destination_bundle:
-    plugin: text_format_recognizer
-    format: 'az_standard'
-    source: field_uaqs_body
-    required_module: 'az_paragraphs_html'
-    passed: 'az_text'
-    failed: 'az_html'
-    module_missing: 'az_text'
+  keep_row:
+    plugin: skip_on_empty
+    method: row
+    source: keep
+    message: 'Could not determine parent entity. Skipping.'
 
-  type:
-    -
-      plugin: array_shift
-      source: '@destination_bundle'
-    -
-      plugin: default_value
-      default_value: 'az_text'
-
-  field_az_full_html:
+  pseudo_processed_body_field:
     plugin: sub_process
     source: field_uaqs_body
     process:
       delta: delta
-      value: value
-      format:
-        plugin: default_value
-        default_value: full_html
-
+      value:
+        plugin: az_entity_embed_process
+        source: value
+      format: format
+  destination_bundle:
+    - plugin: text_format_recognizer
+      format: 'az_standard'
+      source: '@pseudo_processed_body_field'
+      required_module: 'az_paragraphs_html'
+      passed: 'az_text'
+      failed: 'az_html'
+      module_missing: 'az_text'
+  type:
+    - plugin: array_shift
+      source: '@destination_bundle'
+    - plugin: default_value
+      default_value: 'az_text'
+  field_az_full_html:
+    - plugin: sub_process
+      source: field_uaqs_body
+      process:
+        delta: delta
+        value:
+          plugin: az_entity_embed_process
+          source: value
+        format:
+          plugin: default_value
+          default_value: full_html
   field_az_text_area:
     plugin: sub_process
     source: field_uaqs_body
     process:
       delta: delta
-      value: value
+      value:
+        plugin: az_entity_embed_process
+        source: value
       format:
         plugin: default_value
         default_value: az_standard
+
 
 destination:
   plugin: 'entity_reference_revisions:paragraph'


### PR DESCRIPTION
## Description
Preprocess field to transform embedded entities into a form that QS2 can handle.

## Related issues
Closes #1911

## How to test
On a QS1 site Add a basic page
Embed an entity in the body field
Save

On a QS2 site set up to migrate from the QS1 site.
Run the az_migration group, and see the error.

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
