### PR TITLE
Closes #1915 Fix view mode default_value for az_paragraph_full_width_media_row migration.

### DIFF
--- a/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_full_width_media_row.yml
+++ b/modules/custom/az_migration/migrations/migrate_plus.migration.az_paragraph_full_width_media_row.yml
@@ -3,6 +3,7 @@ label: AZ Paragraph Full Width Media Row
 migration_group: az_migration
 migration_tags:
   - Quickstart Content Migration
+  - Quickstart Paragraphs
 status: true
 
 source:
@@ -87,7 +88,6 @@ process:
         uaqs_bg_img_content_left: 'col-md-8 col-lg-6'
         uaqs_bg_img_content_center: 'col-md-8 col-lg-6 col-md-offset-2 col-lg-offset-3'
         uaqs_bg_img_content_right: 'col-md-8 col-lg-6 col-md-offset-4 col-lg-offset-6'
-    - plugin: default_value
       default_value: 'col-md-8 col-lg-6'
   content_style_processed:
     - plugin: default_value


### PR DESCRIPTION
## Description
Add the default value for the static map in the correct place instead of as a separate plugin.

## Related issues
Closes #1915 

## How to test
Run a migration where the source site has full width media rows with empty view mode values.

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
