### PR TITLE
Closes #1922 Adding uaqs_alphabetical_listing to view mapping for views paragraph migration.

### DIFF
--- a/modules/custom/az_migration/src/Plugin/migrate/process/ViewsReferenceMapping.php
+++ b/modules/custom/az_migration/src/Plugin/migrate/process/ViewsReferenceMapping.php
@@ -119,6 +119,14 @@ class ViewsReferenceMapping extends ProcessPluginBase implements ContainerFactor
         'az_flexible_page_categories',
       ],
     ],
+    'uaqs_alphabetical_listing' => [
+      'view' => 'az_alphabetical_listing',
+      'display' => [
+        'default' => 'az_alphabetical_listing_main',
+        'page' => 'az_alphabetical_listing_main',
+      ],
+      'argument_migrations' => [],
+    ],
   ];
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This only affects sites that have uaqs_alphabetical_list turned on and allowed uaqs_alphabetical_list views to be referenced in a view reference paragraph.

See https://bitbucket.org/ua_drupal/ua_quickstart/src/7.x-1.x/modules/custom/uaqs_alphabetical_list/

## Related issues
Closes #1922 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [x] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
