### PR TITLE
Closes #1830: Update AZ Event Default view display to fix heading tags, reorder content

### DIFF
--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
@@ -9,7 +9,6 @@ dependencies:
     - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_link
     - field.field.node.az_event.field_az_location
-    - field.field.node.az_event.field_az_metatag
     - field.field.node.az_event.field_az_photos
     - field.field.node.az_event.field_az_subheading
     - field.field.node.az_event.field_az_summary
@@ -292,7 +291,6 @@ hidden:
   az_event_day: true
   az_event_month: true
   field_az_link: true
-  field_az_metatag: true
   field_az_summary: true
   links: true
   smart_title: true

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
@@ -118,7 +118,7 @@ third_party_settings:
         element: div
         show_label: true
         label_element: h2
-        label_element_classes: 'h3 mt-3'
+        label_element_classes: 'h3'
         attributes: ''
         effect: none
         speed: fast
@@ -137,7 +137,7 @@ third_party_settings:
         element: div
         show_label: true
         label_element: h2
-        label_element_classes: 'h3 mt-3'
+        label_element_classes: 'h3'
         attributes: ''
         effect: none
         speed: fast

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
@@ -34,7 +34,6 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: 'lead mb-3'
-        show_empty_fields: false
         id: ''
         element: div
         show_label: false
@@ -53,7 +52,6 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: 'clearfix pt-2'
-        show_empty_fields: false
         id: ''
         element: div
         show_label: false
@@ -73,7 +71,6 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: 'row mb-5'
-        show_empty_fields: false
         id: ''
         element: div
         show_label: false
@@ -112,7 +109,6 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: col-md-6
-        show_empty_fields: false
         id: ''
         element: div
         show_label: true
@@ -131,7 +127,6 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: col-md-6
-        show_empty_fields: false
         id: ''
         element: div
         show_label: true
@@ -150,7 +145,6 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: col-md-6
-        show_empty_fields: false
         id: ''
         element: div
         show_label: true
@@ -169,7 +163,6 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: col-md-6
-        show_empty_fields: false
         id: ''
         element: div
         show_label: true

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.az_event.field_az_event_date
     - field.field.node.az_event.field_az_link
     - field.field.node.az_event.field_az_location
+    - field.field.node.az_event.field_az_metatag
     - field.field.node.az_event.field_az_photos
     - field.field.node.az_event.field_az_subheading
     - field.field.node.az_event.field_az_summary
@@ -24,16 +25,17 @@ dependencies:
     - user
 third_party_settings:
   field_group:
-    group_span_subtitle:
+    group_subtitle_div:
       children:
         - field_az_subheading
-      label: 'span subtitle'
+      label: 'Subtitle Div'
       parent_name: group_wrapper
       region: content
-      weight: 8
+      weight: 9
       format_type: html_element
       format_settings:
         classes: 'lead mb-3'
+        show_empty_fields: false
         id: ''
         element: div
         show_label: false
@@ -42,35 +44,17 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-    group_category:
+    group_category_div:
       children:
         - field_az_event_category
       label: 'Category Div'
       parent_name: group_wrapper
       region: content
-      weight: 10
-      format_type: html_element
-      format_settings:
-        classes: clearfix
-        id: ''
-        element: div
-        show_label: false
-        label_element: h3
-        label_element_classes: ''
-        attributes: ''
-        effect: none
-        speed: fast
-    group_row_1:
-      children:
-        - group_col_1
-        - group_col_2
-      label: 'row 1'
-      parent_name: group_wrapper
-      region: content
       weight: 11
       format_type: html_element
       format_settings:
-        classes: row
+        classes: 'clearfix pt-2'
+        show_empty_fields: false
         id: ''
         element: div
         show_label: false
@@ -79,11 +63,31 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-    group_row_2:
+    group_when_where_row:
       children:
-        - group_col_3
-        - group_col_4
-      label: 'row 2'
+        - group_when_column
+        - group_where_column
+      label: 'When/Where Row'
+      parent_name: group_wrapper
+      region: content
+      weight: 8
+      format_type: html_element
+      format_settings:
+        classes: 'row mb-5'
+        show_empty_fields: false
+        id: ''
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+    group_contacts_attach_row:
+      children:
+        - group_contacts_column
+        - group_attachments_column
+      label: 'Contacts/Attachments Row'
       parent_name: group_wrapper
       region: content
       weight: 12
@@ -99,87 +103,90 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-    group_col_1:
+    group_when_column:
       children:
         - field_az_event_date
-      label: 'column 1'
-      parent_name: group_row_1
+      label: When
+      parent_name: group_when_where_row
       region: content
       weight: 13
       format_type: html_element
       format_settings:
         classes: col-md-6
+        show_empty_fields: false
         id: ''
         element: div
-        show_label: false
-        label_element: h3
-        label_element_classes: ''
+        show_label: true
+        label_element: h2
+        label_element_classes: 'h3 mt-3'
         attributes: ''
         effect: none
         speed: fast
-    group_col_2:
+    group_where_column:
       children:
         - field_az_location
-      label: 'column 2'
-      parent_name: group_row_1
+      label: Where
+      parent_name: group_when_where_row
       region: content
       weight: 14
       format_type: html_element
       format_settings:
         classes: col-md-6
+        show_empty_fields: false
         id: ''
         element: div
-        show_label: false
-        label_element: h3
-        label_element_classes: ''
+        show_label: true
+        label_element: h2
+        label_element_classes: 'h3 mt-3'
         attributes: ''
         effect: none
         speed: fast
-    group_col_3:
+    group_contacts_column:
       children:
         - field_az_contacts
-      label: 'column 3'
-      parent_name: group_row_2
+      label: Contacts
+      parent_name: group_contacts_attach_row
       region: content
       weight: 8
       format_type: html_element
       format_settings:
         classes: col-md-6
+        show_empty_fields: false
         id: ''
         element: div
-        show_label: false
-        label_element: h3
-        label_element_classes: ''
+        show_label: true
+        label_element: h2
+        label_element_classes: h3
         attributes: ''
         effect: none
         speed: fast
-    group_col_4:
+    group_attachments_column:
       children:
         - field_az_attachments
-      label: 'column 4'
-      parent_name: group_row_2
+      label: Attachments
+      parent_name: group_contacts_attach_row
       region: content
       weight: 9
       format_type: html_element
       format_settings:
         classes: col-md-6
+        show_empty_fields: false
         id: ''
         element: div
-        show_label: false
-        label_element: h3
-        label_element_classes: ''
+        show_label: true
+        label_element: h2
+        label_element_classes: h3
         attributes: ''
         effect: none
         speed: fast
     group_wrapper:
       children:
-        - links
         - field_az_photos
-        - group_span_subtitle
+        - group_when_where_row
+        - group_subtitle_div
         - field_az_body
-        - group_category
-        - group_row_1
-        - group_row_2
+        - group_category_div
+        - group_contacts_attach_row
       label: Wrapper
       parent_name: ''
       region: content
@@ -205,7 +212,7 @@ mode: default
 content:
   field_az_attachments:
     type: file_default
-    label: above
+    label: hidden
     settings:
       use_description_as_link_text: true
     third_party_settings: {  }
@@ -216,11 +223,11 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 9
+    weight: 10
     region: content
   field_az_contacts:
     type: entity_reference_revisions_entity_view
-    label: above
+    label: hidden
     settings:
       view_mode: default
       link: ''
@@ -237,7 +244,7 @@ content:
     region: content
   field_az_event_date:
     type: daterange_ap_style
-    label: above
+    label: hidden
     settings:
       always_display_year: '1'
       use_today: '1'
@@ -255,7 +262,7 @@ content:
     region: content
   field_az_location:
     type: link
-    label: above
+    label: hidden
     settings:
       trim_length: 80
       url_only: false
@@ -281,14 +288,11 @@ content:
     third_party_settings: {  }
     weight: 15
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 6
-    region: content
 hidden:
   az_event_day: true
   az_event_month: true
   field_az_link: true
+  field_az_metatag: true
   field_az_summary: true
+  links: true
   smart_title: true


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Closes #1830 with the following changes to the Default view display for the AZ Event content type:

1. Update the AZ Event Default display to show When, Where, Contacts, and Attachments headings as h2 elements with the h3 class
2. Change the order of the display to be: Event Photos, When/Where, Subtitle, Event Description, Category, Contacts, Attachments
3. Update the labels and machine names of the field groups on the display to be consistent with other Quickstart view displays
5. Add "mb-5" class to the When/Where row to fix vertical space between it and the event subtitle/description below it
6. Add "pt-2" class to the Category containing div to fix vertical space between it and the event subtitle/description above it
7. Disable the Links field since it doesn't appear to change the resulting HTML

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1830 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
View Quickstart demo events and create new events for testing these changes.

[Probo - Brian Test Event](https://5faa4bf7-8b57-40dd-ba41-198e1f4d5803.probo.build/events/brian-test-event)

Comparison of events from the Alumni site:

- Douglas Marshall Gallery: [Probo](https://5faa4bf7-8b57-40dd-ba41-198e1f4d5803.probo.build/events/santa-monica-ca-douglas-marshall-gallery-walk-through-and-panel-discussion) vs. [Alumni site](https://alumni.arizona.edu/events/douglas-marshall-gallery)
- 50th Reunion: [Probo](https://5faa4bf7-8b57-40dd-ba41-198e1f4d5803.probo.build/events/50th-reunion-and-silver-and-sage-society-homecoming-kickoff-mixer) vs. [Alumni site](https://alumni.arizona.edu/events/50th-reunion-and-silver-and-sage-society-homecoming-kickoff-mixer)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [x] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
