### PR TITLE
Closes #2002: Fix memory leak in core to improve stability of migrations.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -146,7 +146,8 @@
                 "Unrelated error message when running tests with database errors (3163925)": "https://www.drupal.org/files/issues/2022-05-12/3163925-19-9-2-x.patch",
                 "Add skip-method option to file_copy and download process plugins (2766369)": "https://www.drupal.org/files/issues/2022-04-23/2766369-33.patch",
                 "Move content overview default task link out of content_moderation module (3199682)": "https://www.drupal.org/files/issues/2022-02-10/3199682-11-9-4-x.patch",
-                "Changing an existing embedded media does not get saved with CKEditor (3102249)": "https://www.drupal.org/files/issues/2020-06-01/3102249-21.patch"
+                "Changing an existing embedded media does not get saved with CKEditor (3102249)": "https://www.drupal.org/files/issues/2020-06-01/3102249-21.patch",
+                "Improve migration system performance: statically cache DrupalSqlBase::$systemData (3154156)": "https://www.drupal.org/files/issues/2022-01-24/3154156-12.patch"
             },
             "drupal/config_distro": {
                 "fnmatch issue": "https://www.drupal.org/files/issues/2020-07-04/3144145-replace-fnmatch-with-preg-match-6.patch",


### PR DESCRIPTION
## Description
Adds patch for core's `migrate_drupal` module to address a known memory leak that exists in the `DrupalSqlBase` migration plugin (that many of our migration plugins extend):
https://www.drupal.org/project/drupal/issues/3154156

## Related issues
Closes #2002 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Try running our `az_migration` group on environments where crashes happened previously.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- Minor release changes
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- [ ] Other or unknown

### Drupal core
- Patch release changes
   - [ ] Security update
   - [x] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major or minor level update
- [ ] Other or unknown

### Drupal contrib projects
- Patch release changes
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- Minor release changes
   - [ ] Major level update
- [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
