### PR TITLE
Closes #2032: Move Event subtitle below title on default display

### DIFF
--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
@@ -28,9 +28,9 @@ third_party_settings:
       children:
         - field_az_subheading
       label: 'Subtitle Div'
-      parent_name: group_wrapper
+      parent_name: ''
       region: content
-      weight: 9
+      weight: 1
       format_type: html_element
       format_settings:
         classes: 'lead mb-3'
@@ -113,7 +113,7 @@ third_party_settings:
         element: div
         show_label: true
         label_element: h2
-        label_element_classes: 'h3'
+        label_element_classes: h3
         attributes: ''
         effect: none
         speed: fast
@@ -131,7 +131,7 @@ third_party_settings:
         element: div
         show_label: true
         label_element: h2
-        label_element_classes: 'h3'
+        label_element_classes: h3
         attributes: ''
         effect: none
         speed: fast
@@ -175,14 +175,13 @@ third_party_settings:
       children:
         - field_az_photos
         - group_when_where_row
-        - group_subtitle_div
         - field_az_body
         - group_category_div
         - group_contacts_attach_row
       label: Wrapper
       parent_name: ''
       region: content
-      weight: 0
+      weight: 2
       format_type: html_element
       format_settings:
         classes: mb-5

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.default.yml
@@ -33,7 +33,7 @@ third_party_settings:
       weight: 1
       format_type: html_element
       format_settings:
-        classes: 'lead mb-3'
+        classes: 'lead mb-4'
         id: ''
         element: div
         show_label: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This moves the subtitle display below the title on the default display mode.

## Related issues
Closes #2032 

## How to test
1. Create an event or edit an existing one
2. Complete the subtitle field
3. Observe subtitle is located below event title on default display

Example event: https://1be10c25-5fa3-46cf-8106-cee70b6a5130.probo.build/events/mini-health-screening-phoenix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- **Minor release changes**
   - [ ] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
