### PR TITLE
Closes #2009: Include Quickstart version in az_metrics (when available).

### DIFF
--- a/modules/custom/az_metrics/az_metrics.module
+++ b/modules/custom/az_metrics/az_metrics.module
@@ -23,7 +23,7 @@ function az_metrics_data() {
   }
 
   // Fetch information about installation profile.
-  $version = NULL;
+  $version = 'Untagged version';
   $extension_list = \Drupal::service('extension.list.module');
   $information = $extension_list->getExtensionInfo('az_quickstart');
   if (isset($information['version'])) {

--- a/modules/custom/az_metrics/az_metrics.module
+++ b/modules/custom/az_metrics/az_metrics.module
@@ -31,7 +31,7 @@ function az_metrics_data() {
   }
   $data = [
     'domains' => $domainList,
-    'version' => $version,
+    'quickstart_version' => $version,
     'mail' => \Drupal::config('system.site')->get('mail'),
     'name' => \Drupal::config('system.site')->get('name'),
     'uuid' => \Drupal::config('system.site')->get('uuid'),

--- a/modules/custom/az_metrics/az_metrics.module
+++ b/modules/custom/az_metrics/az_metrics.module
@@ -21,13 +21,11 @@ function az_metrics_data() {
   foreach ($domainQuery as $d) {
     array_push($domainList, $d->domain);
   }
-  
- // Fetch information about installation profile.
-    $information = $extension_list->getExtensionInfo('az_quickstart');
-    if (isset($information['version'])) {
-      $version = $information['version'];
-    }
-    
+  // Fetch information about installation profile.
+  $information = $extension_list->getExtensionInfo('az_quickstart');
+  if (isset($information['version'])) {
+    $version = $information['version'];
+  }
   $data = [
     'domains' => $domainList,
     'version' => $version,

--- a/modules/custom/az_metrics/az_metrics.module
+++ b/modules/custom/az_metrics/az_metrics.module
@@ -21,6 +21,7 @@ function az_metrics_data() {
   foreach ($domainQuery as $d) {
     array_push($domainList, $d->domain);
   }
+
   // Fetch information about installation profile.
   $version = NULL;
   $extension_list = \Drupal::service('extension.list.module');

--- a/modules/custom/az_metrics/az_metrics.module
+++ b/modules/custom/az_metrics/az_metrics.module
@@ -22,6 +22,8 @@ function az_metrics_data() {
     array_push($domainList, $d->domain);
   }
   // Fetch information about installation profile.
+  $version = NULL;
+  $extension_list = \Drupal::service('extension.list.module');
   $information = $extension_list->getExtensionInfo('az_quickstart');
   if (isset($information['version'])) {
     $version = $information['version'];

--- a/modules/custom/az_metrics/az_metrics.module
+++ b/modules/custom/az_metrics/az_metrics.module
@@ -21,9 +21,16 @@ function az_metrics_data() {
   foreach ($domainQuery as $d) {
     array_push($domainList, $d->domain);
   }
-
+  
+ // Fetch information about installation profile.
+    $information = $extension_list->getExtensionInfo('az_quickstart');
+    if (isset($information['version'])) {
+      $version = $information['version'];
+    }
+    
   $data = [
     'domains' => $domainList,
+    'version' => $version,
     'mail' => \Drupal::config('system.site')->get('mail'),
     'name' => \Drupal::config('system.site')->get('name'),
     'uuid' => \Drupal::config('system.site')->get('uuid'),


### PR DESCRIPTION
## Description
This PR adds in the version numbers to our AZ_Metrics module. This should give us better insight in to how different departments around campus are taking advantage of our different releases and also help us to identify sites that are in need of critical security updates.

## Related issues
#2009 

## How to test
Not sure how to test this.

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [x] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
