### PR TITLE
Closes #2060 AZ Migration: AZ Media should skip file types that do not exist in QS1.

### DIFF
--- a/modules/custom/az_migration/README.md
+++ b/modules/custom/az_migration/README.md
@@ -226,16 +226,24 @@ Source site pre-migration tasks :
 * Delete any files you don’t want migrated.
 * Check for any custom or overridden fields on file_entities.
 * Check for any custom file entity types.
+* Take note of any file types other than `image`, `audio`, `document`, `video`
 
 Migrate the related files using the below command :
 ```
-drush mim az_media
+drush migrate:import az_media
 ```
 
-To rollback the migrated file :
+Update migrated media after updating the codebase:
 ```
-drush mr az_media
+drush migrate:import az_media --update
 ```
+
+To rollback the migrated media:
+```
+drush migrate:rollback az_media
+```
+**Note: If you have custom file_entity types that you would like to migrate, you
+must create a custom migration.**
 
 ## Person migrations
 

--- a/modules/custom/az_migration/migrations/az_media.yml
+++ b/modules/custom/az_migration/migrations/az_media.yml
@@ -21,9 +21,20 @@ process:
 
   # Bundles must exist, previous machine names were image, document, etc.
   bundle:
-    plugin: az_media_bundle_recognizer
-    source: bundle
-    prefix: 'az_'
+    -
+      plugin: skip_on_value
+      source: type
+      method: row
+      value:
+        - image
+        - video
+        - document
+        - audio
+      not_equals: true
+      message: "Not a Quickstart 1 file_entity type, create a custom migration for this file_entity type."
+    -
+      plugin: az_media_bundle_recognizer
+      prefix: 'az_'
 
   # The mfid field is temporary, and is not present in the source.
   # Lookup fid through migration lookup. Should not depend on fid not changing.


### PR DESCRIPTION
## Description
In this PR, I use the `skip_on_value` process plugin with the `not_equals` negator set to true in order to skip all non-QS1 file types.

## Related issues
Closes #2060 

## How to test
Use a source site with a file_entity type that does not include one of the denoted file types
```
        - image
        - video
        - document
        - audio
```

See if non-QS1 file_entity types are migrated.

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
