### PR TITLE
Fixes #2014 Entity embed preprocess consumes elements.

### DIFF
--- a/modules/custom/az_migration/src/Plugin/migrate/process/EntityEmbedProcess.php
+++ b/modules/custom/az_migration/src/Plugin/migrate/process/EntityEmbedProcess.php
@@ -216,7 +216,9 @@ class EntityEmbedProcess extends ProcessPluginBase implements ContainerFactoryPl
     $value = mb_convert_encoding($value, 'HTML-ENTITIES', 'UTF-8');
 
     $dom = new \DOMDocument('1.0', 'UTF-8');
-    $dom->loadHTML($value, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+
+    // @see https://www.php.net/manual/en/domdocument.savehtml.php#121444 Libxml requires root element.
+    $dom->loadHTML('<entity-embed-process>' . $value . '</entity-embed-process>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NOWARNING | LIBXML_NOERROR);
     $elements = $dom->getElementsByTagName("drupal-entity");
 
     // Configuration of custom content.
@@ -295,7 +297,8 @@ class EntityEmbedProcess extends ProcessPluginBase implements ContainerFactoryPl
       }
     }
 
-    $value = $dom->SaveHTML();
+    // @see https://www.php.net/manual/en/domdocument.savehtml.php#121444 Remove the root tag we added.
+    $value = str_replace(['<entity-embed-process>', '</entity-embed-process>'], '', $dom->saveHTML());
     return $value;
   }
 


### PR DESCRIPTION
Entity embed preprocess emits warnings when parsing invalid tags, and sometimes consumes following elements to the embed.

## Description
Turned off warnings from DomDocument HTML parsing, and wrapped the tags in a temporary root tag. Libxml requires that a root tag exists, or it emits a closing copy of the first tag encountered. See [saveHTML()](https://www.php.net/manual/en/domdocument.savehtml.php)

## Related issues
#2014 

## How to test
Migrate content that contains both an embed and a following tag in the same html block and verify that no warnings are emitted and that the following tags don't disappear.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
