### PR TITLE
Fixes #2010 Add calendar cell information to non-view paths.

### DIFF
--- a/modules/custom/az_event/js/az_calendar_filter.es6.js
+++ b/modules/custom/az_event/js/az_calendar_filter.es6.js
@@ -109,11 +109,28 @@
               .attr('aria-pressed', 'false');
           }
 
+          // Get initial day if present.
+          const $inputWrapper = $wrapper.closest(
+            '.views-widget-az-calendar-filter',
+          );
+          const initial = $inputWrapper.find('input').eq(0).val();
+          let calendarInitialDay = new Date();
+          if (typeof initial !== 'undefined') {
+            const initialDates = initial.split('-');
+            if (initialDates.length === 3) {
+              calendarInitialDay = new Date(
+                initialDates[0],
+                initialDates[1] - 1,
+                initialDates[2],
+              );
+            }
+          }
           // Initialize the calendar datepicker options.
           $calendar.datepicker({
             dateFormat: 'm-d-yy',
             showOtherMonths: true,
             selectOtherMonths: true,
+            defaultDate: calendarInitialDay,
             dayNamesMin: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
             beforeShowDay(date) {
               // Loop through date ranges to determine if a day qualifies.

--- a/modules/custom/az_event/js/az_calendar_filter.js
+++ b/modules/custom/az_event/js/az_calendar_filter.js
@@ -4,23 +4,19 @@
 * https://www.drupal.org/node/2815083
 * @preserve
 **/
-
 (function ($, Drupal, drupalSettings) {
   Drupal.behaviors.azCalendarFilter = {
     attach: function attach(context, settings) {
       var filterInformation = drupalSettings.azCalendarFilter;
-
       if (!drupalSettings.hasOwnProperty('calendarFilterRanges')) {
         drupalSettings.calendarFilterRanges = [];
       }
-
       drupalSettings.azCalendarFilter = {};
       settings.azCalendarFilter = {};
       Object.keys(filterInformation).forEach(function (property) {
         if (filterInformation.hasOwnProperty(property)) {
           drupalSettings.calendarFilterRanges[property] = [];
           var ranges = filterInformation[property];
-
           for (var i = 0; i < ranges.length; i++) {
             drupalSettings.calendarFilterRanges[property].push([$.datepicker.parseDate('@', ranges[i][0] * 1000), $.datepicker.parseDate('@', ranges[i][1] * 1000)]);
           }
@@ -38,12 +34,10 @@
         var $submitButton = $wrapper.closest('.views-exposed-form').find('button.form-submit');
         var $dropDown = $wrapper.closest('.views-exposed-form').find('.form-select');
         var task = null;
-
         function triggerFilterChange($ancestor, delay) {
           if (task != null) {
             clearTimeout(task);
           }
-
           task = setTimeout(function () {
             if (!$submitButton.prop('disabled')) {
               $ancestor.find('input').eq(0).change();
@@ -54,57 +48,57 @@
             }
           }, delay);
         }
-
         $dropDown.on('change', function () {
           var $ancestor = $wrapper.closest('.views-widget-az-calendar-filter');
           triggerFilterChange($ancestor, 0);
         });
-
         function updateCalendarFilters(startDate, endDate) {
           var $ancestor = $wrapper.closest('.views-widget-az-calendar-filter');
           var dates = [startDate, endDate];
-
           for (var i = 0; i < dates.length; i++) {
             var month = dates[i].getMonth() + 1;
             var day = dates[i].getDate();
             var year = dates[i].getFullYear();
             $ancestor.find('input').eq(i).val("".concat(year, "-").concat(month, "-").concat(day));
           }
-
           triggerFilterChange($ancestor, 0);
           $ancestor.find('.btn').removeClass('active').attr('aria-pressed', 'false');
         }
-
+        var $inputWrapper = $wrapper.closest('.views-widget-az-calendar-filter');
+        var initial = $inputWrapper.find('input').eq(0).val();
+        var calendarInitialDay = new Date();
+        if (typeof initial !== 'undefined') {
+          var initialDates = initial.split('-');
+          if (initialDates.length === 3) {
+            calendarInitialDay = new Date(initialDates[0], initialDates[1] - 1, initialDates[2]);
+          }
+        }
         $calendar.datepicker({
           dateFormat: 'm-d-yy',
           showOtherMonths: true,
           selectOtherMonths: true,
+          defaultDate: calendarInitialDay,
           dayNamesMin: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
           beforeShowDay: function beforeShowDay(date) {
             var dateClass = 'calendar-filter-day-no-events';
             var time = date.getTime();
             var withinRange = false;
-
             if (rangeStart && rangeEnd) {
               if (rangeStart <= time && rangeEnd >= time) {
                 withinRange = true;
-
                 if (rangeStart === rangeEnd) {
                   return [true, 'calendar-filter-window'];
                 }
               }
             }
-
             if (drupalSettings.calendarFilterRanges.hasOwnProperty(rangeKey)) {
               var ranges = drupalSettings.calendarFilterRanges[rangeKey];
-
               for (var i = 0; i < ranges.length; i++) {
                 if (ranges[i][0].getTime() <= time && ranges[i][1].getTime() >= time) {
                   dateClass = withinRange ? 'calendar-filter-window' : 'calendar-filter-day-events';
                 }
               }
             }
-
             return [true, dateClass];
           },
           onChangeMonthYear: function onChangeMonthYear(year, month) {
@@ -135,7 +129,6 @@
           var diff = current.getDate() - day;
           var startDay = today;
           var endDay = today;
-
           if ($pressed.hasClass('calendar-filter-week')) {
             startDay = new Date(year, month, diff);
             endDay = new Date(year, month, diff + 6);
@@ -143,7 +136,6 @@
             startDay = new Date(year, month, 1);
             endDay = new Date(year, month + 1, 0);
           }
-
           $calendar.datepicker('setDate', startDay);
           $calendar.datepicker('setDate', null);
           rangeStart = startDay.getTime();

--- a/modules/custom/az_event/src/Plugin/views/filter/AZCalendarFilter.php
+++ b/modules/custom/az_event/src/Plugin/views/filter/AZCalendarFilter.php
@@ -36,7 +36,10 @@ class AZCalendarFilter extends Date {
       // Prepare a wrapper for the calendar JS to access.
       $calendar_element = [
         '#type' => 'container',
-        '#attached' => ['library' => ['az_event/az_calendar_filter']],
+        '#attached' => [
+          'library' => ['az_event/az_calendar_filter'],
+          'drupalSettings' => ['azCalendarFilter' => $filter_settings],
+        ],
         '#attributes' => [
           'class' => [
             'az-calendar-filter-wrapper',


### PR DESCRIPTION
Presently, if the exposed filter block for the full calendar appears on a path other than the one the view is on (e.g. `/calendar`) then the calendar cell highlighting for days with events does not work. This is because the javascript cell data information were javascript settings on the view, not the exposed filter.

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

This PR adds the javascript settings to the filter block as well. Also, since the main use of this is to put the date picker on another page, this PR also adds the feature to the javascript to read the initial filter value (e.g. if we load into the page and a different month than the current one is selected by the filters. Previously, the current month would always be selected.)

## Related issues
#2010 

## How to test

- Verify calendar still works as expected
- Add calendar exposed filter block to another page that doesn't have the view
- Verify that on the other page, the calendar continues to show shaded cells for days with events
- Change month or day on the exposed filter
- Verify it takes you to the calendar page
- Verify that the range you chose is used (e.g. if you switched to january, verify that the `/calendar` page and calendar show january.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- **Minor release changes**
   - [ ] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [x] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
