### PR TITLE
#690 Test Arizona Barrio TWBS equivalence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,9 @@
         "npm-asset/jquery-ui-touch-punch": "0.2.3",
         "npm-asset/slick-carousel": "1.8.0"
     },
+    "replace": {
+        "twbs/bootstrap": "*"
+    },
     "require-dev": {
         "az-digital/az-quickstart-dev": "~1"
     },


### PR DESCRIPTION
In the issue discussion on #690, @joshuasosa provided the good suggestion to try setting `az_barrio` to have composer settings to be replacement of `twbs/boostrap` as a means of causing `bootstrap_barrio` to not download the bootstrap source as it normally does. This might be a good means of addressing [our open barrio issue](https://www.drupal.org/project/bootstrap_barrio/issues/3138347) on our end.

## Related issues
#690 

## How to test
TBD - check if there are any packagist implications of providing this replacement setting

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [x] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
