### PR TITLE
PR for issue/1938: Include accessCheck() for all entity queries

### DIFF
--- a/modules/custom/az_global_footer/az_global_footer.install
+++ b/modules/custom/az_global_footer/az_global_footer.install
@@ -46,6 +46,7 @@ function az_global_footer_uninstall() {
 function az_global_footer_update_920501() {
   $updated_count = 0;
   $menu_link_content_ids = \Drupal::entityQuery('menu_link_content')
+    ->accessCheck(FALSE)
     ->condition('menu_name', 'az-footer-topics')
     ->condition('title', 'Global Engagement')
     ->condition('link__uri', 'https://global.arizona.edu')

--- a/modules/custom/az_paragraphs/az_paragraphs.install
+++ b/modules/custom/az_paragraphs/az_paragraphs.install
@@ -26,6 +26,7 @@ function az_paragraphs_update_920301(&$sandbox) {
   $paragraphs_per_batch = 25;
 
   $paragraph_ids = \Drupal::entityQuery('paragraph')
+    ->accessCheck(FALSE)
     ->range($sandbox['current'], $sandbox['current'] + $paragraphs_per_batch)
     ->execute();
 

--- a/modules/custom/az_paragraphs/az_paragraphs_text_background/az_paragraphs_text_background.install
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_background/az_paragraphs_text_background.install
@@ -31,6 +31,7 @@ function az_paragraphs_text_background_update_9201(&$sandbox) {
   $paragraphs_per_batch = 25;
 
   $paragraph_ids = \Drupal::entityQuery('paragraph')
+    ->accessCheck(FALSE)
     ->condition('type', 'az_text_background')
     ->range($sandbox['current'], $sandbox['current'] + $paragraphs_per_batch)
     ->execute();

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/az_paragraphs_text_media.install
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/az_paragraphs_text_media.install
@@ -27,6 +27,7 @@ function az_paragraphs_text_media_update_9201(&$sandbox) {
   $paragraphs_per_batch = 25;
 
   $paragraph_ids = \Drupal::entityQuery('paragraph')
+    ->accessCheck(FALSE)
     ->condition('type', 'az_text_media')
     ->range($sandbox['current'], $sandbox['current'] + $paragraphs_per_batch)
     ->execute();
@@ -70,6 +71,7 @@ function az_paragraphs_text_media_update_920401(&$sandbox) {
   $paragraphs_per_batch = 25;
 
   $paragraph_ids = \Drupal::entityQuery('paragraph')
+    ->accessCheck(FALSE)
     ->condition('type', 'az_text_media')
     ->range($sandbox['current'], $sandbox['current'] + $paragraphs_per_batch)
     ->execute();


### PR DESCRIPTION
As described in [this change record for Drupal core](https://www.drupal.org/node/3201242):

> ... all entity queries on content entities should always include an explicit call to ::accessCheck() prior to the query being executed. For Drupal 10 this will be enforced by throwing an exception if ::accessCheck() is not called.

This PR is based on branch issue/1938. It adds five more calls to accessCheck() for instances of \Drupal::entityQuery() in the Quickstart codebase. This should take care of the remaining entity queries which needed the accessCheck() call.