### PR TITLE
Fixes #2130 Barrio webform required field issue.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,6 +123,7 @@
                 "Remove jquery_ui_slider (3210947)": "https://www.drupal.org/files/issues/2022-02-16/3210947-12.patch"
             },
             "drupal/bootstrap_barrio": {
+                "Fix barrio webform required field issue": "https://gist.githubusercontent.com/tadean/09ef9559553c788c5637077462b392dd/raw/1190b7d78843af29e2eae31c4601a51e65e5b352/barrio_webform_required_field_issue.patch",
                 "Fix schema (3217958)": "https://gist.githubusercontent.com/trackleft/6b7752228979c6932e8d09e01381dd28/raw/70bd7ed90ab487b454a1106aa9935a335b7d4f49/gistfile1.txt",
                 "Node template contextual menu issue (3158009)": "https://www.drupal.org/files/issues/2020-07-09/node_contextual.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,7 @@
                 "Remove jquery_ui_slider (3210947)": "https://www.drupal.org/files/issues/2022-02-16/3210947-12.patch"
             },
             "drupal/bootstrap_barrio": {
-                "Fix barrio webform required field issue": "https://gist.githubusercontent.com/tadean/09ef9559553c788c5637077462b392dd/raw/1190b7d78843af29e2eae31c4601a51e65e5b352/barrio_webform_required_field_issue.patch",
+                "Fix barrio webform required field issue (3133643)": "https://gist.githubusercontent.com/tadean/09ef9559553c788c5637077462b392dd/raw/1190b7d78843af29e2eae31c4601a51e65e5b352/barrio_webform_required_field_issue.patch",
                 "Fix schema (3217958)": "https://gist.githubusercontent.com/trackleft/6b7752228979c6932e8d09e01381dd28/raw/70bd7ed90ab487b454a1106aa9935a335b7d4f49/gistfile1.txt",
                 "Node template contextual menu issue (3158009)": "https://www.drupal.org/files/issues/2020-07-09/node_contextual.patch"
             },


### PR DESCRIPTION
## Description
Quickstart currently does not display the red asterisk for webform fields because a required library is not included by our version of barrio. This has been fixed in [more recent barrio versions](https://www.drupal.org/project/bootstrap_barrio/issues/3133643). Until we update our version of barrio or decide to fork our subtheme we can fix the issue by including a template patch that includes the library.

## Related issues
#2130 

## How to test

- enable webform and webform UI
- create webform with a required field
- verify that the red asterisk is displayed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [x] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [x] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
