### PR TITLE
Fixes #2201 Custom form display disabled on module uninstall.

### DIFF
--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -287,7 +287,7 @@ class QuickstartConfigProvider extends ConfigProviderBase {
       $value = $this->addDefaultConfigHash($value);
       if (!$this->validateDependencies($name, $data, $enabled_extensions, $all_config)) {
         // Couldn't validate dependency.
-        \Drupal::logger('az_core')->notice("Could not validate dependences of override @name.", [
+        \Drupal::logger('az_core')->notice("Could not validate dependencies of override @name.", [
           '@name' => $name,
         ]);
         unset($data[$name]);

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -5,6 +5,8 @@ namespace Drupal\az_core\Plugin\ConfigProvider;
 use Drupal\config_provider\Plugin\ConfigProviderBase;
 use Drupal\Core\Config\InstallStorage;
 use Drupal\Core\Config\StorageInterface;
+use Drupal\config_snapshot\ConfigSnapshotStorageTrait;
+use Drupal\config_sync\ConfigSyncSnapshotterInterface;
 
 /**
  * Class for providing configuration from a quickstart default directory.
@@ -17,6 +19,8 @@ use Drupal\Core\Config\StorageInterface;
  * )
  */
 class QuickstartConfigProvider extends ConfigProviderBase {
+
+  use ConfigSnapshotStorageTrait;
 
   /**
    * The configuration provider ID.
@@ -201,6 +205,44 @@ class QuickstartConfigProvider extends ConfigProviderBase {
   }
 
   /**
+   * Checks if an active config item matches the distribution snapshot.
+   *
+   * @param string $name
+   *   The string name of a configuration item.
+   *
+   * @return bool
+   *   FALSE if the item is customized, or TRUE if it is synced.
+   */
+  protected function canOverride($name) {
+    /** @var \Drupal\config_update\ConfigListByProviderInterface $lister */
+    $lister = \Drupal::service('config_update.config_list');
+    /** @var \Drupal\config_update\ConfigDiffer $differ */
+    $differ = \Drupal::service('config_update.config_diff');
+
+    // Read active config value for name.
+    $active = $this->getActiveStorages()->read($name);
+    // Find out which module owns the configuration and load the snapshot value.
+    $owner = $lister->getConfigProvider($name);
+    if (!empty($owner[1])) {
+      $snapshot_storage = $this->getConfigSnapshotStorage(ConfigSyncSnapshotterInterface::CONFIG_SNAPSHOT_SET, $owner[0], $owner[1]);
+      $snap = $snapshot_storage->read($name);
+    }
+    // Guard against missing items.
+    $snap = (!empty($snap)) ? $snap : [];
+    $active = (!empty($active)) ? $active : [];
+    // Not relevant for user roles. Permissions created dynamically.
+    if (strpos($name, 'user.role.') !== 0) {
+      // Diff active config and snapshot of module to check for customization.
+      $diff = $differ->diff($active, $snap);
+      // Overrides only allowed if no changes in diff.
+      if (!$diff->isEmpty() && !empty($active)) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
+  /**
    * Returns a list of immediate overrides available at module install time.
    *
    * @param \Drupal\Core\Extension\Extension[] $extensions
@@ -215,7 +257,7 @@ class QuickstartConfigProvider extends ConfigProviderBase {
 
     // Find the direct overrides for use at module install time.
     $storage = $this->getExtensionInstallStorage(static::ID);
-    $config_names = $this->listConfig($storage, $extensions);
+    $config_names = (!empty($extensions)) ? $this->listConfig($storage, $extensions) : [];
     $data = $storage->readMultiple($config_names);
 
     // Get active configuration to check dependencies with.
@@ -226,13 +268,13 @@ class QuickstartConfigProvider extends ConfigProviderBase {
     // Get the install configuration present for the specified modules.
     // We need to check if an already-enabled module contained passive override.
     $install_storage = $this->getExtensionInstallStorage(InstallStorage::CONFIG_INSTALL_DIRECTORY);
-    $install_config_names = $this->listConfig($install_storage, $extensions);
+    $install_config_names = (!empty($extensions)) ? $this->listConfig($install_storage, $extensions) : [];
 
     // Now compare to quickstart config of already-loaded modules;
     // We are checking to see if an already loaded module contained a change
     // that couldn't be loaded previously for dependency reasons.
     $override_storage = $this->getExtensionInstallStorage(static::ID);
-    $override_config_names = $this->listConfig($override_storage, $old_extensions);
+    $override_config_names = (!empty($old_extensions)) ? $this->listConfig($override_storage, $old_extensions) : [];
     $intersect = array_intersect($override_config_names, $install_config_names);
     $overrides = $storage->readMultiple($intersect);
 
@@ -245,6 +287,16 @@ class QuickstartConfigProvider extends ConfigProviderBase {
       $value = $this->addDefaultConfigHash($value);
       if (!$this->validateDependencies($name, $data, $enabled_extensions, $all_config)) {
         // Couldn't validate dependency.
+        \Drupal::logger('az_core')->notice("Could not validate dependences of override @name.", [
+          '@name' => $name,
+        ]);
+        unset($data[$name]);
+      }
+      elseif (!$this->canOverride($name)) {
+        // Configuration is customized.
+        \Drupal::logger('az_core')->notice("Disallowing override of customized configuration @name.", [
+          '@name' => $name,
+        ]);
         unset($data[$name]);
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently when modules are disabled in Quickstart, customized entity form displays are being reverted, causing custom fields to become hidden on entity forms. This is a symptom of the fact that Quickstart configuration override modules are reapplying their override each time a module was uninstalled.

Our configuration provider uses the `listConfig()` function to gather information about changing module configuration to know what configuration may need overrides enabled, and when no modules are selected (e.g. no new modules is enabled), it returns all configuration rather than no configuration; this lead to our provider reapplying its overrides on every module uninstall. This PR puts in place a check to make sure the list of extensions isn't an empty array to prevent this.

Additionally, there is the more general problem that the configuration override system probably should not override things unless it is safe to. This PR puts in place a check that `diffs` the configuration of the active site and the last known configuration snapshot of a distribution module. Overrides are only allowed if the active configuration of a module is unchanged. This means overrides will no longer be applied if the configuration entity in the override is customized on the active site.

## Related issues
#2201 

## How to test

- Make a change to an entity form display for a quickstart content type, e.g. adding a new custom field to `az_person`
- disable a module
- verify the custom field is still in the person display
- disable `az_cas`
- make a change to the `cas` settings
- enable `az_cas`
- check the drupal log for warning that the override was ignored due to customizations (`Disallowing override of customized configuration`)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [x] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [x] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
