### PR TITLE
#2234: Allow smart_date 3.6.1 to be used since 3.7.0 requires PHP 8.0+.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
         "drupal/seckit": "2.0.1",
         "drupal/slick": "2.7.0",
         "drupal/slick_views": "2.6.0",
-        "drupal/smart_date": "3.7.0",
+        "drupal/smart_date": "3.6.1 || 3.7.0",
         "drupal/smart_title": "1.0-beta1",
         "drupal/smtp": "1.2.0",
         "drupal/token": "1.11.0",


### PR DESCRIPTION
## Description
Expands the `drupal/smart_date` composer version requirement to support either 3.7.0 or 3.6.1 since 3.7.0 requires PHP 8.0+ which won't be possible for all Quickstart site hosting environments yet.

## Related issues
#2234 

## How to test
`composer install` on web servers using either PHP 7.4 or 8.0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [x] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
