### PR TITLE
Closes #2268: Add drupal/asset_injector as optional module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/access_unpublished": "1.5.0",
         "drupal/antibot": "2.0.2",
+        "drupal/asset_injector": "2.16.0",
         "drupal/auto_entitylabel": "3.0.0",
         "drupal/background_image_formatter": "1.7",
         "drupal/better_exposed_filters": "5.0",


### PR DESCRIPTION
## Description
Adds [Asset Injector](https://www.drupal.org/project/asset_injector) module to Quickstart as optional module (disabled by default).

## Related issues
Closes #2268

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [x] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
