### PR TITLE
Closes #625 change filters to use better exposed filters

### DIFF
--- a/modules/custom/az_news/config/install/views.view.az_news.yml
+++ b/modules/custom/az_news/config/install/views.view.az_news.yml
@@ -26,46 +26,70 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+      title: News
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       pager:
         type: full
         options:
-          items_per_page: 10
           offset: 0
-          id: 0
+          items_per_page: 10
           total_pages: null
+          id: 0
           tags:
-            previous: ‹‹
             next: ››
+            previous: ‹‹
             first: '« First'
             last: 'Last »'
           expose:
@@ -77,91 +101,38 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-      style:
-        type: default
+      exposed_form:
+        type: bef
         options:
-          row_class: media-list-row
-          default_row_class: false
-          uses_fields: false
-      row:
-        type: 'entity:node'
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+          text_input_required: 'Select any filter and click on Apply to see results'
+          text_input_required_format: null
+          bef:
+            general:
+              autosubmit: false
+              autosubmit_exclude_textfield: false
+              autosubmit_textfield_delay: 500
+              autosubmit_hide: false
+              input_required: false
+              allow_secondary: false
+              secondary_label: 'Advanced options'
+              secondary_open: false
+            sort:
+              plugin_id: default
+      access:
+        type: perm
         options:
-          relationship: none
-          view_mode: az_media_list
-      fields:
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          entity_type: node
-          entity_field: title
-          label: ''
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            trim: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          value:
-            az_news: az_news
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
       sorts:
         field_az_published_value:
           id: field_az_published_value
@@ -170,13 +141,13 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           order: DESC
-          exposed: false
           expose:
             label: ''
             field_identifier: field_az_published_value
+          exposed: false
           granularity: second
-          plugin_id: datetime
         created:
           id: created
           table: node_field_data
@@ -184,20 +155,15 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-            field_identifier: created
-          granularity: second
           entity_type: node
           entity_field: created
           plugin_id: date
-      title: News
-      header: {  }
-      footer: {  }
-      empty: {  }
-      relationships: {  }
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
       arguments:
         term_node_tid_depth:
           id: term_node_tid_depth
@@ -206,6 +172,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: taxonomy_index_tid_depth
           default_action: ignore
           exception:
             value: all
@@ -220,8 +188,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -231,15 +199,61 @@ display:
             type: 'entity:taxonomy_term'
             fail: ignore
           validate_options:
-            operation: view
-            multiple: 1
             bundles: {  }
             access: false
-          depth: 1
+            operation: view
+            multiple: 1
           break_phrase: true
+          depth: 1
           use_taxonomy_term_path: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
           entity_type: node
-          plugin_id: taxonomy_index_tid_depth
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            az_news: az_news
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: default
+        options:
+          row_class: media-list-row
+          default_row_class: false
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: az_media_list
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -252,31 +266,16 @@ display:
         - user.permissions
       tags: {  }
   az_feature:
-    display_plugin: block
     id: az_feature
     display_title: 'Feature View'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
       pager:
         type: some
         options:
-          items_per_page: 1
           offset: 0
-      defaults:
-        pager: false
-        pager_options: false
-        sorts: false
-        style: false
-        row: false
-        style_options: false
-      row:
-        type: 'entity:node'
-        options:
-          relationship: none
-          view_mode: az_feature
-      pager_options: null
+          items_per_page: 1
       sorts:
         sticky:
           id: sticky
@@ -285,14 +284,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-            field_identifier: sticky
           entity_type: node
           entity_field: sticky
           plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: sticky
+          exposed: false
         field_az_published_value:
           id: field_az_published_value
           table: node__field_az_published
@@ -300,20 +299,35 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           order: DESC
-          exposed: false
           expose:
             label: ''
             field_identifier: field_az_published_value
+          exposed: false
           granularity: second
-          plugin_id: datetime
       style:
         type: default
         options:
           row_class: media-list-row
           default_row_class: false
           uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: az_feature
+      defaults:
+        pager: false
+        style: false
+        style_options: false
+        row: false
+        sorts: false
+        pager_options: false
+      display_description: ''
+      pager_options: null
       style_options: null
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -324,13 +338,16 @@ display:
         - user.permissions
       tags: {  }
   az_grid:
-    display_plugin: block
     id: az_grid
     display_title: 'Grid View'
+    display_plugin: block
     position: 3
     display_options:
-      display_extenders: {  }
-      display_description: ''
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 3
       style:
         type: views_bootstrap_grid
         options:
@@ -342,25 +359,17 @@ display:
           col_md: col-md-4
           col_lg: col-lg-4
           col_xl: col-xl-4
-      defaults:
-        style: false
-        row: false
-        pager: false
-        footer: false
       row:
         type: 'entity:node'
         options:
           relationship: none
           view_mode: az_card
-      block_description: 'Three column news block'
-      allow:
-        items_per_page: false
-      pager:
-        type: some
-        options:
-          items_per_page: 3
-          offset: 0
-      block_category: 'Lists (Views)'
+      defaults:
+        pager: false
+        style: false
+        row: false
+        footer: false
+      display_description: ''
       footer:
         area_text_custom:
           id: area_text_custom
@@ -369,10 +378,15 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: false
-          tokenize: false
-          content: "<div class=\"text-align-center\">\r\n<a title=\"Read all news\" class=\"btn btn-outline-blue\" href=\"/news\">Read all news</a>\r\n</div>\r\n"
           plugin_id: text_custom
+          empty: false
+          content: "<div class=\"text-align-center\">\r\n<a title=\"Read all news\" class=\"btn btn-outline-blue\" href=\"/news\">Read all news</a>\r\n</div>\r\n"
+          tokenize: false
+      display_extenders: {  }
+      block_description: 'Three column news block'
+      block_category: 'Lists (Views)'
+      allow:
+        items_per_page: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -383,53 +397,21 @@ display:
         - user.permissions
       tags: {  }
   az_grid_filter:
-    display_plugin: block
     id: az_grid_filter
     display_title: 'Grid View with Filter'
+    display_plugin: block
     position: 3
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      style:
-        type: views_bootstrap_grid
-        options:
-          row_class: ''
-          default_row_class: false
-          uses_fields: false
-          col_xs: col-12
-          col_sm: col-sm-12
-          col_md: col-md-4
-          col_lg: col-lg-4
-          col_xl: col-xl-4
-      defaults:
-        style: false
-        row: false
-        pager: false
-        footer: false
-        pager_options: false
-        style_options: false
-        exposed_form: false
-        filters: false
-        filter_groups: false
-        use_ajax: false
-      row:
-        type: 'entity:node'
-        options:
-          relationship: none
-          view_mode: az_card
-      block_description: 'Three column news block'
-      allow:
-        items_per_page: false
       pager:
         type: full
         options:
-          items_per_page: 9
           offset: 0
-          id: 0
+          items_per_page: 9
           total_pages: null
+          id: 0
           tags:
-            previous: '‹ Previous'
             next: 'Next ›'
+            previous: '‹ Previous'
             first: '« First'
             last: 'Last »'
           expose:
@@ -441,23 +423,6 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-      block_category: 'Lists (Views)'
-      footer:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: "<style>\r\n#views-exposed-form-az-news-az-grid-filter {\r\n    margin-bottom: 0.5em;\r\n}\r\n#views-exposed-form-az-news-az-grid-filter label {\r\n    font-weight: bold;\r\n    display: block;\r\n}\r\n#views-exposed-form-az-news-az-grid-filter select {\r\n    color: #001c48;\r\n    font-weight: 500;\r\n    text-decoration: none;\r\n    letter-spacing: .04em;\r\n    white-space: normal;\r\n    border-width: 2px;\r\n    background-color: #dee2e6;\r\n    border-color: #dee2e6;\r\n    display: inline-block;\r\n    text-align: center;\r\n    vertical-align: middle;\r\n    -webkit-user-select: none;\r\n    -moz-user-select: none;\r\n    -ms-user-select: none;\r\n    user-select: none;\r\n    padding: 0.375rem 0.75rem;\r\n    font-size: 1rem;\r\n    line-height: 1.5;\r\n    border-radius: 0;\r\n    transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;\r\n}\r\n</style>"
-            format: full_html
-          plugin_id: text
-      pager_options: null
-      style_options: null
       exposed_form:
         type: bef
         options:
@@ -491,27 +456,27 @@ display:
                   is_secondary: false
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            az_news: az_news
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            az_news: az_news
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -522,6 +487,7 @@ display:
           relationship: none
           group_type: group
           admin_label: Category
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -559,17 +525,65 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: true
-          type: select
-          limit: true
           vid: az_news_tags
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: views_bootstrap_grid
+        options:
+          row_class: ''
+          default_row_class: false
+          uses_fields: false
+          col_xs: col-12
+          col_sm: col-sm-12
+          col_md: col-md-4
+          col_lg: col-lg-4
+          col_xl: col-xl-4
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: az_card
+      defaults:
+        use_ajax: false
+        pager: false
+        exposed_form: false
+        style: false
+        style_options: false
+        row: false
+        filters: false
+        filter_groups: false
+        pager_options: false
+        footer: false
       use_ajax: true
+      display_description: ''
+      pager_options: null
+      style_options: null
+      footer:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: "<style>\r\n#views-exposed-form-az-news-az-grid-filter {\r\n    margin-bottom: 0.5em;\r\n}\r\n#views-exposed-form-az-news-az-grid-filter label {\r\n    font-weight: bold;\r\n    display: block;\r\n}\r\n#views-exposed-form-az-news-az-grid-filter select {\r\n    color: #001c48;\r\n    font-weight: 500;\r\n    text-decoration: none;\r\n    letter-spacing: .04em;\r\n    white-space: normal;\r\n    border-width: 2px;\r\n    background-color: #dee2e6;\r\n    border-color: #dee2e6;\r\n    display: inline-block;\r\n    text-align: center;\r\n    vertical-align: middle;\r\n    -webkit-user-select: none;\r\n    -moz-user-select: none;\r\n    -ms-user-select: none;\r\n    user-select: none;\r\n    padding: 0.375rem 0.75rem;\r\n    font-size: 1rem;\r\n    line-height: 1.5;\r\n    border-radius: 0;\r\n    transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;\r\n}\r\n</style>"
+            format: full_html
+          tokenize: false
+      display_extenders: {  }
+      block_description: 'Three column news block'
+      block_category: 'Lists (Views)'
+      allow:
+        items_per_page: false
     cache_metadata:
       max-age: -1
       contexts:
@@ -582,30 +596,30 @@ display:
         - user.permissions
       tags: {  }
   az_paged_row:
-    display_plugin: page
     id: az_paged_row
     display_title: 'Paged Row View'
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: news
-      display_description: ''
       style:
         type: default
         options:
           row_class: media-list-row
           default_row_class: false
           uses_fields: false
-      defaults:
-        style: false
-        row: false
-        style_options: false
       row:
         type: 'entity:node'
         options:
           relationship: none
           view_mode: az_media_list
+      defaults:
+        style: false
+        style_options: false
+        row: false
+      display_description: ''
       style_options: null
+      display_extenders: {  }
+      path: news
     cache_metadata:
       max-age: -1
       contexts:
@@ -617,69 +631,17 @@ display:
         - user.permissions
       tags: {  }
   az_sidebar:
-    display_plugin: block
     id: az_sidebar
     display_title: 'Small Row View'
+    display_plugin: block
     position: 4
     display_options:
-      display_extenders: {  }
-      display_description: ''
+      title: News
       pager:
         type: some
         options:
-          items_per_page: 3
           offset: 0
-      defaults:
-        pager: false
-        filters: false
-        filter_groups: false
-        title: false
-        style: false
-        row: false
-        arguments: false
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          value:
-            az_news: az_news
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
-      block_description: 'Sidebar News Block'
-      title: News
-      style:
-        type: default
-        options:
-          row_class: media-list-row
-          default_row_class: false
-          uses_fields: false
-      row:
-        type: 'entity:node'
-        options:
-          relationship: none
-          view_mode: az_minimal_media_list
+          items_per_page: 3
       arguments:
         term_node_tid_depth:
           id: term_node_tid_depth
@@ -688,6 +650,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: taxonomy_index_tid_depth
           default_action: ignore
           exception:
             value: all
@@ -702,8 +666,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -713,15 +677,13 @@ display:
             type: 'entity:taxonomy_term'
             fail: ignore
           validate_options:
-            operation: view
-            multiple: 1
             bundles: {  }
             access: false
-          depth: 1
+            operation: view
+            multiple: 1
           break_phrase: true
+          depth: 1
           use_taxonomy_term_path: false
-          entity_type: node
-          plugin_id: taxonomy_index_tid_depth
         nid:
           id: nid
           table: node_field_data
@@ -729,6 +691,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
           default_action: default
           exception:
             value: all
@@ -742,8 +707,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -755,14 +720,63 @@ display:
           validate_options:
             bundles:
               az_news: az_news
+            access: false
             operation: view
             multiple: 0
-            access: false
           break_phrase: false
           not: true
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
           entity_type: node
-          entity_field: nid
-          plugin_id: node_nid
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            az_news: az_news
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+        options:
+          row_class: media-list-row
+          default_row_class: false
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: az_minimal_media_list
+      defaults:
+        title: false
+        pager: false
+        style: false
+        row: false
+        arguments: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
+      block_description: 'Sidebar News Block'
     cache_metadata:
       max-age: -1
       contexts:
@@ -773,47 +787,21 @@ display:
         - user.permissions
       tags: {  }
   az_teaser_grid:
-    display_plugin: page
     id: az_teaser_grid
     display_title: 'Teaser Grid Page'
+    display_plugin: page
     position: 5
     display_options:
-      display_extenders: {  }
-      display_description: 'Grid of teasers that appears on /news-teasers (offset by 4)'
-      style:
-        type: views_bootstrap_grid
-        options:
-          row_class: ''
-          default_row_class: false
-          uses_fields: false
-          col_xs: col-12
-          col_sm: col-sm-12
-          col_md: col-md-4
-          col_lg: col-lg-4
-          col_xl: col-xl-4
-      defaults:
-        style: false
-        row: false
-        style_options: false
-        pager: false
-        pager_options: false
-      row:
-        type: 'entity:node'
-        options:
-          relationship: none
-          view_mode: az_card
-      style_options: null
-      path: news-teasers
       pager:
         type: full
         options:
-          items_per_page: 12
           offset: 4
-          id: 0
+          items_per_page: 12
           total_pages: null
+          id: 0
           tags:
-            previous: ‹‹
             next: ››
+            previous: ‹‹
             first: '« First'
             last: 'Last »'
           expose:
@@ -825,7 +813,33 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
+      style:
+        type: views_bootstrap_grid
+        options:
+          row_class: ''
+          default_row_class: false
+          uses_fields: false
+          col_xs: col-12
+          col_sm: col-sm-12
+          col_md: col-md-4
+          col_lg: col-lg-4
+          col_xl: col-xl-4
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: az_card
+      defaults:
+        pager: false
+        style: false
+        style_options: false
+        row: false
+        pager_options: false
+      display_description: 'Grid of teasers that appears on /news-teasers (offset by 4)'
       pager_options: null
+      style_options: null
+      display_extenders: {  }
+      path: news-teasers
     cache_metadata:
       max-age: -1
       contexts:
@@ -837,27 +851,17 @@ display:
         - user.permissions
       tags: {  }
   marquee:
-    display_plugin: block
     id: marquee
     display_title: 'Recent News Marquee'
+    display_plugin: block
     position: 6
     display_options:
-      display_extenders: {  }
-      display_description: ''
+      title: ''
       pager:
         type: some
         options:
-          items_per_page: 1
           offset: 0
-      defaults:
-        pager: false
-        pager_options: false
-        style: false
-        row: false
-        style_options: false
-        title: false
-        css_class: false
-      pager_options: null
+          items_per_page: 1
       style:
         type: default
         options:
@@ -869,10 +873,20 @@ display:
         options:
           relationship: none
           view_mode: az_marquee
-      style_options: null
-      block_description: 'Recent News Marquee'
-      title: ''
+      defaults:
+        title: false
+        css_class: false
+        pager: false
+        style: false
+        style_options: false
+        row: false
+        pager_options: false
       css_class: row
+      display_description: ''
+      pager_options: null
+      style_options: null
+      display_extenders: {  }
+      block_description: 'Recent News Marquee'
       allow:
         items_per_page: false
     cache_metadata:
@@ -885,32 +899,17 @@ display:
         - user.permissions
       tags: {  }
   row_attachment:
-    display_plugin: attachment
     id: row_attachment
     display_title: 'Row Attachment'
+    display_plugin: attachment
     position: 7
     display_options:
-      display_extenders: {  }
       title: ''
-      defaults:
-        title: false
-        pager: false
-        pager_options: false
-        css_class: false
-        style: false
-        row: false
-        style_options: false
-      displays:
-        marquee: marquee
-      attachment_position: after
-      inherit_arguments: true
       pager:
         type: some
         options:
-          items_per_page: 3
           offset: 1
-      pager_options: null
-      css_class: ''
+          items_per_page: 3
       style:
         type: default
         options:
@@ -922,8 +921,23 @@ display:
         options:
           relationship: none
           view_mode: az_medium_media_list
-      style_options: null
+      defaults:
+        title: false
+        css_class: false
+        pager: false
+        style: false
+        style_options: false
+        row: false
+        pager_options: false
+      css_class: ''
       display_description: ''
+      pager_options: null
+      style_options: null
+      display_extenders: {  }
+      displays:
+        marquee: marquee
+      attachment_position: after
+      inherit_arguments: true
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
<!--- Change filters to use better exposed filters -->

## Description
<!--- Did this for a Workshop show and tell -->
Did this for a Workshop show and tell.

## Related issues
#625 
## How to test
Go to the Az New View and go under Advanced to confirm that the better exposed filters is selected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
