### PR TITLE
Fixes #2312 Changes to existing news, event and person content do not update without clearing cache.

### DIFF
--- a/modules/custom/az_news/az_news.module
+++ b/modules/custom/az_news/az_news.module
@@ -61,7 +61,6 @@ function az_news_node_view(array &$build, EntityInterface $entity, EntityViewDis
             'node' => $entity,
           ], [], $bubbleable_metadata)),
       ];
-      $bubbleable_metadata->applyTo($build);
     }
   }
 

--- a/modules/custom/az_news/az_news.module
+++ b/modules/custom/az_news/az_news.module
@@ -51,9 +51,9 @@ function az_news_entity_extra_field_info() {
 function az_news_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
 
   if ($entity instanceof FieldableEntityInterface && $entity->hasField('field_az_link')) {
-    $bubbleable_metadata = new BubbleableMetadata();
     // Read more pseudo field.
     if ($display->getComponent('az_news_read_more')) {
+      $bubbleable_metadata = new BubbleableMetadata();
       $build['az_news_read_more'][] = [
         '#type' => 'markup',
         '#markup' => Html::escape(\Drupal::service('token')
@@ -61,8 +61,8 @@ function az_news_node_view(array &$build, EntityInterface $entity, EntityViewDis
             'node' => $entity,
           ], [], $bubbleable_metadata)),
       ];
+      $bubbleable_metadata->applyTo($build);
     }
-    $bubbleable_metadata->applyTo($build);
   }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a bug in the AZ News module that was poisoning the cache metadata on all content types with a `field_az_links` instance in displays without the `az_news_read_more` fieldgroup (i.e. the default full displays for AZ News, AZ Person, AZ Event).
 
## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2312 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

- Change a field values on an existing Person, News or Event nodes
- Check to see whether the changes are reflected immediately or not without needing to manually clear caches

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
