### PR TITLE
Closes #2315: Downgrade menu_block to 8.x-1.7 until we have a better solution for empty sidebars getting rendered.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -180,9 +180,6 @@
             "drupal/media_migration": {
                 "Catch migrate RequirementsExceptions (3268480)": "https://www.drupal.org/files/issues/2022-03-08/3268480-2.patch"
             },
-            "drupal/menu_block": {
-                "Menu block renders when tree is empty as of 8.x-1.8 [regression] (3271218)": "https://www.drupal.org/files/issues/2022-04-29/menu_block_rendered_empty-3271218-17.patch"
-            },
             "drupal/migrate_plus": {
                 "XML namespacing issue (2933531)": "https://www.drupal.org/files/issues/2019-08-22/register_namespaces-2933531-7.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "drupal/media_library_form_element": "2.0.6",
         "drupal/media_library_theme_reset": "1.5.0",
         "drupal/media_migration": "1.0.0-alpha16",
-        "drupal/menu_block": "1.10.0",
+        "drupal/menu_block": "1.7.0",
         "drupal/menu_link_attributes": "1.3.0",
         "drupal/metatag": "1.22.0",
         "drupal/migrate_plus": "5.3.0",


### PR DESCRIPTION
## Description
Downgrades menu_block back to 8.x-1.7 (the version used in Quickstart 2.5.x).  This should resolve the immediate problems identified in issue #2315 for now for sites upgrading to Quickstart 2.6.x and give us time to find a better solution to deal with the larger core issue that is the underlying cause of the issue: https://www.drupal.org/project/drupal/issues/953034

This reverts PR #2049.

Verified that no database or config schema changes exist between 8.x-1.7 and 8.x-1.10.

## Related issues
Closes #2315 

## How to test
- Add a custom menu
- Add a menu block for the new menu to the sidebar first region
- Verify that an empty sidebar is not displayed for pages not in the menu

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [x] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
