### PR TITLE
Close #2424 Adding badge display for all default taxonomy vocabularies.

### DIFF
--- a/modules/custom/az_core/config/install/smart_title.settings.yml
+++ b/modules/custom/az_core/config/install/smart_title.settings.yml
@@ -5,5 +5,8 @@ smart_title:
   - 'node:az_news'
   - 'node:az_flexible_page'
   - 'node:az_person'
+  - 'taxonomy_term:az_event_categories'
+  - 'taxonomy_term:az_news_tags'
+  - 'taxonomy_term:az_page_categories'
   - 'taxonomy_term:az_person_categories'
   - 'taxonomy_term:az_person_categories_secondary'

--- a/modules/custom/az_event/config/install/core.entity_view_display.taxonomy_term.az_event_categories.az_badge.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.taxonomy_term.az_event_categories.az_badge.yml
@@ -1,0 +1,44 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.taxonomy_term.az_badge
+    - taxonomy.vocabulary.az_event_categories
+  module:
+    - field_group
+    - smart_title
+third_party_settings:
+  smart_title:
+    enabled: true
+    settings:
+      smart_title__link: false
+      smart_title__tag: div
+      smart_title__classes: {  }
+  field_group:
+    group_link:
+      children:
+        - smart_title
+      label: Link
+      parent_name: ''
+      region: content
+      weight: 0
+      format_type: link
+      format_settings:
+        classes: 'badge badge-light badge-link'
+        show_empty_fields: false
+        id: ''
+        target: entity
+        custom_uri: ''
+        target_attribute: default
+id: taxonomy_term.az_event_categories.az_badge
+targetEntityType: taxonomy_term
+bundle: az_event_categories
+mode: az_badge
+content:
+  smart_title:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  description: true

--- a/modules/custom/az_flexible_page/config/install/core.entity_view_display.taxonomy_term.az_page_categories.az_badge.yml
+++ b/modules/custom/az_flexible_page/config/install/core.entity_view_display.taxonomy_term.az_page_categories.az_badge.yml
@@ -1,0 +1,44 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.taxonomy_term.az_badge
+    - taxonomy.vocabulary.az_page_categories
+  module:
+    - field_group
+    - smart_title
+third_party_settings:
+  smart_title:
+    enabled: true
+    settings:
+      smart_title__link: false
+      smart_title__tag: div
+      smart_title__classes: {  }
+  field_group:
+    group_link:
+      children:
+        - smart_title
+      label: Link
+      parent_name: ''
+      region: content
+      weight: 0
+      format_type: link
+      format_settings:
+        classes: 'badge badge-light badge-link'
+        show_empty_fields: false
+        id: ''
+        target: entity
+        custom_uri: ''
+        target_attribute: default
+id: taxonomy_term.az_page_categories.az_badge
+targetEntityType: taxonomy_term
+bundle: az_page_categories
+mode: az_badge
+content:
+  smart_title:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  description: true

--- a/modules/custom/az_news/config/install/core.entity_view_display.taxonomy_term.az_news_tags.az_badge.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.taxonomy_term.az_news_tags.az_badge.yml
@@ -1,0 +1,44 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.taxonomy_term.az_badge
+    - taxonomy.vocabulary.az_news_tags
+  module:
+    - field_group
+    - smart_title
+third_party_settings:
+  smart_title:
+    enabled: true
+    settings:
+      smart_title__link: false
+      smart_title__tag: div
+      smart_title__classes: {  }
+  field_group:
+    group_link:
+      children:
+        - smart_title
+      label: Link
+      parent_name: ''
+      region: content
+      weight: 0
+      format_type: link
+      format_settings:
+        classes: 'badge badge-light badge-link'
+        show_empty_fields: false
+        id: ''
+        target: entity
+        custom_uri: ''
+        target_attribute: default
+id: taxonomy_term.az_news_tags.az_badge
+targetEntityType: taxonomy_term
+bundle: az_news_tags
+mode: az_badge
+content:
+  smart_title:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  description: true


### PR DESCRIPTION
## Description
Implemented the az_badge display for all default taxonomy vocabularies so that we can use them in additional displays.

## Related issues
Related to #2406 
Related to #2423 
Related to #2398

## How to test
Add taxonomy as rendered entity to any display mode, and choose Badge.

## Types of changes
Enhancement.

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [x] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
