### PR TITLE
Closes #2382 - Fix PHP 8 code deprecation in custom smart_date migrate plugin.

### DIFF
--- a/modules/custom/az_event/src/Plugin/migrate/process/SmartDateCreateRecurrenceOnField.php
+++ b/modules/custom/az_event/src/Plugin/migrate/process/SmartDateCreateRecurrenceOnField.php
@@ -37,7 +37,7 @@ class SmartDateCreateRecurrenceOnField extends ProcessPluginBase {
       $rrule = SmartDateRule::load($value);
       if ($rrule) {
         $values = [];
-        $first_instance = FALSE;
+        $first_instance = [];
         $before = NULL;
         // Retrieve all instances for this rule, with overrides applied.
         if (empty($rrule->get('limit')->getString())) {


### PR DESCRIPTION
## Description
Fixes a PHP 8 code deprecation error when installing AZ Demo module.

## Related issues
Closes #2382 

## How to test
Install AZ Demo & check error logs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
