### PR TITLE
Fixes #2439 Add Publication Image to Full View Display and Card View Display

### DIFF
--- a/modules/custom/az_core/config/install/smart_title.settings.yml
+++ b/modules/custom/az_core/config/install/smart_title.settings.yml
@@ -5,6 +5,7 @@ smart_title:
   - 'node:az_news'
   - 'node:az_flexible_page'
   - 'node:az_person'
+  - 'node:az_publication'
   - 'taxonomy_term:az_event_categories'
   - 'taxonomy_term:az_news_tags'
   - 'taxonomy_term:az_page_categories'

--- a/modules/custom/az_publication/az_publication.info.yml
+++ b/modules/custom/az_publication/az_publication.info.yml
@@ -30,3 +30,4 @@ dependencies:
   - 'optional_end_date:optional_end_date'
   - 'paragraphs:paragraphs'
   - 'pathauto:pathauto'
+  - 'smart_title:smart_title'

--- a/modules/custom/az_publication/config/install/core.entity_view_display.node.az_publication.az_card.yml
+++ b/modules/custom/az_publication/config/install/core.entity_view_display.node.az_publication.az_card.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.node.az_card
     - field.field.node.az_publication.field_az_accessed_date
     - field.field.node.az_publication.field_az_authors
     - field.field.node.az_publication.field_az_publication_abstract
@@ -27,7 +28,6 @@ dependencies:
   module:
     - field_group
     - smart_title
-    - text
     - user
 third_party_settings:
   field_group:
@@ -35,12 +35,12 @@ third_party_settings:
       children:
         - az_publication_bibliography
       label: Reference
-      parent_name: group_information
+      parent_name: group_link
       region: content
-      weight: 3
+      weight: 7
       format_type: html_element
       format_settings:
-        classes: ''
+        classes: 'text-muted font-weight-normal small mt-2'
         show_empty_fields: false
         id: ''
         element: div
@@ -50,17 +50,16 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-    group_row:
+    group_card_clickable:
       children:
-        - group_information
-        - group_cover
-      label: Row
+        - group_link
+      label: 'Card Clickable'
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: ' row mb-2 d-flex'
+        classes: 'card card-borderless card-clickable mb-4'
         show_empty_fields: false
         id: ''
         element: div
@@ -70,125 +69,78 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-    group_cover:
-      children:
-        - group_cover_link
-      label: Cover
-      parent_name: group_row
-      region: content
-      weight: 8
-      format_type: html_element
-      format_settings:
-        classes: 'col-12 col-md-4 order-md-1'
-        show_empty_fields: false
-        id: ''
-        element: div
-        show_label: false
-        label_element: h3
-        label_element_classes: ''
-        attributes: ''
-        effect: none
-        speed: fast
-    group_information:
-      children:
-        - group_az_publication_reference
-        - field_az_publication_abstract
-        - group_file
-      label: Information
-      parent_name: group_row
-      region: content
-      weight: 7
-      format_type: html_element
-      format_settings:
-        classes: 'col-12 col-md-8 order-md-2'
-        show_empty_fields: false
-        id: ''
-        element: div
-        show_label: false
-        label_element: h3
-        label_element_classes: ''
-        attributes: ''
-        effect: none
-        speed: fast
-    group_file:
-      children:
-        - field_az_publication_media
-      label: File
-      parent_name: group_information
-      region: content
-      weight: 5
-      format_type: html_element
-      format_settings:
-        classes: mb-2
-        show_empty_fields: false
-        id: ''
-        element: div
-        show_label: false
-        label_element: h3
-        label_element_classes: ''
-        attributes: ''
-        effect: none
-        speed: fast
-    group_cover_link:
+    group_link:
       children:
         - field_az_publication_image
-      label: 'Cover Link'
-      parent_name: group_cover
+        - group_heading
+        - group_az_publication_reference
+      label: Link
+      parent_name: group_card_clickable
       region: content
-      weight: 2
+      weight: 1
       format_type: link
       format_settings:
-        classes: ''
+        classes: 'card-body p-0 hide-contextual-links'
         show_empty_fields: false
         id: ''
-        target: custom_uri
-        custom_uri: '[node:field_az_publication_media:entity:field_media_az_document:entity:url]'
+        target: entity
+        custom_uri: ''
         target_attribute: default
+    group_heading:
+      children:
+        - smart_title
+      label: Heading
+      parent_name: group_link
+      region: content
+      weight: 6
+      format_type: html_element
+      format_settings:
+        classes: 'card-title text-midnight h5 mb-0'
+        show_empty_fields: false
+        id: ''
+        element: h4
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
   smart_title:
-    enabled: false
-id: node.az_publication.default
+    enabled: true
+    settings:
+      smart_title__link: false
+      smart_title__tag: ''
+      smart_title__classes:
+        - card-clickable-link
+        - mt-2
+id: node.az_publication.az_card
 targetEntityType: node
 bundle: az_publication
-mode: default
+mode: az_card
 content:
   az_publication_bibliography:
     settings: {  }
     third_party_settings: {  }
     weight: 0
     region: content
-  field_az_publication_abstract:
-    type: text_default
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 4
-    region: content
   field_az_publication_image:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: az_medium
+      view_mode: az_card_image
       link: false
     third_party_settings: {  }
-    weight: 2
+    weight: 5
     region: content
-  field_az_publication_media:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: default
-      link: false
-    third_party_settings: {  }
-    weight: 2
-    region: content
-  links:
+  smart_title:
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 4
     region: content
 hidden:
   field_az_accessed_date: true
   field_az_authors: true
+  field_az_publication_abstract: true
   field_az_publication_approximate: true
   field_az_publication_category: true
   field_az_publication_container: true
@@ -199,10 +151,11 @@ hidden:
   field_az_publication_issue: true
   field_az_publication_link: true
   field_az_publication_location: true
+  field_az_publication_media: true
   field_az_publication_page: true
   field_az_publication_pmid: true
   field_az_publication_publisher: true
   field_az_publication_type: true
   field_az_publication_version: true
   field_az_publication_volume: true
-  smart_title: true
+  links: true

--- a/modules/custom/az_publication/config/install/core.entity_view_display.node.az_publication.default.yml
+++ b/modules/custom/az_publication/config/install/core.entity_view_display.node.az_publication.default.yml
@@ -44,9 +44,9 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         element: div
-        show_label: false
+        show_label: true
         label_element: div
-        label_element_classes: 'h3 mb-0'
+        label_element_classes: 'h3 mb-0 mt-0'
         attributes: ''
         effect: none
         speed: fast


### PR DESCRIPTION
Presently the publication image media field on publications is not used by any active displays. This PR adds the publication image to the default display, and adds a card display that contains the image, title, and publishing reference.

The image is considered optional and is used for sites that wish to have cover images associated with their publications.

Publication images are not used in bibliographies, i.e. they do not appear in views that use the Publication Reference view mode.

## Related issues
#2439 

## How to test

- Enable `az_publication` (and `az_demo` optionally, if you want some media images already on the site)
- Create some publications; make sure some have images and publication documents
- Verify that if a publication has an image, it is displayed (in node view) alongside the reference and abstract
- If the publication has an image and a document, verify that the image links to the document.
- In node view, verify that on mobile sizes, the cover image appears **below** the reference and abstract, not above it.
- Create a new view that displays publications. Use bootstrap grid (3 items per row) and use the card display mode
- Visit the view
- Verify that cards work and contain the cover image, title, and reference.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [x] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
