### PR TITLE
Fixes #2362 Publication Views exposed filters overlap

### DIFF
--- a/modules/custom/az_publication/az_publication.module
+++ b/modules/custom/az_publication/az_publication.module
@@ -303,11 +303,11 @@ function az_publication_preprocess_views_view(&$variables) {
     // Only run for publication search.
     if ($variables['id'] === 'az_publications') {
       // Reduce the width of the text input form elements from the default.
-      $allow_shrink = [
+      $resize_element = [
         'name',
         'title',
       ];
-      foreach ($allow_shrink as $element) {
+      foreach ($resize_element as $element) {
         if (!empty($variables['exposed'][$element])) {
           $variables['exposed'][$element]['#size'] = 20;
         }

--- a/modules/custom/az_publication/az_publication.module
+++ b/modules/custom/az_publication/az_publication.module
@@ -302,9 +302,19 @@ function az_publication_preprocess_views_view(&$variables) {
   if (!empty($variables['id'])) {
     // Only run for publication search.
     if ($variables['id'] === 'az_publications') {
-      // Allow the publication year field to shrink if present.
+      // Reduce the width of the text input form elements from the default.
+      $allow_shrink = [
+        'name',
+        'title',
+      ];
+      foreach ($allow_shrink as $element) {
+        if (!empty($variables['exposed'][$element])) {
+          $variables['exposed'][$element]['#size'] = 20;
+        }
+      }
+      // Year field doesn't need a standard width text field.
       if (!empty($variables['exposed']['field_az_publication_date_value'])) {
-        $variables['exposed']['field_az_publication_date_value']['#wrapper_attributes']['class'][] = 'flex-shrink-1';
+        $variables['exposed']['field_az_publication_date_value']['#size'] = 6;
       }
       if (!empty($variables['exposed']['field_az_publication_type_value'])) {
         // Add class so publication type select is styled like text inputs.

--- a/modules/custom/az_publication/templates/views-exposed-form--az-publications.html.twig
+++ b/modules/custom/az_publication/templates/views-exposed-form--az-publications.html.twig
@@ -16,6 +16,6 @@
   #}
 {{ q }}
 {% endif %}
-<div class="form-row flex-lg-nowrap">
+<div class="form-row">
   {{ form }}
 </div>


### PR DESCRIPTION
Publication exposed form filters currently attempt to display them as a flex row all in one line in the Bootstrap large viewport size, with the year field allowed to flex shrink as it doesn't need to be as large as the other text fields. This approach works on the normal large viewport width, but fails when a sidebar is present as it causes the type filter to overlap once the year shrinks too far.

## Description
This PR takes an alternate approach and disables the `lg-nowrap` behavior. Instead, the size of the rendered text elements are reduced to have form elements that are not unnecessarily wide to begin with. This creates a situation where they are less likely to need to wrap, but can still wrap if necessary (e.g. pages with sidebars on both sides and similar circumstances.)

Note that this does not affect the maximum character limit of the form elements, only their physical width.

## Related issues
#2362 

## How to test

- Enable `az_publication`
- Create a flexible page with the Search display of the publication view.
- Create a publication
- Visit the flexible page.
- Verify that filters display correctly
- Add a sidebar block to appear on the page (ideally the menu block)
- Verify that the year form input is no longer covered by the type input
- Verify that form elements do wrap to the next line if necessary (mobile sizes etc)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [x] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
