### PR TITLE
Closes #2486: Remove tooling for Drupal console 😢.

### DIFF
--- a/.ddev/commands/web/drupal
+++ b/.ddev/commands/web/drupal
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-## Description: Provide Drupal console tooling to automatically know the Drupal root.
-## Usage: drupal [flags] [args]
-## Example: "ddev drupal --version"
-
-vendor/bin/drupal $@

--- a/.lando.yml
+++ b/.lando.yml
@@ -77,10 +77,6 @@ tooling:
   drush:
     service: appserver
     cmd: /app/vendor/bin/drush --root=/app/web
-  # Provide Drupal console tooling to automatically know the Drupal root.
-  drupal:
-    service: appserver
-    cmd: /app/vendor/bin/drupal --root=/app/web
   # Provide phpcs tooling to check coding standards.
   phpcs:
     service: appserver

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,9 +265,9 @@ ddev eslint myfile.js
 
 Developing within Drupal can be a real challenge without debugging enabled.
 
-[Devel](https://www.drupal.org/project/devel) and [Drupal Console](https://drupalconsole.com/) are both included in the [development metapackage](https://github.com/az-digital/az-quickstart-dev) that is downloaded when installing a site locally via Lando, or DDev.
+[Devel](https://www.drupal.org/project/devel) is included in the [development metapackage](https://github.com/az-digital/az-quickstart-dev) that is downloaded when installing a site locally via Lando, or DDev.
 
-You can easily enable them by using the following commands.
+You can easily enable it by using the following commands.
 
 ### Lando
 Quickstart provides Lando tooling for enabling theme debugging.


### PR DESCRIPTION
## Description
Removes lando and ddev tooling for Drupal console since it is not compatible with D10 and is abandoned/not maintained.

## Related issues
Closes #2486 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [x] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
