### PR TITLE
#2331 Update slack channel names from #azdigital-general to #azdigital-support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ team of web-focused volunteers that meet weekly to create projects like [Arizona
       project.
     * Use the `#friday-meetings` channel to ask questions or get updates related
       to Arizona Digital meetings.
-    * Use the `#azdigital-general` channel to ask general questions related to
-      Arizona Digital.
+    * Use the `#azdigital-support` channel to ask general questions related to
+      Arizona Digital, and get support for Arizona Digital products.
   * A basic understanding of [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
   * Local containerized (Docker) dev environment tool either lando or ddev
     * [Lando](https://docs.lando.dev/basics/installation.html)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ team of web-focused volunteers that meet weekly to create projects like [Arizona
     * Use the `#friday-meetings` channel to ask questions or get updates related
       to Arizona Digital meetings.
     * Use the `#azdigital-support` channel to ask general questions related to
-      Arizona Digital, and get support for Arizona Digital products.
+      Arizona Digital and get support for Arizona Digital products.
   * A basic understanding of [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
   * Local containerized (Docker) dev environment tool either lando or ddev
     * [Lando](https://docs.lando.dev/basics/installation.html)


### PR DESCRIPTION
## Description

Announced change:https://uarizona.slack.com/archives/C0SAW6H4J/p1687372251771549
Made change: https://uarizona.slack.com/archives/C0SAW6H4J/p1687372599604809
Updated arizona-bootstrap: https://github.com/az-digital/arizona-bootstrap/pull/793
Searched quickstart.arizona.edu for azdigital-general https://quickstart.arizona.edu/search/node?keys=azdigital-general

## Related issues
#2331 

