### PR TITLE
#2330 Update slack channel names from #friday-meetings to #azdigital-meetings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ team of web-focused volunteers that meet weekly to create projects like [Arizona
     * Use the `#azdigital-quickstart` channel for questions/comments related to this
       project.
     * Use the `#azdigital-meetings` channel to ask questions or get updates related
-      to Arizona Digital meetings, and workshops.
+      to Arizona Digital meetings and workshops.
     * Use the `#azdigital-general` channel to ask general questions related to
       Arizona Digital.
   * A basic understanding of [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ team of web-focused volunteers that meet weekly to create projects like [Arizona
   * [Slack](https://uarizona.slack.com) is our main source of communications.
     * Use the `#azdigital-quickstart` channel for questions/comments related to this
       project.
-    * Use the `#friday-meetings` channel to ask questions or get updates related
-      to Arizona Digital meetings.
+    * Use the `#azdigital-meetings` channel to ask questions or get updates related
+      to Arizona Digital meetings, and workshops.
     * Use the `#azdigital-general` channel to ask general questions related to
       Arizona Digital.
   * A basic understanding of [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).


### PR DESCRIPTION
## Description

- Announced change:https://uarizona.slack.com/archives/C0SAACCMS/p1687372371857999 
- Made change: https://uarizona.slack.com/archives/C0SAACCMS/p1687372576307579 
- Updated channel topic: https://uarizona.slack.com/archives/C0SAACCMS/p1687373204173049 
- Updated arizona-bootstrap: https://github.com/az-digital/arizona-bootstrap/pull/794 
- Searched quickstart.arizona.edu for friday-meetings https://quickstart.arizona.edu/search/node?keys=friday-meetings
- Searched github for friday-meetings https://github.com/search?q=org%3Aaz-digital%20friday-meetings%20&type=code
- Made change to template repo: https://github.com/az-digital/.github/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc

## Related issues
#2330
