### PR TITLE
Closes #2525 Add error handling to 2.7.x az_news database update.

### DIFF
--- a/modules/custom/az_news/az_news.install
+++ b/modules/custom/az_news/az_news.install
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\field\Entity\FieldConfig;
+use Drupal\Core\Entity\EntityStorageException;
 
 /**
  * Install az_paragraphs_photo_gallery.
@@ -145,8 +146,13 @@ function az_news_update_1020701() {
       $config_record = $config_storage->read($field_config_id);
 
       /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $storage */
-      $entity = $storage->createFromStorageRecord($config_record);
-      $entity->save();
+      try {
+        $entity = $storage->createFromStorageRecord($config_record);
+        $entity->save();
+      }
+      catch (EntityStorageException $e) {
+        \Drupal::logger('az_news')->notice($e->getMessage());
+      }
     }
   }
 

--- a/modules/custom/az_news/az_news.install
+++ b/modules/custom/az_news/az_news.install
@@ -6,8 +6,8 @@
  */
 
 use Drupal\Core\Config\FileStorage;
-use Drupal\field\Entity\FieldConfig;
 use Drupal\Core\Entity\EntityStorageException;
+use Drupal\field\Entity\FieldConfig;
 
 /**
  * Install az_paragraphs_photo_gallery.

--- a/modules/custom/az_news/az_news.install
+++ b/modules/custom/az_news/az_news.install
@@ -147,6 +147,7 @@ function az_news_update_1020701() {
 
       /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $storage */
       try {
+        /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $storage */
         $entity = $storage->createFromStorageRecord($config_record);
         $entity->save();
       }

--- a/modules/custom/az_news/az_news.install
+++ b/modules/custom/az_news/az_news.install
@@ -145,7 +145,6 @@ function az_news_update_1020701() {
       $storage = \Drupal::entityTypeManager()->getStorage($entity_type);
       $config_record = $config_storage->read($field_config_id);
 
-      /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $storage */
       try {
         /** @var \Drupal\Core\Config\Entity\ConfigEntityStorageInterface $storage */
         $entity = $storage->createFromStorageRecord($config_record);


### PR DESCRIPTION
## Description

<img width="1728" alt="image" src="https://github.com/az-digital/az_quickstart/assets/1023167/03ce7461-b9a6-42f1-9ee9-9edc47866b41">

## Related issues
Closes #2525 

## How to test

For sites that are currently ahead of any released version of quickstart. Example dev-main/ RC-1
For sites that applied config distro updates before running the database updates.

## Types of changes


### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
