### PR TITLE
#2560 Update github action to use specific release branch (2.6.x) of scaffolding repo

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -49,7 +49,7 @@ jobs:
           git push
       - name: Build project # This would actually build your project, using zip for an example artifact
         run: |
-          git clone https://github.com/az-digital/az-quickstart-scaffolding.git az_quickstart
+          git clone -b 2.6.x https://github.com/az-digital/az-quickstart-scaffolding.git az_quickstart
           cd az_quickstart
           composer config repositories.az_quickstart vcs https://github.com/az-digital/az_quickstart.git
           composer config use-github-api false


### PR DESCRIPTION
## Description
Use 2.6.x branch of scaffolding repo when creating release artifact.

## Related issues
#2560 

