### PR TITLE
Closes #2617 Remove the back slash from the analytics dashboard link

### DIFF
--- a/modules/custom/az_google_tag/az_google_tag.module
+++ b/modules/custom/az_google_tag/az_google_tag.module
@@ -17,7 +17,7 @@ function az_google_tag_toolbar_alter(&$items) {
       'title' => t('Analytics Dashboard'),
       'url' => Url::fromUri('https://lookerstudio.google.com/reporting/ef02c272-afe4-4862-b4bd-8706e3436b2f/page/nbaTD', [
         'query' => [
-          'params' => '{"df21":"include%EE%80%800%EE%80%80IN%EE%80%80' . $site_url . '/"}',
+          'params' => '{"df21":"include%EE%80%800%EE%80%80IN%EE%80%80' . $site_url . '"}',
         ],
         'absolute' => TRUE,
       ]),


### PR DESCRIPTION

## Description
I removed the "/" from the query parameters.

## Related issues
#2617 

## How to test
Validate that the Analytics Dashboard link in the admin toolbar takes you to the new Looker Studio, and that it doesn't have a "/" or the URL encoded %2F at the end of the domain name.


## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
