### PR TITLE
Closes #2663 - Allow multiple access schemes with Workbench Access

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -194,7 +194,7 @@
                 "Ajax pager - Input value viewsreference contains a non-scalar value (3326841)": "https://www.drupal.org/files/issues/2023-01-05/3326841.patch"
             },
             "drupal/workbench_access": {
-                "Allow multiple access schemas": "https://www.drupal.org/files/issues/2023-08-16/2982550-39.patch"
+                "Allow multiple access schemas (2982550)": "https://www.drupal.org/files/issues/2023-08-16/2982550-39.patch"
             },
             "drupal/xmlsitemap": {
                 "Call to undefined method ModuleHandler::getImplementations() in xmlsitemap_check_status() (3355204)": "https://git.drupalcode.org/project/xmlsitemap/-/commit/f7122db.patch"

--- a/composer.json
+++ b/composer.json
@@ -198,6 +198,9 @@
             },
             "renanbr/bibtex-parser": {
                 "Parser performance issue": "https://gist.githubusercontent.com/tadean/39b90d00cd3edfff7c5653f907e15721/raw/8feb59cb4447b0f667fe5f4936a25c4d30211e1b/renanbr_bibtex_parser_performance.patch"
+            },
+            "drupal/workbench_access": {
+                "Allow multiple access schemas": "https://www.drupal.org/files/issues/2023-05-15/workbench_access--handle-multiple-schemes-access--2982550--36.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.json
+++ b/composer.json
@@ -193,14 +193,14 @@
                 "Add Label field formatter (2938433)": "https://www.drupal.org/files/issues/2021-01-27/add_label_formatter-2938433-7.patch",
                 "Ajax pager - Input value viewsreference contains a non-scalar value (3326841)": "https://www.drupal.org/files/issues/2023-01-05/3326841.patch"
             },
+            "drupal/workbench_access": {
+                "Allow multiple access schemas": "https://www.drupal.org/files/issues/2023-08-16/2982550-39.patch"
+            }
             "drupal/xmlsitemap": {
                 "Call to undefined method ModuleHandler::getImplementations() in xmlsitemap_check_status() (3355204)": "https://git.drupalcode.org/project/xmlsitemap/-/commit/f7122db.patch"
             },
             "renanbr/bibtex-parser": {
                 "Parser performance issue": "https://gist.githubusercontent.com/tadean/39b90d00cd3edfff7c5653f907e15721/raw/8feb59cb4447b0f667fe5f4936a25c4d30211e1b/renanbr_bibtex_parser_performance.patch"
-            },
-            "drupal/workbench_access": {
-                "Allow multiple access schemas": "https://www.drupal.org/files/issues/2023-05-15/workbench_access--handle-multiple-schemes-access--2982550--36.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.json
+++ b/composer.json
@@ -195,7 +195,7 @@
             },
             "drupal/workbench_access": {
                 "Allow multiple access schemas": "https://www.drupal.org/files/issues/2023-08-16/2982550-39.patch"
-            }
+            },
             "drupal/xmlsitemap": {
                 "Call to undefined method ModuleHandler::getImplementations() in xmlsitemap_check_status() (3355204)": "https://git.drupalcode.org/project/xmlsitemap/-/commit/f7122db.patch"
             },


### PR DESCRIPTION
## Description
Adds a patch that addresses a bug preventing you from having multiple access schemes in combination with the "Deny access to unassigned content" setting.

## Related issues
Closes #2663 

## How to test
In a fresh QS build (not using this PR):
- Install Workbench Access
- Add 2 user accounts for testing, and assign them the "Content Editor" role (not "Content Admin")
- Set up a couple sections on the website (or use AZQS demo content)
- In Workbench Access settings, enable the "Deny access to unassigned content" setting
- Create an Access Scheme, using menus, for one section of the site, and assign one of your users to it
- Create another Access Scheme, using menus, for another section of the site, and assign your other user to it
- Use Masquerade to try editing the 2 sections of the site using both editor accounts.

This test should fail (i.e., user assigned to section 1 shouldn't be able to actually edit it)

In [Probo build](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-2664.probo.build/):
- Install Workbench Access
- Add 2 user accounts for testing, and assign them the "Content Editor" role (not "Content Admin")
- Set up a couple sections/pages on the website (or use AZQS demo content)
- In Workbench Access settings, enable the "Deny access to unassigned content" setting
- Create an Access Scheme for one section of the site, using menus, and assign one of your users to it
- Create another Access Scheme for another section of the site, using menus, and assign your other user to it
- Use Masquerade to try editing the 2 sections of the site using both editor accounts

You should now be able to edit the appropriate sections, and be denied to the appropriate sections.



## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [x] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
