### PR TITLE
Closes #2713 Event rows without thumbnails are missing top padding on mobile devices

### DIFF
--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
@@ -236,14 +236,14 @@ third_party_settings:
       weight: 6
       format_type: html_element
       format_settings:
-        classes: 'col-lg-3 pt-3 px-3 pr-lg-0 mb-n3 mb-lg-0'
+        classes: 'col-lg-3 pt-3 px-3 pr-lg-0 mb-lg-0'
         show_empty_fields: false
         id: ''
         element: div
         show_label: false
         label_element: h3
         label_element_classes: ''
-        attributes: ''
+        attributes: 'style="margin-bottom: -1.2em"'
         effect: none
         speed: fast
   smart_title:

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
@@ -161,7 +161,7 @@ third_party_settings:
       weight: 8
       format_type: html_element
       format_settings:
-        classes: 'col-lg-9 pt-lg-3 px-3 pl-lg-4 pb-3'
+        classes: 'col-lg-9 py-3 px-3 pl-lg-4'
         show_empty_fields: false
         id: ''
         element: div

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row.yml
@@ -161,7 +161,7 @@ third_party_settings:
       weight: 8
       format_type: html_element
       format_settings:
-        classes: 'col-lg-9 py-3 px-3 pl-lg-4'
+        classes: 'col-lg-9 pt-lg-3 px-3 pl-lg-4 pb-3'
         show_empty_fields: false
         id: ''
         element: div
@@ -180,7 +180,7 @@ third_party_settings:
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'h5 text-chili mt-0'
+        classes: 'h5 text-chili mt-3 mt-lg-0'
         id: ''
         element: div
         show_label: false
@@ -236,7 +236,7 @@ third_party_settings:
       weight: 6
       format_type: html_element
       format_settings:
-        classes: 'col-lg-3 pt-3 px-3 pr-lg-0'
+        classes: 'col-lg-3 pt-3 px-3 pr-lg-0 mb-n3 mb-lg-0'
         show_empty_fields: false
         id: ''
         element: div


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
In the Row display for AZ Event, adds a negative margin for the  Summary Thumbnail field group and a top margin for the Heading field group. This fixes an issue where event rows did not have the proper top padding on mobile devices.

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2713 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Link to Probo site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-2715.probo.build/

1. Visit the [Calendar page](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-2715.probo.build/calendar)
2. Confirm that event rows have the proper padding above the event title on both mobile and desktop screens

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
