### PR TITLE
Closes #2824 Visual changes to node edit form with 2.8 pre-release

### DIFF
--- a/modules/custom/az_core/az_core.libraries.yml
+++ b/modules/custom/az_core/az_core.libraries.yml
@@ -4,6 +4,10 @@ claro-node-form-overrides:
       css/claro-node-form-overrides.css: {}
   dependencies:
     - claro/node-form
+arizona-bootstrap-node-form-overrides:
+  css:
+    layout:
+      css/arizona-bootstrap-node-form-overrides.css: {}
 az-enterprise-attributes:
   css:
     component:

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -315,10 +315,11 @@ function az_core_form_block_form_alter(&$form, &$form_state, $form_id) {
 /**
  * Implements hook_form_BASE_FORM_ID_alter() for \Drupal\node\NodeForm.
  *
- * Adds style overrides for claro/node-form.
+ * Adds style overrides for claro/node-form and arizona-bootstrap.
  */
 function az_core_form_node_form_alter(&$form, FormStateInterface $form_state) {
   $form['#attached']['library'][] = 'az_core/claro-node-form-overrides';
+  $form['#attached']['library'][] = 'az_core/arizona-bootstrap-node-form-overrides';
 }
 
 /**

--- a/modules/custom/az_core/css/arizona-bootstrap-node-form-overrides.css
+++ b/modules/custom/az_core/css/arizona-bootstrap-node-form-overrides.css
@@ -1,0 +1,42 @@
+/*
+  Overrides Arizona Bootstrap styling for node form.
+  @see https://github.com/az-digital/az_quickstart/issues/2824
+*/
+
+.toolbar-tray a {
+  font-weight: unset;
+}
+
+nav.breadcrumb {
+  background-color: unset;
+  padding: 0;
+}
+  
+.breadcrumb .breadcrumb__link {
+  color: unset;
+  font-weight: 700;
+}
+
+h1.page-title {
+  font-weight: 700;
+  line-height: var(--line-height-heading);
+}
+
+h1.page-title,
+h4.form-item__label,
+span.fieldset-label,
+legend.fieldset__legend {
+  color: var(--color-fg);
+}
+
+.fieldset__legend {
+  font-size: unset;
+}
+
+a.chosen-single {
+  font-weight: unset;
+}
+
+.tabledrag-cell-content .tabledrag-handle::after {
+  padding: 16px 16px 16px 33px;
+}

--- a/modules/custom/az_core/css/claro-node-form-overrides.css
+++ b/modules/custom/az_core/css/claro-node-form-overrides.css
@@ -5,7 +5,7 @@
 */
 
 @media screen and (min-width: 61rem) {
-  .layout-node-form {
+  div.layout-node-form {
     grid-template-columns: calc(65% - var(--space-l)) minmax(22.5rem, 1fr);
   }
   

--- a/modules/custom/az_core/css/claro-node-form-overrides.css
+++ b/modules/custom/az_core/css/claro-node-form-overrides.css
@@ -1,5 +1,5 @@
 /*
-  Overrides Claro layout for node form.
+  Overrides Claro layout and styling for node form.
   @see https://github.com/az-digital/az_quickstart/issues/1716
   @see https://github.com/az-digital/az_quickstart/issues/2824
   @see https://www.drupal.org/project/drupal/issues/3184667
@@ -10,13 +10,13 @@
     grid-template-columns: calc(65% - var(--space-l)) minmax(22.5rem, 1fr);
   }
 
-  .layout-region--node-main .claro-details__summary {
-    color: unset;
-  }
-  
   .layout-region.layout-region--node-main,
   .layout-region.layout-region--node-footer {
     margin-inline: 0;
     width: initial;
   }
+}
+
+.layout-region--node-main .claro-details__summary {
+  color: unset;
 }

--- a/modules/custom/az_core/css/claro-node-form-overrides.css
+++ b/modules/custom/az_core/css/claro-node-form-overrides.css
@@ -1,12 +1,17 @@
 /*
   Overrides Claro layout for node form.
   @see https://github.com/az-digital/az_quickstart/issues/1716
+  @see https://github.com/az-digital/az_quickstart/issues/2824
   @see https://www.drupal.org/project/drupal/issues/3184667
 */
 
 @media screen and (min-width: 61rem) {
   div.layout-node-form {
     grid-template-columns: calc(65% - var(--space-l)) minmax(22.5rem, 1fr);
+  }
+
+  .layout-region--node-main .claro-details__summary {
+    color: unset;
   }
   
   .layout-region.layout-region--node-main,

--- a/modules/custom/az_core/css/claro-node-form-overrides.css
+++ b/modules/custom/az_core/css/claro-node-form-overrides.css
@@ -5,6 +5,10 @@
 */
 
 @media screen and (min-width: 61rem) {
+  .layout-node-form {
+    grid-template-columns: calc(65% - var(--space-l)) minmax(22.5rem, 1fr);
+  }
+  
   .layout-region.layout-region--node-main,
   .layout-region.layout-region--node-footer {
     margin-inline: 0;

--- a/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
@@ -54,6 +54,7 @@ az_paragraphs.preview:
       css/az_paragraphs_preview.css: {}
       css/az_paragraphs_widget.css: {}
   dependencies:
+    - az_barrio/global-styling
     - az_barrio/material-design-icons-sharp
     - az_barrio/arizona-bootstrap
     - az_barrio/button-no-conflict


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

1. Fixes two issues caused by Claro node form styling:
   - Fixes the column widths for the main and secondary regions of the node edit form so they match Quickstart 2.7 and before.
   - Fixes inconsistent colors for accordion headings.
2. Fixes multiple issues caused by Arizona Bootstrap styling:
   - Adds a new `arizona-bootstrap-node-form-overrides` CSS library.
   - Fixes font-weight and color issues for links, breadcrumbs, and headings.
   - Fixes white background color added to breadcrumb nav element.
   - Fixes element size of draggable icon for multi-value fields.
3. Fixes issue caused by absence of AZ Barrio global styling
   - Restores `az_barrio/global-styling` dependency to az_paragraphs.preview to fix paragraph rows not being striped.

I'm open to suggestions about better approaches for any of this!

Regarding the column widths, I was unable to fix them using only the CSS `fr` unit. For example, changing the width value of the first column from `3fr` to `2fr` did not make any difference. If anyone has ideas about how to simplify the CSS rule for the grid columns, please add a comment or code suggestion!

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2824 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
- [Link to Probo site for this PR](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-2826.probo.build)
- [Link to comparison Probo site](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-2831.probo.build) (Citation Style Language update)
- (to be added?) Quickstart 2.7 comparison site

Log in, edit or create a node, and confirm that the appearance of the node edit form matches that of Quickstart 2.7, except in a couple cases of fixing inconsistent heading colors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
