### PR TITLE
Fixes #2851 Cannot Save Curation Options

### DIFF
--- a/modules/custom/az_curated_views/src/Plugin/views/field/AZCuratedViewsField.php
+++ b/modules/custom/az_curated_views/src/Plugin/views/field/AZCuratedViewsField.php
@@ -77,6 +77,17 @@ class AZCuratedViewsField extends BulkForm {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function viewsFormValidate(&$form, FormStateInterface $form_state) {
+    $ids = $form_state->getValue($this->options['id']);
+    if (empty($ids) || empty(array_filter($ids))) {
+      $form_state->setErrorByName('', $this->emptySelectedMessage());
+    }
+    // Unlike parent class, do not throw form error when action is empty.
+  }
+
+  /**
    * Submit handler for the curation form.
    *
    * @param mixed $form


### PR DESCRIPTION
2.8 beta testing revealed that publication curation options cannot be saved, clicking "Save" produces the error "No Action option selected." This is because 10.1's `BulkForm` class which the curation form extends now throws an error if no action is selected.

## Description
This PR fixes the issue by overriding the parent class's form validation function to no longer throw an error if no action is selected (as this form does not have actions).

## Related issues
Closes #2851

## How to test

- enable `az_demo` and `az_publication`
- place the optional block `AZ Publications: Person` on Person content pages
- Create publications, and assign them an author that references a Person
- View that person page
- On the Publications block, select the `Curate Publications` contextual action
- Verify that curation options can be saved and function correctly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
