### PR TITLE
Closes #2864  Update security.yml github action to not run on pushing of tags

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,6 +3,8 @@ on:
   push:
     schedule:
       - cron:  '0 13 * * *'
+    tags-ignore:
+      - '*'
 jobs:
   dependency-audit:
     name: Dependency Check


### PR DESCRIPTION
## Related issues
Closes #2864 

See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore