### PR TITLE
Close #2928 Always show summary fields when adding or editing content.

### DIFF
--- a/modules/custom/az_event/config/install/core.entity_form_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_form_display.node.az_event.default.yml
@@ -45,7 +45,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'For use in feeds and content listings.'
+        description: 'Summary fields determine how this event appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
         required_fields: true
         weight: -10
 id: node.az_event.default

--- a/modules/custom/az_event/config/install/core.entity_form_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_form_display.node.az_event.default.yml
@@ -45,7 +45,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'Summary fields determine how this event appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
+        description: 'Summary fields determine how this event appears in feeds, listings and other displays throughout the site.'
         required_fields: true
         weight: -10
 id: node.az_event.default

--- a/modules/custom/az_event/config/install/core.entity_form_display.node.az_event.default.yml
+++ b/modules/custom/az_event/config/install/core.entity_form_display.node.az_event.default.yml
@@ -42,11 +42,12 @@ third_party_settings:
       format_type: details_sidebar
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
         open: true
         description: 'For use in feeds and content listings.'
         required_fields: true
-        weight: 0
+        weight: -10
 id: node.az_event.default
 targetEntityType: node
 bundle: az_event
@@ -106,6 +107,8 @@ content:
         custom
       show_extra: false
       hide_date: false
+      allday: true
+      remove_seconds: false
     third_party_settings:
       smart_date_recur:
         modal: true

--- a/modules/custom/az_flexible_page/config/install/core.entity_form_display.node.az_flexible_page.default.yml
+++ b/modules/custom/az_flexible_page/config/install/core.entity_form_display.node.az_flexible_page.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'Summary fields determine how this page appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
+        description: 'Summary fields determine how this page appears in feeds, listings and other displays throughout the site.'
         required_fields: true
         weight: -10
     group_categorization:

--- a/modules/custom/az_flexible_page/config/install/core.entity_form_display.node.az_flexible_page.default.yml
+++ b/modules/custom/az_flexible_page/config/install/core.entity_form_display.node.az_flexible_page.default.yml
@@ -28,11 +28,12 @@ third_party_settings:
       format_type: details_sidebar
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
-        open: false
+        open: true
         description: 'These fields appear in display modes other that the full page view mode.'
         required_fields: true
-        weight: 0
+        weight: -10
     group_categorization:
       children:
         - field_az_page_category

--- a/modules/custom/az_flexible_page/config/install/core.entity_form_display.node.az_flexible_page.default.yml
+++ b/modules/custom/az_flexible_page/config/install/core.entity_form_display.node.az_flexible_page.default.yml
@@ -31,7 +31,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'These fields appear in display modes other that the full page view mode.'
+        description: 'Summary fields determine how this page appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
         required_fields: true
         weight: -10
     group_categorization:

--- a/modules/custom/az_news/config/install/core.entity_form_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_form_display.node.az_news.default.yml
@@ -50,7 +50,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: ''
+        description: 'Summary fields determine how this news article appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
         required_fields: true
         weight: -10
     group_az_extra_fields:

--- a/modules/custom/az_news/config/install/core.entity_form_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_form_display.node.az_news.default.yml
@@ -47,11 +47,12 @@ third_party_settings:
       format_type: details_sidebar
       format_settings:
         classes: 'group-summary field-group-tab'
+        show_empty_fields: false
         id: ''
-        open: false
+        open: true
+        description: ''
         required_fields: true
-        weight: 0
-        direction: vertical
+        weight: -10
     group_az_extra_fields:
       children:
         - field_az_attachments

--- a/modules/custom/az_news/config/install/core.entity_form_display.node.az_news.default.yml
+++ b/modules/custom/az_news/config/install/core.entity_form_display.node.az_news.default.yml
@@ -50,7 +50,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'Summary fields determine how this news article appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
+        description: 'Summary fields determine how this news article appears in feeds, listings and other displays throughout the site.'
         required_fields: true
         weight: -10
     group_az_extra_fields:

--- a/modules/custom/az_person/config/install/core.entity_form_display.node.az_person.default.yml
+++ b/modules/custom/az_person/config/install/core.entity_form_display.node.az_person.default.yml
@@ -57,7 +57,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: ''
+        description: 'Summary fields determine how this person appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
         required_fields: true
         weight: -10
 id: node.az_person.default

--- a/modules/custom/az_person/config/install/core.entity_form_display.node.az_person.default.yml
+++ b/modules/custom/az_person/config/install/core.entity_form_display.node.az_person.default.yml
@@ -56,10 +56,10 @@ third_party_settings:
         classes: 'group-summary field-group-tab'
         show_empty_fields: false
         id: ''
-        open: false
+        open: true
         description: ''
         required_fields: true
-        weight: 0
+        weight: -10
 id: node.az_person.default
 targetEntityType: node
 bundle: az_person

--- a/modules/custom/az_person/config/install/core.entity_form_display.node.az_person.default.yml
+++ b/modules/custom/az_person/config/install/core.entity_form_display.node.az_person.default.yml
@@ -57,7 +57,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'Summary fields determine how this person appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
+        description: 'Summary fields determine how this person appears in feeds, listings and other displays throughout the site.'
         required_fields: true
         weight: -10
 id: node.az_person.default

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_event.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_event.default.yml
@@ -44,11 +44,12 @@ third_party_settings:
       format_type: details_sidebar
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
         open: true
         description: 'For use in feeds and content listings.'
         required_fields: true
-        weight: 0
+        weight: -10
 id: node.az_event.default
 targetEntityType: node
 bundle: az_event
@@ -108,6 +109,8 @@ content:
         custom
       show_extra: false
       hide_date: false
+      allday: true
+      remove_seconds: false
     third_party_settings:
       smart_date_recur:
         modal: true

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_event.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_event.default.yml
@@ -47,7 +47,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'For use in feeds and content listings.'
+        description: 'Summary fields determine how this event appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
         required_fields: true
         weight: -10
 id: node.az_event.default

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_event.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_event.default.yml
@@ -47,7 +47,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'Summary fields determine how this event appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
+        description: 'Summary fields determine how this event appears in feeds, listings and other displays throughout the site.'
         required_fields: true
         weight: -10
 id: node.az_event.default

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_flexible_page.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_flexible_page.default.yml
@@ -33,7 +33,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'These fields appear in display modes other that the full page view mode.'
+        description: 'Summary fields determine how this page appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
         required_fields: true
         weight: -10
     group_categorization:

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_flexible_page.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_flexible_page.default.yml
@@ -33,7 +33,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'Summary fields determine how this page appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
+        description: 'Summary fields determine how this page appears in feeds, listings and other displays throughout the site.'
         required_fields: true
         weight: -10
     group_categorization:

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_flexible_page.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_flexible_page.default.yml
@@ -30,11 +30,12 @@ third_party_settings:
       format_type: details_sidebar
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
-        open: false
+        open: true
         description: 'These fields appear in display modes other that the full page view mode.'
         required_fields: true
-        weight: 0
+        weight: -10
     group_categorization:
       children:
         - field_az_page_category
@@ -62,7 +63,7 @@ third_party_settings:
         classes: ''
         id: ''
         open: false
-        description: 'Display this page with a Marketing Campaign Page style.'
+        description: 'Display this page with a Marketing Campaign Page style, hiding the navigation menu and other page regions. See <a href="https://quickstart.arizona.edu/pages">Adding Pages</a> for details about each style.'
         required_fields: true
         weight: 0
 id: node.az_flexible_page.default
@@ -116,6 +117,7 @@ content:
     region: content
     settings:
       sidebar: true
+      use_details: true
     third_party_settings: {  }
   field_az_page_category:
     type: options_select

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_news.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_news.default.yml
@@ -52,7 +52,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'Summary fields determine how this news appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
+        description: 'Summary fields determine how this news article appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
         required_fields: true
         weight: -10
     group_az_extra_fields:

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_news.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_news.default.yml
@@ -52,7 +52,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: ''
+        description: 'Summary fields determine how this news appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
         required_fields: true
         weight: -10
     group_az_extra_fields:

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_news.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_news.default.yml
@@ -52,7 +52,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'Summary fields determine how this news article appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
+        description: 'Summary fields determine how this news article appears in feeds, listings and other displays throughout the site.'
         required_fields: true
         weight: -10
     group_az_extra_fields:

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_news.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_news.default.yml
@@ -49,11 +49,12 @@ third_party_settings:
       format_type: details_sidebar
       format_settings:
         classes: 'group-summary field-group-tab'
+        show_empty_fields: false
         id: ''
-        open: false
+        open: true
+        description: ''
         required_fields: true
-        weight: 0
-        direction: vertical
+        weight: -10
     group_az_extra_fields:
       children:
         - field_az_attachments

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_person.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_person.default.yml
@@ -59,7 +59,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: 'Summary fields determine how this person appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
+        description: 'Summary fields determine how this person appears in feeds, listings and other displays throughout the site.'
         required_fields: true
         weight: -10
 id: node.az_person.default

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_person.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_person.default.yml
@@ -58,10 +58,10 @@ third_party_settings:
         classes: 'group-summary field-group-tab'
         show_empty_fields: false
         id: ''
-        open: false
+        open: true
         description: ''
         required_fields: true
-        weight: 0
+        weight: -10
 id: node.az_person.default
 targetEntityType: node
 bundle: az_person
@@ -159,6 +159,7 @@ content:
     region: content
     settings:
       sidebar: true
+      use_details: true
     third_party_settings: {  }
   field_az_person_category:
     type: options_buttons

--- a/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_person.default.yml
+++ b/modules/custom/az_seo/config/quickstart/core.entity_form_display.node.az_person.default.yml
@@ -59,7 +59,7 @@ third_party_settings:
         show_empty_fields: false
         id: ''
         open: true
-        description: ''
+        description: 'Summary fields determine how this person appears in feeds, listings and other displays throughout the site. Utilize these options to tailor the presentation and effectiveness of your content in various contexts.'
         required_fields: true
         weight: -10
 id: node.az_person.default


### PR DESCRIPTION
## Description
When editing content it is not apparent just how important the summary fields are.

I'v set the summary fieldset to always open on the edit form of each content type that comes with quickstart.
This has been done for 
- az_news
- az_event
- az_flexible_page
- az_person


## Related issues
Closes #2928 

## How to test
Create or edit any of the following types of content: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-2932.probo.build/user/login?destination=/node/add

- az_news
- az_event
- az_flexible_page
- az_person

Notice the summary section on the right of the screen.
<img width="1728" alt="image" src="https://github.com/az-digital/az_quickstart/assets/1023167/356b055d-f0be-48ee-9410-64799a59b648">
<img width="1688" alt="image" src="https://github.com/az-digital/az_quickstart/assets/1023167/20421574-95ea-4e5d-a657-7e65b55b2ac2">
<img width="1712" alt="image" src="https://github.com/az-digital/az_quickstart/assets/1023167/fa90ba89-c6b4-4f7f-9068-dcd64ba20a5a">
<img width="1723" alt="image" src="https://github.com/az-digital/az_quickstart/assets/1023167/c4918926-d431-437e-9195-1aa403002175">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
