### PR TITLE
Closes #2946 Video Thumbnail in Page/Event/News Editor Too Small

### DIFF
--- a/modules/custom/az_media/az_media.module
+++ b/modules/custom/az_media/az_media.module
@@ -8,15 +8,16 @@
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\editor\Entity\Editor;
 use Drupal\Core\Logger\RfcLogLevel;
 use Drupal\responsive_image\Entity\ResponsiveImageStyle;
 
 /**
- * Implements hook_ckeditor_css_alter().
+ * Implements hook_library_info_alter().
  */
-function az_media_ckeditor_css_alter(array &$css, Editor $editor) {
-  $css[] = \Drupal::service('extension.list.module')->getPath('az_media') . '/css/az-media-edit.css';
+function az_media_library_info_alter(array &$libraries, $extension) {
+  if ($extension === 'ckeditor5' && isset($libraries['internal.drupal.ckeditor5.media'])) {
+    $libraries['internal.drupal.ckeditor5.media']['dependencies'][] = 'az_media/az_media_edit';
+  }
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Since `hook_ckeditor_css_alter` is no longer available, this PR replaces that hook with `hook_library_info_alter` to add the az_media_edit CSS library as a dependency of the CKEditor 5 Media library.

Resolved questions ([see answers in comment from @joeparsons below](#issuecomment-1828617671)):

1. Is it acceptable to rely on the [internal.drupal.ckeditor5.media](https://git.drupalcode.org/project/drupal/-/blob/10.1.x/core/modules/ckeditor5/ckeditor5.libraries.yml?ref_type=heads#L76) library? This was the approach taken by the OEmbed Lazyload module to resolve a [similar issue](https://www.drupal.org/project/oembed_lazyload/issues/3339708).
2. Currently, this PR resolves only the first problem noted in the related issue, where the video thumbnail is too small and only shows the play button. Should this PR also address the other two issues mentioned?
   - Remote media elements do not reflect their 'size' setting. (This problem is not a regression.)
   - "Could not retrieve the oEmbed resource" error is sometimes displayed after adding a new video.


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2946 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Link to Probo site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-2949.probo.build

Confirm that video thumbnails are displayed in the editor with a width of 400 pixels for all four Quickstart content types.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
