### PR TITLE
Close #2962 handle empty values in TextFormatRecognizer.php

### DIFF
--- a/modules/custom/az_migration/src/Plugin/migrate/process/TextFormatRecognizer.php
+++ b/modules/custom/az_migration/src/Plugin/migrate/process/TextFormatRecognizer.php
@@ -102,8 +102,8 @@ class TextFormatRecognizer extends ProcessPluginBase implements ContainerFactory
       // likely to exist in the source regardless of intent.
       $markup = trim(_filter_autop(check_markup($value, $format)));
       if (!empty($markup)) {
-        // Attempt to parse the resultant html and convert back to canonical html
-        // if successful.
+        // Attempt to parse the resultant html and convert back to canonical
+        // html if successful.
         $markupDoc = new \DOMDocument();
         if (@$markupDoc->loadHTML($markup)) {
           $markup = $markupDoc->saveXML();
@@ -119,4 +119,5 @@ class TextFormatRecognizer extends ProcessPluginBase implements ContainerFactory
 
     return $this->configuration['failed'];
   }
+
 }

--- a/modules/custom/az_migration/src/Plugin/migrate/process/TextFormatRecognizer.php
+++ b/modules/custom/az_migration/src/Plugin/migrate/process/TextFormatRecognizer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\az_migration\Plugin\migrate\process;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
@@ -75,13 +77,11 @@ class TextFormatRecognizer extends ProcessPluginBase implements ContainerFactory
     if (isset($value['value'])) {
       $value = $value['value'];
     }
-
     if (!empty($this->configuration['required_module'])) {
       // Don't proceed if the specified module is not loaded.
       if (!$this->moduleHandler->moduleExists($this->configuration['required_module'])) {
         return $this->configuration['module_missing'];
       }
-
     }
 
     if (!empty($this->configuration['format']) &&
@@ -93,7 +93,7 @@ class TextFormatRecognizer extends ProcessPluginBase implements ContainerFactory
       // Attempt to parse the resultant html and convert back to canonical html
       // if successful.
       $fullDoc = new \DOMDocument();
-      if (@$fullDoc->loadHTML($full)) {
+      if (!empty($full) && @$fullDoc->loadHTML($full)) {
         $full = $fullDoc->saveXML();
       }
 
@@ -101,11 +101,13 @@ class TextFormatRecognizer extends ProcessPluginBase implements ContainerFactory
       // Attempt to put autoparagraphs back in after the fact, since they are
       // likely to exist in the source regardless of intent.
       $markup = trim(_filter_autop(check_markup($value, $format)));
-      // Attempt to parse the resultant html and convert back to canonical html
-      // if successful.
-      $markupDoc = new \DOMDocument();
-      if (@$markupDoc->loadHTML($markup)) {
-        $markup = $markupDoc->saveXML();
+      if (!empty($markup)) {
+        // Attempt to parse the resultant html and convert back to canonical html
+        // if successful.
+        $markupDoc = new \DOMDocument();
+        if (@$markupDoc->loadHTML($markup)) {
+          $markup = $markupDoc->saveXML();
+        }
       }
 
       // Let's compare canonical markup after going back from parsed html.
@@ -117,5 +119,4 @@ class TextFormatRecognizer extends ProcessPluginBase implements ContainerFactory
 
     return $this->configuration['failed'];
   }
-
 }


### PR DESCRIPTION
## Description
In the case of empty paragraphs. or paragraphs with broken markup that is stripped regardless of the selected filter.

## Related issues
Closes #2962 

