### PR TITLE
Prepare 2.8.x branch for new minor release branch 2.9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "2.9.x-dev"
+            "dev-main": "2.10.x-dev"
         },
         "patches": {
             "drupal/antibot": {


### PR DESCRIPTION
Simulated changes that would have been created by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action for the 2.8.x branch.