### PR TITLE
Closes #3016: Autowire controller services.

### DIFF
--- a/modules/custom/az_publication/az_publication_import/src/Controller/AZPublicationImportController.php
+++ b/modules/custom/az_publication/az_publication_import/src/Controller/AZPublicationImportController.php
@@ -3,7 +3,8 @@
 namespace Drupal\az_publication_import\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\system\SystemManager;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Returns responses for Quickstart Publication Import routes.
@@ -11,21 +12,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class AZPublicationImportController extends ControllerBase {
 
   /**
-   * System Manager Service.
-   *
-   * @var \Drupal\system\SystemManager
+   * Constructs a new \Drupal\az_publication_import\Controller object.
    */
-  protected $systemManager;
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    $instance = new static();
-
-    $instance->systemManager = $container->get('system.manager');
-    return $instance;
-  }
+  public function __construct(
+    #[Autowire(service: 'system.manager')]
+    protected SystemManager $systemManager,
+  ) {}
 
   /**
    * Provides a single block from the administration menu as a page.

--- a/modules/custom/az_publication/src/Controller/AZAuthorController.php
+++ b/modules/custom/az_publication/src/Controller/AZAuthorController.php
@@ -5,41 +5,25 @@ namespace Drupal\az_publication\Controller;
 use Drupal\az_publication\Entity\AZAuthorInterface;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Link;
+use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class AZAuthorController.
  *
  *  Returns responses for Author routes.
  */
-class AZAuthorController extends ControllerBase implements ContainerInjectionInterface {
+class AZAuthorController extends ControllerBase {
 
   /**
-   * The date formatter.
-   *
-   * @var \Drupal\Core\Datetime\DateFormatter
+   * Constructs a new \Drupal\az_publication\Controller object.
    */
-  protected $dateFormatter;
-
-  /**
-   * The renderer.
-   *
-   * @var \Drupal\Core\Render\Renderer
-   */
-  protected $renderer;
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    $instance = parent::create($container);
-    $instance->dateFormatter = $container->get('date.formatter');
-    $instance->renderer = $container->get('renderer');
-    return $instance;
-  }
+  public function __construct(
+    protected DateFormatterInterface $dateFormatter,
+    protected RendererInterface $renderer,
+  ) {}
 
   /**
    * Displays a Author revision.


### PR DESCRIPTION
## Description
Autowires controller services using feature added in Drupal 10.2.x.

Associated Drupal 10.2.x change record: https://www.drupal.org/node/3395716
## Related issues
Closes #3016
## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [x] New internal API or API improvement with backwards compatibility
   - [x] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
