### PR TITLE
Closes #3018: Enable auto-configuration for event subscribers.

### DIFF
--- a/modules/custom/az_cas/az_cas.services.yml
+++ b/modules/custom/az_cas/az_cas.services.yml
@@ -1,7 +1,7 @@
 services:
+  _defaults:
+    autoconfigure: true
   az_cas.az_cas_route_subscriber:
     class: Drupal\az_cas\Routing\AzCasRouteSubscriber
     arguments:
       - '@config.factory'
-    tags:
-      - { name: 'event_subscriber' }

--- a/modules/custom/az_event/az_event_trellis/az_event_trellis.services.yml
+++ b/modules/custom/az_event/az_event_trellis/az_event_trellis.services.yml
@@ -1,4 +1,6 @@
 services:
+  _defaults:
+    autoconfigure: true
   az_event_trellis.trellis_helper:
     class: Drupal\az_event_trellis\TrellisHelper
     arguments:
@@ -13,5 +15,3 @@ services:
       - '@messenger'
       - '@entity_type.manager'
       - '@current_user'
-    tags:
-      - { name: 'event_subscriber' }

--- a/modules/custom/az_metrics/az_metrics.services.yml
+++ b/modules/custom/az_metrics/az_metrics.services.yml
@@ -1,8 +1,8 @@
 services:
+  _defaults:
+    autoconfigure: true
   az_metrics.event_subscriber:
     class: Drupal\az_metrics\EventSubscriber\AZMetricsSubscriber
     arguments:
       - '@database'
       - '@datetime.time'
-    tags:
-      - { name: event_subscriber }

--- a/modules/custom/az_news/az_news_feeds/az_news_feeds.services.yml
+++ b/modules/custom/az_news/az_news_feeds/az_news_feeds.services.yml
@@ -1,8 +1,8 @@
 services:
+  _defaults:
+    autoconfigure: true
   # Listens to migration events.
   az_news_feeds.migrate_events_subscriber:
     class: 'Drupal\az_news_feeds\EventSubscriber\AzNewsFeedsMigrateSubscriber'
     arguments:
       - '@config.factory'
-    tags:
-      - { name: 'event_subscriber' }

--- a/modules/custom/az_publication/az_publication_import/az_publication_import.services.yml
+++ b/modules/custom/az_publication/az_publication_import/az_publication_import.services.yml
@@ -1,8 +1,8 @@
 services:
+  _defaults:
+    autoconfigure: true
   pubmigration_subscriber:
     class: Drupal\az_publication_import\EventSubscriber\AZPublicationImportEventSubscriber
     arguments:
       - '@messenger'
       - '@entity_type.manager'
-    tags:
-      - { name: 'event_subscriber' }


### PR DESCRIPTION
## Description
Enables auto-configuration feature for event subscribers added in Drupal 10.2.x.

Associated Drupal 10.2.x change record: https://www.drupal.rg/node/3357408

## Related issues
Closes #3018 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [x] New internal API or API improvement with backwards compatibility
   - [x] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
