### PR TITLE
Ensure route and entity definition use same keys

### DIFF
--- a/modules/custom/az_publication/az_publication.links.task.yml
+++ b/modules/custom/az_publication/az_publication.links.task.yml
@@ -14,8 +14,8 @@ entity.az_author.edit_form:
   base_route: entity.az_author.canonical
   title: 'Edit'
 
-entity.az_author.version_history:
-  route_name: entity.az_author.version_history
+entity.az_author.version-history:
+  route_name: entity.az_author.version-history
   base_route: entity.az_author.canonical
   title: 'Revisions'
 

--- a/modules/custom/az_publication/src/Entity/AZAuthor.php
+++ b/modules/custom/az_publication/src/Entity/AZAuthor.php
@@ -71,7 +71,7 @@ use Drupal\user\UserInterface;
  *     "add-form" = "/admin/structure/az_author/add",
  *     "edit-form" = "/admin/structure/az_author/{az_author}/edit",
  *     "delete-form" = "/admin/structure/az_author/{az_author}/delete",
- *     "version-history" = "/admin/structure/az_author/{az_author}/revisions",
+ *     "version_history" = "/admin/structure/az_author/{az_author}/revisions",
  *     "revision" = "/admin/structure/az_author/{az_author}/revisions/{az_author_revision}/view",
  *     "revision_revert" = "/admin/structure/az_author/{az_author}/revisions/{az_author_revision}/revert",
  *     "revision_delete" = "/admin/structure/az_author/{az_author}/revisions/{az_author_revision}/delete",


### PR DESCRIPTION
## Description
https://github.com/az-digital/az_quickstart/blob/main/modules/custom/az_publication/az_publication.links.task.yml#L17
uses an underscore.

## Related issues
Close #3131

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
