### PR TITLE
Closes #3185 Workbench Access menu schemes may cause menu items to change when pages are saved

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -215,7 +215,7 @@
             },
             "drupal/workbench_access": {
                 "Allow multiple access schemas (2982550)": "https://www.drupal.org/files/issues/2023-08-16/2982550-39.patch",
-                "Content is assigned to wrong menu level if user does not have access to the current level (3187152)": "https://www.drupal.org/files/issues/2023-03-22/workbench_access_3187152-9.patch"
+                "Content is assigned to wrong menu level if user does not have access to the current level (3187152)": "https://www.drupal.org/files/issues/2023-09-26/3187152-workbench_access-menu-default-20.patch"
             },
             "drupal/xmlsitemap": {
                 "Module incorrectly assumes string, triggering PHP 8 fatal error (3355204)": "https://www.drupal.org/files/issues/2023-04-19/3355204_metatag_2.patch"

--- a/composer.json
+++ b/composer.json
@@ -214,7 +214,8 @@
                 "View without empty handling could break caching (3017716)": "https://www.drupal.org/files/issues/2024-02-09/3017716-22.patch"
             },
             "drupal/workbench_access": {
-                "Allow multiple access schemas (2982550)": "https://www.drupal.org/files/issues/2023-08-16/2982550-39.patch"
+                "Allow multiple access schemas (2982550)": "https://www.drupal.org/files/issues/2023-08-16/2982550-39.patch",
+                "Content is assigned to wrong menu level if user does not have access to the current level (3187152)": "https://www.drupal.org/files/issues/2023-03-22/workbench_access_3187152-9.patch"
             },
             "drupal/xmlsitemap": {
                 "Module incorrectly assumes string, triggering PHP 8 fatal error (3355204)": "https://www.drupal.org/files/issues/2023-04-19/3355204_metatag_2.patch"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
To resolve a problem where a page's parent item in the menu may change when a Content Editor saves the page, this PR adds a patch from comment 20 on the following Workbench Access issue:

- [Content is assigned to wrong menu level if user does not have access to the current level](https://www.drupal.org/project/workbench_access/issues/3187152)

I tested this patch with the demo content: I created a Menu Access Scheme and gave a new Content Editor user access to some specific pages (Split Screen, Menu Blocks - First Child). When I masqueraded as that user and re-saved those pages, their associated menu items did not change.

In contrast, when I saved those pages in another environment using the Quickstart main branch, the menu items for those pages were moved under different parent items: first, the Split Screen page was moved under Text and then the Menu Blocks - First Child page was moved under Split Screen.

<img width="441" alt="image" src="https://github.com/az-digital/az_quickstart/assets/74572157/2debf4d3-1abf-489d-b87b-efcafc9642f9">


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3185 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3187.probo.build

1. (already completed in Probo) Install the Workbench Access and Masquerade modules.
2. (already completed in Probo) Set up a menu access scheme using the Main Navigation menu and Page content type.
3. (already completed in Probo) Edit the Workbench Access scheme settings to Deny access to all unassigned content.
4. As an administrator user, create a Content Editor user and give the user access to only specific pages in the Main Navigation menu (click on the user and then click the Workbench Access tab).
   - The allowed pages should have a parent page that is NOT accessible to the user or a parent menu item that is not an actual page (such as "Pages").
6. Masquerade as the user (from People, click the Operations dropdown and select Masquerade as).
7. Edit one or more of the pages the user is allowed to access and simply save the page (not making any changes).
8. Unmasquerade
9. Visit the individual pages or the Main Navigation menu to verify that the parent menu item for those pages has not changed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [x] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
