### PR TITLE
Fixes #3220 Trellis Event Importer can import incorrect Event

### DIFF
--- a/modules/custom/az_event/az_event_trellis/src/Plugin/views/field/AZEventTrellisViewsField.php
+++ b/modules/custom/az_event/az_event_trellis/src/Plugin/views/field/AZEventTrellisViewsField.php
@@ -63,21 +63,16 @@ class AZEventTrellisViewsField extends BulkForm {
 
     foreach ($this->view->result as $row_index => $row) {
       $form[$this->options['id']][$row_index] = [
-        '#tree' => TRUE,
+        '#type' => 'checkbox',
+        // We are not able to determine a main "title" for each row, so we can
+        // only output a generic label.
+        '#title' => $this->t('Update this item'),
+        '#title_display' => 'invisible',
+        '#return_value' => $row->Id ?? '',
+        '#default_value' => !empty($form_state->getValue($this->options['id'])[$row_index]) ? 1 : NULL,
       ];
-
-      foreach ($this->view->result as $row_index => $row) {
-        $form[$this->options['id']][$row_index] = [
-          '#type' => 'checkbox',
-          // We are not able to determine a main "title" for each row, so we can
-          // only output a generic label.
-          '#title' => $this->t('Update this item'),
-          '#title_display' => 'invisible',
-          '#return_value' => $row->Id ?? '',
-          '#default_value' => !empty($form_state->getValue($this->options['id'])[$row_index]) ? 1 : NULL,
-        ];
-      }
     }
+
     // Change default BulkForm label.
     if (!empty($form['actions']['submit'])) {
       $form['actions']['submit']['#value'] = $this->t('Import');

--- a/modules/custom/az_event/az_event_trellis/src/TrellisHelper.php
+++ b/modules/custom/az_event/az_event_trellis/src/TrellisHelper.php
@@ -110,6 +110,8 @@ final class TrellisHelper {
         $json = json_decode($json, TRUE);
         if ($json !== NULL) {
           $ids = $json['data']['Event_IDs'] ?? [];
+          // Ensure events are in Id order.
+          sort($ids);
           // @todo determine cache expiration.
           $expire = time() + 1800;
           // Cache search result.
@@ -135,6 +137,8 @@ final class TrellisHelper {
     $events = [];
     $fetch = [];
     $url = $this->getEventEndpoint();
+    // Remove any duplicate ids to mimic remote API.
+    $trellis_ids = array_unique($trellis_ids);
     // Grab events that are in cache.
     foreach ($trellis_ids as $trellis_id) {
       $cached = $this->getTrellisCache($trellis_id);
@@ -165,6 +169,10 @@ final class TrellisHelper {
       catch (GuzzleException $e) {
       }
     }
+    // Make sure events are in Id order regardless of cached/fetched.
+    usort($events, function ($a, $b) {
+      return strcmp($a['Id'], $b['Id']);
+    });
     return $events;
   }
 


### PR DESCRIPTION
## Description
The Trellis Event importer contains a caching layer for events to avoid having to fetch the events from the remote API if they have recently been seen. Other events are fetched as needed a single request because the nature of the Trellis event search API is to fetch multiple events in a single request.

Depending on status of the warmed cached this mix of cached and fetched events means that in some cases, the order of events in an API call is not constant. In most cases this does not matter, but if this happens during a views bulk form submit and rebuild of the form options, it can cause views to think a different row in the results were selected than the ones that actually were, which results in the wrong event being imported.

This PR introduces a defined sort order to the API calls so that events appear in the same order regardless of caching or remote API responses.

## Related issues
#3220 

## How to test

- enable az_event_trellis
- enable az_enterprise_attributes_import
- visit `/admin/trellis-event-importer`
- search keyword `blue chip`
- search keyword `ONE`
- select `March 2024 ONE Workshop` and `February 2024 ONE Workshop` for import
- click `Import`
- verify correct events are imported

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
