### PR TITLE
Backport Update for Google Tag version 2.0.4 to Quickstart 2.8.x branch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -176,6 +176,9 @@
             "drupal/easy_breadcrumb": {
                 "explode(): Passing null to parameter #2 ($string) of type string is deprecated (3284123)": "https://git.drupalcode.org/project/easy_breadcrumb/-/commit/e1655f4260ca82262d49deefbd717801664c5c78.diff"
             },
+            "drupal/google_tag": {
+                "Enforce Privacy Consent Policy checkbox default value is checked even when it is disabled (3424623)": "https://www.drupal.org/files/issues/2024-03-01/3424623-9-allow-saving-google-tag-setting-for-consent-mode.patch"
+            },
             "drupal/intelligencebank": {
                 "Use a renderable array for link buttons (3353858)": "https://www.drupal.org/files/issues/2023-06-02/issue-335385-convert-markup-to-renderable-array.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "drupal/field_group": "3.4.0",
         "drupal/field_group_link": "3.1.0",
         "drupal/flag": "4.0-beta4",
-        "drupal/google_tag": "2.0.2",
+        "drupal/google_tag": "2.0.4",
         "drupal/honeypot": "2.1.3",
         "drupal/image_widget_crop": "2.4.0",
         "drupal/inline_entity_form": "2.0.0-rc9",
@@ -175,9 +175,6 @@
             },
             "drupal/easy_breadcrumb": {
                 "explode(): Passing null to parameter #2 ($string) of type string is deprecated (3284123)": "https://git.drupalcode.org/project/easy_breadcrumb/-/commit/e1655f4260ca82262d49deefbd717801664c5c78.diff"
-            },
-            "drupal/google_tag": {
-                "GoogleTagUpgradeManager not mapping negate values correctly (3382757)": "https://www.drupal.org/files/issues/2023-08-22/3382757-5.patch"
             },
             "drupal/intelligencebank": {
                 "Use a renderable array for link buttons (3353858)": "https://www.drupal.org/files/issues/2023-06-02/issue-335385-convert-markup-to-renderable-array.patch"

--- a/modules/custom/az_google_tag/config/install/google_tag.container.az_comprehensive.yml
+++ b/modules/custom/az_google_tag/config/install/google_tag.container.az_comprehensive.yml
@@ -22,7 +22,8 @@ advanced_settings:
         nonGoogleIframes
       blocklist_classes: |-
         customScripts
-      customPixels      include_environment: false
+        customPixels      
+      include_environment: false
       environment_id: ''
       environment_token: ''
 dimensions_metrics: {  }

--- a/modules/custom/az_google_tag/config/install/google_tag.container.az_comprehensive.yml
+++ b/modules/custom/az_google_tag/config/install/google_tag.container.az_comprehensive.yml
@@ -10,38 +10,22 @@ weight: 0
 tag_container_ids:
   - GTM-ML2BZB
 advanced_settings:
+  consent_mode: true
   gtm:
-    data_layer: dataLayer
-    include_classes: false
-    allowlist_classes: |-
-      google
-      nonGooglePixels
-      nonGoogleScripts
-      nonGoogleIframes
-    blocklist_classes: |-
-      customScripts
-      customPixels
-    include_environment: false
-    environment_id: ''
-    environment_token: ''
+    GTM-ML2BZB:
+      data_layer: dataLayer
+      include_classes: false
+      allowlist_classes: ''
+      blocklist_classes: ''
+      include_environment: false
+      environment_id: ''
+      environment_token: ''
 dimensions_metrics: {  }
 conditions:
   request_path:
     id: request_path
     negate: true
-    pages: |-
-      /admin*
-      batch*
-      block/add/*
-      /block/*/edit
-      file/add
-      file/*/edit
-      /node/add*
-      /node/*/edit
-      /node/*/delete
-      /user/*/edit*
-      /user/*/cancel*
-      taxonomy/term/*/edit
+    pages: "/admin*\r\n/batch*\r\n/clone/*\r\n/devel/*\r\n/node/add*\r\n/node/*/edit\r\n/node/*/delete\r\n/node/*/revisions\r\n/node/*/usage\r\n/user/*/edit*\r\n/user/*/cancel*\r\n/user/*/scheduled*\r\n/user/*/connected-accounts\r\n/user/*/submissions\r\n/group/*/edit\r\n/group/*/delete\r\n/group/*/content*\r\n/group/*/nodes\r\n/group/*/revisions\r\n/group/*/members\r\n/group/*/media*\r\n/group/*/usage\r\n/group/*/subgroups\r\n/group/*/create\r\n/media/*/edit\r\n/media/*/delete\r\n/media/*/usage\r\n/taxonomy/*/edit\r\n/taxonomy/*/delete\r\n/taxonomy/*/usage"
   response_code:
     id: response_code
     negate: true
@@ -59,9 +43,9 @@ events:
   generate_lead:
     value: ''
     currency: ''
-  custom: {  }
-  sign_up:
-    method: CMS
-  search: {  }
   login:
     method: CMS
+  sign_up:
+    method: CMS
+  custom: {  }
+  search: {  }

--- a/modules/custom/az_google_tag/config/install/google_tag.container.az_comprehensive.yml
+++ b/modules/custom/az_google_tag/config/install/google_tag.container.az_comprehensive.yml
@@ -15,9 +15,14 @@ advanced_settings:
     GTM-ML2BZB:
       data_layer: dataLayer
       include_classes: false
-      allowlist_classes: ''
-      blocklist_classes: ''
-      include_environment: false
+      allowlist_classes: |-
+        google
+        nonGooglePixels
+        nonGoogleScripts
+        nonGoogleIframes
+      blocklist_classes: |-
+        customScripts
+      customPixels      include_environment: false
       environment_id: ''
       environment_token: ''
 dimensions_metrics: {  }

--- a/modules/custom/az_google_tag/config/install/google_tag.container.az_comprehensive.yml
+++ b/modules/custom/az_google_tag/config/install/google_tag.container.az_comprehensive.yml
@@ -10,7 +10,7 @@ weight: 0
 tag_container_ids:
   - GTM-ML2BZB
 advanced_settings:
-  consent_mode: true
+  consent_mode: false
   gtm:
     GTM-ML2BZB:
       data_layer: dataLayer


### PR DESCRIPTION
Exported config from 2.8.x branch.