### PR TITLE
Fixes #3234 AZBackgroundMediaFormatter breaks field displays on non-paragraph entities

### DIFF
--- a/modules/custom/az_paragraphs/src/Plugin/Field/FieldFormatter/AZBackgroundMediaFormatter.php
+++ b/modules/custom/az_paragraphs/src/Plugin/Field/FieldFormatter/AZBackgroundMediaFormatter.php
@@ -431,7 +431,7 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
     $all_settings = [];
     // Paragraph instance settings override everything.
     $paragraph_settings = $this->getParagraphSettings($items);
-    $all_settings += $paragraph_settings['az_text_media_paragraph_behavior'];
+    $all_settings += $paragraph_settings['az_text_media_paragraph_behavior'] ?? [];
     // Field formatter settings.
     $all_settings += $this->getSettings();
     // Fill in all the rest of the required settings.


### PR DESCRIPTION
## Description
`AZBackgroundMediaFormatter` currently assumes it is present on a paragraph entity and causes PHP errors in field displays if on a non-paragraph entity, or paragraph missing the appropriate behaviors.

There is usually no reason for this to occur, but this can accidentally occur on user-defined content types if an entity reference field is disabled and Drupal automatically selects it as the formatter due to weight.

## Related issues
Closes #3234 

## How to test

- Add a reference field to a node type
- Set the display formatter for the field as `Background Media`
- Create a piece of content of the above node type
- Verify the node can be viewed without PHP errors

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
