### PR TITLE
Closes #3141: Customize Add CAS User(s) menu local action and optionally remove standard Add user action.

### DIFF
--- a/modules/custom/az_cas/az_cas.module
+++ b/modules/custom/az_cas/az_cas.module
@@ -115,3 +115,21 @@ function az_cas_module_implements_alter(&$implementations, $hook) {
     $implementations['az_cas'] = $group;
   }
 }
+
+/**
+ * Implements hook_menu_local_actions_alter().
+ *
+ * Customizes "Add CAS User(s)" menu local action and optionally disables the
+ * standard "Add user" menu local action on the admin user listing page.
+ */
+function az_cas_menu_local_actions_alter(&$local_actions) {
+  $az_cas_config = \Drupal::config('az_cas.settings');
+
+  $local_actions['cas.bulk_add_cas_users']['title'] = t('Add user(s) with NetID');
+  $local_actions['cas.bulk_add_cas_users']['weight'] = -1;
+
+  $disable_admin_add_user_button = $az_cas_config->get('disable_admin_add_user_button');
+  if ($disable_admin_add_user_button) {
+    unset($local_actions['user_admin_create']);
+  }
+}

--- a/modules/custom/az_cas/config/install/az_cas.settings.yml
+++ b/modules/custom/az_cas/config/install/az_cas.settings.yml
@@ -1,2 +1,3 @@
 disable_login_form: true
+disable_admin_add_user_button: false
 disable_password_recovery_link: true

--- a/modules/custom/az_cas/config/install/az_cas.settings.yml
+++ b/modules/custom/az_cas/config/install/az_cas.settings.yml
@@ -1,3 +1,3 @@
 disable_login_form: true
-disable_admin_add_user_button: false
+disable_admin_add_user_button: true
 disable_password_recovery_link: true

--- a/modules/custom/az_cas/config/schema/az_cas.schema.yml
+++ b/modules/custom/az_cas/config/schema/az_cas.schema.yml
@@ -5,6 +5,9 @@ az_cas.settings:
     disable_login_form:
       type: boolean
       label: 'Disable login form'
+    disable_admin_add_user_button:
+      type: boolean
+      label: 'Disable button for adding non-CAS users in admin interface'
     disable_password_recovery_link:
       type: boolean
       label: 'Disable password recovery link'

--- a/modules/custom/az_cas/src/Form/AzCasSettingsForm.php
+++ b/modules/custom/az_cas/src/Form/AzCasSettingsForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\az_cas\Form;
 
+use Drupal\Core\Cache\CacheFactoryInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
@@ -22,6 +23,13 @@ class AzCasSettingsForm extends ConfigFormBase {
   protected $routeBuilder;
 
   /**
+   * The cache factory.
+   *
+   * @var \Drupal\Core\Cache\CacheFactoryInterface
+   */
+  protected $cacheFactory;
+
+  /**
    * Constructs a AzCasSettingsForm object.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
@@ -30,11 +38,14 @@ class AzCasSettingsForm extends ConfigFormBase {
    *   The typed config manager.
    * @param \Drupal\Core\Routing\RouteBuilderInterface $route_builder
    *   The route builder.
+   * @param \Drupal\Core\Cache\CacheFactoryInterface $cache_factory
+   *   The cache factory.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, TypedConfigManagerInterface|null $typedConfigManager, RouteBuilderInterface $route_builder) {
+  public function __construct(ConfigFactoryInterface $config_factory, TypedConfigManagerInterface|null $typedConfigManager, RouteBuilderInterface $route_builder, CacheFactoryInterface $cache_factory) {
     parent::__construct($config_factory, $typedConfigManager);
 
     $this->routeBuilder = $route_builder;
+    $this->cacheFactory = $cache_factory;
   }
 
   /**
@@ -44,7 +55,8 @@ class AzCasSettingsForm extends ConfigFormBase {
     return new static(
       $container->get('config.factory'),
       $container->get('config.typed'),
-      $container->get('router.builder')
+      $container->get('router.builder'),
+      $container->get('cache_factory')
     );
   }
 
@@ -75,6 +87,13 @@ class AzCasSettingsForm extends ConfigFormBase {
       '#default_value' => $az_cas_config->get('disable_login_form'),
     ];
 
+    $form['disable_admin_add_user_button'] = [
+      '#title' => t("Disable 'Add user' button"),
+      '#type' => 'checkbox',
+      '#description' => t("Removes button for adding non-CAS users in admin interface."),
+      '#default_value' => $az_cas_config->get('disable_admin_add_user_button'),
+    ];
+
     $form['disable_password_recovery_link'] = [
       '#title' => t("Disable 'request new password' form"),
       '#type' => 'checkbox',
@@ -91,10 +110,13 @@ class AzCasSettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->config('az_cas.settings')
       ->set('disable_login_form', $form_state->getValue('disable_login_form'))
+      ->set('disable_admin_add_user_button', $form_state->getValue('disable_admin_add_user_button'))
       ->set('disable_password_recovery_link', $form_state->getValue('disable_password_recovery_link'))
       ->save();
 
     $this->routeBuilder->setRebuildNeeded();
+    $this->cacheFactory->get('render')->deleteAll();
+    $this->cacheFactory->get('discovery')->deleteAll();
 
     parent::submitForm($form, $form_state);
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
- Changes the text of the "Add CAS User(s)" button on the /admin/people page to be "Add user(s) with NetID"
- Updates the weight of the "Add user(s) with NetID" so it appears first
- Adds a new config setting to the AZ CAS module for optionally disabling (removing) the standard "Add user" button

## Related issues
Closes #3141 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
On [ProboCI site](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3250.probo.build/):
- Login with azadmin or azuseradmin account
- Navigate to /admin/people
- Verify that the "Add CAS User(s)" button has been renamed "Add user(s) with NetID"
- Verify that the "Add user(s) with NetID" button appears first (left of the "Add user" button)
- Navigate to /admin/config/az-quickstart/settings/az-cas
- Turn on "Disable 'Add user' button" setting, save
- Go back to /admin/people
- Verify that "Add user" button has been removed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [x] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
