### PR TITLE
Closes #2357 Add better metatag defaults for Quickstart

### DIFF
--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -276,13 +276,7 @@ function az_core_canonical_url(array $data, bool $absolute = FALSE) {
   $node = $data['node'];
   /** @var \Drupal\Core\Url $url */
   $url = $node->toUrl();
-
-  if ($absolute) {
-    $uri = $url->setOption('absolute', TRUE)->toString();
-  }
-  else {
-    $uri = $url->toUriString();
-  }
+  $uri = $absolute ? $url->setOption('absolute', TRUE)->toString() : $url->toUriString();
 
   if (!empty($node->field_az_link[0]->uri)) {
     $uri = $node->field_az_link[0]->uri;

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -193,6 +193,10 @@ function az_core_token_info() {
           'name' => t("AZ Canonical URL"),
           'description' => t("Returns the URI value of field_az_link if present on the node or the default node URI if not."),
         ],
+        'az-canonical-absolute-url' => [
+          'name' => t("AZ Canonical Absolute URL"),
+          'description' => t("Returns an absolute URL for field_az_link if present on the node or the default node URL if not."),
+        ],
         'az-canonical-summary-link-title' => [
           'name' => t("AZ Canonical Summary Link Title"),
           'description' => t("Returns the link title value of field_az_link if present on the node or nothing if not."),
@@ -213,6 +217,10 @@ function az_core_tokens($type, $tokens, array $data, array $options, BubbleableM
       switch ($name) {
         case 'az-canonical-url':
           $replacements[$original] = az_core_canonical_url($data);
+          break;
+
+        case 'az-canonical-absolute-url':
+          $replacements[$original] = az_core_canonical_url($data, TRUE);
           break;
 
         case 'az-canonical-summary-link-title':
@@ -250,23 +258,31 @@ function az_core_canonical_summary_link_title(array $data) {
 }
 
 /**
- * Token replacement callback providing the canonical URI for a node.
+ * Token replacement callback providing the canonical URI or URL for a node.
  *
  * Returns the URI value of field_az_link if present on the node or the default
- * node URI if not.
+ * node URI if not. Optionally return an absolute URL instead.
  *
  * @param array $data
  *   Node data from hook_tokens().
+ * @param bool $absolute
+ *   Flag to determine whether to return an absolute URL.
  *
  * @return string
- *   The node's canonical URI.
+ *   The node's canonical URI or URL.
  */
-function az_core_canonical_url(array $data) {
+function az_core_canonical_url(array $data, bool $absolute = FALSE) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $data['node'];
   /** @var \Drupal\Core\Url $url */
   $url = $node->toUrl();
-  $uri = $url->setOption('absolute', TRUE)->toString();
+
+  if ($absolute) {
+    $uri = $url->setOption('absolute', TRUE)->toString();
+  }
+  else {
+    $uri = $url->toUriString();
+  }
 
   if (!empty($node->field_az_link[0]->uri)) {
     $uri = $node->field_az_link[0]->uri;

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -259,14 +259,14 @@ function az_core_canonical_summary_link_title(array $data) {
  *   Node data from hook_tokens().
  *
  * @return string
- *   The node's canononical URI.
+ *   The node's canonical URI.
  */
 function az_core_canonical_url(array $data) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $data['node'];
   /** @var \Drupal\Core\Url $url */
   $url = $node->toUrl();
-  $uri = $url->toUriString();
+  $uri = $url->setOption('absolute',TRUE)->toString();
 
   if (!empty($node->field_az_link[0]->uri)) {
     $uri = $node->field_az_link[0]->uri;

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -266,7 +266,7 @@ function az_core_canonical_url(array $data) {
   $node = $data['node'];
   /** @var \Drupal\Core\Url $url */
   $url = $node->toUrl();
-  $uri = $url->setOption('absolute',TRUE)->toString();
+  $uri = $url->setOption('absolute', TRUE)->toString();
 
   if (!empty($node->field_az_link[0]->uri)) {
     $uri = $node->field_az_link[0]->uri;

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.global.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.global.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: global
+label: Global
+tags:
+  canonical_url: '[current-page:url]'
+  generator: 'Arizona Quickstart (https://quickstart.arizona.edu)'
+  title: '[current-page:title] | [site:name]'

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.global.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.global.yml
@@ -1,9 +1,0 @@
-langcode: en
-status: true
-dependencies: {  }
-id: global
-label: Global
-tags:
-  canonical_url: '[current-page:url]'
-  generator: 'Arizona Quickstart (https://quickstart.arizona.edu)'
-  title: '[current-page:title] | [site:name]'

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node.yml
@@ -10,6 +10,6 @@ tags:
   og_image: '[node:field_az_media_image:entity:field_media_az_image]'
   og_site_name: '[site:name]'
   og_title: '[node:title]'
-  og_url: '[node:az-canonical-url]'
+  og_url: '[node:az-canonical-absolute-url]'
   title: '[node:title] | [site:name]'
   twitter_cards_type: summary

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node.yml
@@ -4,6 +4,12 @@ dependencies: {  }
 id: node
 label: Content
 tags:
+  canonical_url: '[node:az-canonical-url]'
   description: '[node:field_az_summary]'
-  canonical_url: '[node:field_az_link:uri]'
+  og_description: '[node:field_az_summary]'
+  og_image: '[node:field_az_media_image]'
+  og_site_name: '[site:name]'
+  og_title: '[node:title]'
+  og_url: '[node:az-canonical-url]'
   title: '[node:title] | [site:name]'
+  twitter_cards_type: summary

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node.yml
@@ -7,7 +7,7 @@ tags:
   canonical_url: '[node:az-canonical-url]'
   description: '[node:field_az_summary]'
   og_description: '[node:field_az_summary]'
-  og_image: '[node:field_az_media_image]'
+  og_image: '[node:field_az_media_image:entity:field_media_az_image]'
   og_site_name: '[site:name]'
   og_title: '[node:title]'
   og_url: '[node:az-canonical-url]'

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node.yml
@@ -4,12 +4,12 @@ dependencies: {  }
 id: node
 label: Content
 tags:
-  canonical_url: '[node:az-canonical-url]'
+  canonical_url: '[node:field_az_link:uri]'
   description: '[node:field_az_summary]'
   og_description: '[node:field_az_summary]'
   og_image: '[node:field_az_media_image:entity:field_media_az_image]'
   og_site_name: '[site:name]'
   og_title: '[node:title]'
-  og_url: '[node:az-canonical-url]'
+  og_url: '[current-page:metatag:canonical_url]'
   title: '[node:title] | [site:name]'
   twitter_cards_type: summary

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node.yml
@@ -10,6 +10,6 @@ tags:
   og_image: '[node:field_az_media_image:entity:field_media_az_image]'
   og_site_name: '[site:name]'
   og_title: '[node:title]'
-  og_url: '[current-page:metatag:canonical_url]'
+  og_url: '[node:az-canonical-url]'
   title: '[node:title] | [site:name]'
   twitter_cards_type: summary

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node__az_event.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node__az_event.yml
@@ -4,4 +4,4 @@ dependencies: {  }
 id: node__az_event
 label: 'Content: Event'
 tags:
-  og_image: '[node:field_az_media_thumbnail_image]'
+  og_image: '[node:field_az_media_thumbnail_image:entity:field_media_az_image]'

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node__az_event.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node__az_event.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__az_event
+label: 'Content: Event'
+tags:
+  og_image: '[node:field_az_media_thumbnail_image]'

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node__az_news.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node__az_news.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__az_news
+label: 'Content: News'
+tags:
+  og_image: '[node:field_az_media_thumbnail_image]'
+  og_type: article

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node__az_news.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node__az_news.yml
@@ -4,5 +4,5 @@ dependencies: {  }
 id: node__az_news
 label: 'Content: News'
 tags:
-  og_image: '[node:field_az_media_thumbnail_image]'
+  og_image: '[node:field_az_media_thumbnail_image:entity:field_media_az_image]'
   og_type: article

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node__az_news.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node__az_news.yml
@@ -4,5 +4,6 @@ dependencies: {  }
 id: node__az_news
 label: 'Content: News'
 tags:
+  article_published_time: '[node:field_az_published:date:html_datetime]'
   og_image: '[node:field_az_media_thumbnail_image:entity:field_media_az_image]'
   og_type: article

--- a/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node__az_person.yml
+++ b/modules/custom/az_seo/config/quickstart/metatag.metatag_defaults.node__az_person.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__az_person
+label: 'Content: Person'
+tags:
+  og_type: profile
+  profile_first_name: '[node:field_az_fname]'
+  profile_last_name: '[node:field_az_lname]'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Updates the default settings for the Metatag contrib module, primarily to:

- Enable social media previews
- Potentially improve SEO

Tasks to complete:

- [x] Figure out how to set both the canonical link and the og:url tag
   - Currently in Quickstart, if a node doesn't have an external link, the `[node:az-canonical-url]` token returns this URL string internally: `route:entity.node.canonical;node=17`. This string can't be used for a metatag value.
   - This PR introduces a new token to return an absolute URL instead, so that the `og:url` tag should always match the `rel="canonical"` link annotation. I tested this on a multidev of a multilingual site and confirmed that each translation of a page has a canonical link set for its specific URL (such as `/some-page` and `/es/some-page`).
   - More info on canonical links: https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls. In short, changing the behavior of what Quickstart sets as a canonical link should be a separate issue, which may alter the sitemap as well.
- [x] Confirm what image tags to use, depending on image size and style recommendations
   - The PR is currently using the _original_ thumbnail image (without cropping).
   - [Facebook recommendations](https://developers.facebook.com/docs/sharing/webmasters/images): at least 1200 x 630 px for best display on high res devices, 600 x 315 px to display link page posts with larger images. The minimum is 200 x 200 px and the size should be less than 8 MB. Image cropped to 1.91:1 aspect ratio.
   - [Twitter recommendations](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary): minimum 144x144 px, maximum 4096x4096 px, less than 5 MB in size. Images cropped to square.
   - **Tentative decision:** Although we could potentially set the image style to the "Max 1300x1300" style, this would result in many image files being generated (unnecessarily in my opinion). So using the original image seems like the best option.
- [x] Confirm what changes to make to the robots tag, if any
   - The main change to make would be conditional: setting robots to noindex, nofollow for nodes with an external link. This can be a follow-up PR.
- [x] Fix duplicate Generator tags
   - This is an [issue with the Metatag module](https://www.drupal.org/project/metatag/issues/2735195#comment-14531696): the Generator tag from Drupal does not get overridden. A Generator tag for "Arizona Quickstart" will not be included in this PR.

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2357

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3255.probo.build

1. Log into the Probo site and update pages, news, etc. with summary text and other content for testing. ([Example](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3255.probo.build/news/could-mans-best-friend-be-mans-best-medicine))
2. View the source of the page and check the <head> element to confirm that the `og` tags are present and that the `og:url` tag matches the `rel="canonical"` link annotation.
3. Use the tools below to test the social media previews for various URLs:

- https://metatags.io
- [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)
- [Twitter Card Validator](https://cards-dev.twitter.com/validator)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [x] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
