### PR TITLE
Closes #3280 Removing Horizontal Negative Margins from Exposed Forms

### DIFF
--- a/themes/custom/az_barrio/templates/views/views-exposed-form.html.twig
+++ b/themes/custom/az_barrio/templates/views/views-exposed-form.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Theme override for a views exposed form.
+ *
+ * Available variables:
+ * - form: A render element representing the form.
+ *
+ * @see template_preprocess_views_exposed_form()
+ */
+#}
+{% if q is not empty %}
+  {#
+    This ensures that, if clean URLs are off, the 'q' is added first,
+    as a hidden form element, so that it shows up first in the POST URL.
+  #}
+{{ q }}
+{% endif %}
+<div class="d-flex flex-wrap">
+  {{ form }}
+</div>


### PR DESCRIPTION
Remove unnecessary horizontal negative margin from exposed forms.

## Description
This change improves the visual layout of exposed forms by removing the horizontal negative margins previously applied by the `form-row` class. The replacement with `d-flex flex-wrap` enhances form responsiveness across various device widths without affecting the functionality.

## Related issues
- Closes #3280
- Blocks #2998
- Blocked by #3279 (blocked because it is difficult to test without demo content.)

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Minor release changes**
   - [x] Breaking or visual change to existing behavior
   
## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
