### PR TITLE
Close #3293 Allow reinstallation of az_demo module.

### DIFF
--- a/modules/custom/az_demo/config/install/views.view.az_finder.yml
+++ b/modules/custom/az_demo/config/install/views.view.az_finder.yml
@@ -22,6 +22,9 @@ dependencies:
     - node
     - taxonomy
     - user
+  enforced:
+    module:
+      - az_demo
 id: az_finder
 label: 'AZ Finder'
 module: views

--- a/modules/custom/az_demo/config/optional/block.block.az_barrio_exposedformaz_findercontent.yml
+++ b/modules/custom/az_demo/config/optional/block.block.az_barrio_exposedformaz_findercontent.yml
@@ -9,6 +9,9 @@ dependencies:
     - views
   theme:
     - az_barrio
+  enforced:
+    module:
+      - az_demo
 id: az_barrio_exposedformaz_findercontent
 theme: az_barrio
 region: sidebar_first

--- a/modules/custom/az_demo/config/optional/block.block.az_barrio_exposedformaz_finderevent.yml
+++ b/modules/custom/az_demo/config/optional/block.block.az_barrio_exposedformaz_finderevent.yml
@@ -9,6 +9,9 @@ dependencies:
     - views
   theme:
     - az_barrio
+  enforced:
+    module:
+      - az_demo
 id: az_barrio_exposedformaz_finderevent
 theme: az_barrio
 region: sidebar_first

--- a/modules/custom/az_demo/config/optional/block.block.az_barrio_exposedformaz_findernews.yml
+++ b/modules/custom/az_demo/config/optional/block.block.az_barrio_exposedformaz_findernews.yml
@@ -9,6 +9,9 @@ dependencies:
     - views
   theme:
     - az_barrio
+  enforced:
+    module:
+      - az_demo
 id: az_barrio_exposedformaz_findernews
 theme: az_barrio
 region: sidebar_first

--- a/modules/custom/az_demo/config/optional/block.block.az_barrio_exposedformaz_finderpage.yml
+++ b/modules/custom/az_demo/config/optional/block.block.az_barrio_exposedformaz_finderpage.yml
@@ -9,6 +9,9 @@ dependencies:
     - views
   theme:
     - az_barrio
+  enforced:
+    module:
+      - az_demo
 id: az_barrio_exposedformaz_finderpage
 theme: az_barrio
 region: sidebar_first

--- a/modules/custom/az_demo/config/optional/block.block.az_barrio_exposedformaz_finderperson.yml
+++ b/modules/custom/az_demo/config/optional/block.block.az_barrio_exposedformaz_finderperson.yml
@@ -9,6 +9,9 @@ dependencies:
     - views
   theme:
     - az_barrio
+  enforced:
+    module:
+      - az_demo
 id: az_barrio_exposedformaz_finderperson
 theme: az_barrio
 region: sidebar_first


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
This pull request adds `enforced` configuration to various configuration items within the `az_demo` module. By enforcing these configurations to be dependent on the `az_demo` module, we ensure that they are automatically removed when the module is uninstalled, addressing the issue where the module could not be cleanly reinstalled due to lingering configurations.

## Related issues
- Fixes #3293

## How to test
1. Install the `az_demo` module.
2. Uninstall the `az_demo` module.
3. Reinstall the `az_demo` module.
4. Confirm that no errors related to pre-existing configuration data are encountered.

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update
