### PR TITLE
Fixes #3347, Fixes #3338 Allow QuickstartConfigProvider to ignore some Diff types.

### DIFF
--- a/modules/custom/az_core/src/AZConfigOverride.php
+++ b/modules/custom/az_core/src/AZConfigOverride.php
@@ -119,6 +119,9 @@ class AZConfigOverride implements LoggerAwareInterface {
         $snapshots = [];
         // Edit active configuration for each explicit override.
         foreach ($overrides as $name => $data) {
+          $this->logger->info("Applying override config to @config_id.", [
+            '@config_id' => $name,
+          ]);
           $config = $this->configFactory->getEditable($name);
           $config->setData($data);
           $config->Save();


### PR DESCRIPTION
## Description
In #3338 it was found that for some sites that have been active, Quickstart overrides from the new `az_finder` were not being applied to the packaged views. This issue was variable and depended on how the views had been saved and updated on the sites in question, and was not typically exhibited in test builds. It was found in the cases examined that the actual diff was in `cache_metadata` keys of the views which are generated dynamically when views are updated, in some cases.

A potential fix for this is to update `QuickstartConfigProvider` to not consider `cache_metadata` keys when it determines if the configuration item has been customized before applying the override.

Note that this is mostly a convenience change, because the overrides do still become available, they just must be applied via distribution update. Since `az_finder` is an experimental module, we could alternately go the route of documenting that this distribution import is needed rather than making changes to diff resolution.

This may be generally related to Drupal contrib issues like [Normalize view display cache_metadata.max_age property](https://www.drupal.org/project/config_normalizer/issues/3007483) and we may want to consider a more comprehensive upstream fix for this in the future.

## Related issues
Closes #3338 
Closes #3347 

## How to test
- There is no specific way to generate this problem on a fresh build of a site. Begin with a site that exhibits the symptom (enabling `az_finder` on a site that has been active generates notices of `Disallowing override of customized configuration` even if the view is not thought to have been customized)
- Begin with a version of the site where `az_finder` has not been enabled.
- Verify that all distribution updates and database updates have been applied.
- enable `az_finder`
- Verify that `Applying override config to config.name` appears in the log for the views being overridden.
- Verify that the view in question is using the new exposed filter plugin.
###  TEST for regression in the reverse case (actual customization)
- Begin with the site in a state where `az_finder` has not yet been enabled
- Make an actual customization to one of the views (e.g. `az_news`) such as changing the title
- Save the change to the view.
- Enable `az_finder`
- Verify that `Disallowing override of customized configuration` appears in the log and the view is not changed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [x] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
