### PR TITLE
Closes #3339 New breakpoint to hide arrows on small displays

### DIFF
--- a/modules/custom/az_carousel/config/install/slick.optionset.center_mode.yml
+++ b/modules/custom/az_carousel/config/install/slick.optionset.center_mode.yml
@@ -7,7 +7,7 @@ weight: 0
 label: 'Center Mode'
 group: ''
 skin: ''
-breakpoints: 1
+breakpoints: 2
 optimized: false
 options:
   options__active_tab: edit-options-responsives
@@ -67,6 +67,43 @@ options:
     responsive:
       -
         breakpoint: 1110
+        unslick: false
+        settings:
+          adaptiveHeight: false
+          autoplay: false
+          pauseOnHover: false
+          pauseOnDotsHover: false
+          pauseOnFocus: false
+          autoplaySpeed: 3000
+          arrows: false
+          centerMode: true
+          centerPadding: 10%
+          dots: true
+          draggable: false
+          fade: false
+          focusOnSelect: true
+          infinite: true
+          initialSlide: 0
+          respondTo: window
+          rows: 1
+          slidesPerRow: 1
+          slidesToShow: 1
+          slidesToScroll: 1
+          speed: 500
+          swipe: true
+          swipeToSlide: false
+          edgeFriction: 0.35
+          touchMove: true
+          touchThreshold: 5
+          cssEase: ease
+          cssEaseBezier: ''
+          cssEaseOverride: ''
+          variableWidth: true
+          vertical: false
+          verticalSwiping: false
+          waitForAnimate: false
+      -
+        breakpoint: 1309
         unslick: false
         settings:
           adaptiveHeight: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hides arrow controls on viewports less than 1310 across.

This is accomplished by adding a second breakpoint to the Slick optionset "Center Mode" that we ship with QS2. The old (and only) breakpoint has been adjusted to no longer show the arrow controls. The new breakpoint is a duplicate of the prior but with arrows enabled. The trigger for the breakpoint is actually 1309 (not 1310) which allows for a pixel-perfect alignment. However, we may choose to set this to 1310 for maintainability purposes.

Maths: 1110 (slide content) + 100 (left arrow) + 100 (right arrow) = 1310px wide
_We could insert some extra padding here if we don't want the arrows to ever touch the active slide. For example, if we did a 1370 breakpoint, this would have the effect of adding 30px of padding to the left and right of the active slide. It also means that the arrows will disappear sooner when shrinking the viewport horizontally._

I attempted to do this with just one breakpoint but that ended up breaking the slide image. I suspect this is because we use "variable width".

## Related issues
Closes #3339 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
1. Create a carousel with at least two carousel items.
2. Adjust resolution so that viewport is greater than 1110 but less than 1310 wide. In this range, the arrow controls were previously overlapping the carousel slide content. Arrow controls should no longer appear until the viewport passes 1310+ px across.

At 1309px wide:
![azquickstart lndo site_ (2)](https://github.com/az-digital/az_quickstart/assets/2702851/2b488dcf-4be5-476b-8506-0eb227775d07)

At 1310px wide:
![azquickstart lndo site_](https://github.com/az-digital/az_quickstart/assets/2702851/3d36f405-9de2-428d-8c0e-80daff3af809)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [X] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
