### PR TITLE
Closes #3453 | Remove duplicate required asterisk on Webforms

### DIFF
--- a/themes/custom/az_barrio/templates/forms/fieldset.html.twig
+++ b/themes/custom/az_barrio/templates/forms/fieldset.html.twig
@@ -34,8 +34,6 @@
   set legend_classes = [
     'col-form-label',
     'font-weight-bold',
-    required ? 'js-form-required',
-    required ? 'form-required',
   ]
 %}
 <fieldset{{ attributes.addClass(classes) }}>


### PR DESCRIPTION
## Description
Corrects duplicate asterisks on required multi-select fields (i.e., checkboxes, radios, checkboxes other, radios other). 

## Related issues
Closes #3453 

## How to test
1. Install Webform & Webform UI.
2. Build a Webform with different types of fields.
_Be sure to include some multi-select field types, and mark them as required._
3. View the Webform and verify that multi-select fields no longer have a duplicate asterisk.

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
