### PR TITLE
Fixes #3556, Fixes #3557 Regressions in AZEventTrellisViewsField, AZTrellisEventSource

### DIFF
--- a/modules/custom/az_event/az_event_trellis/src/Plugin/migrate/source/AZTrellisEventSource.php
+++ b/modules/custom/az_event/az_event_trellis/src/Plugin/migrate/source/AZTrellisEventSource.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace Drupal\az_event_trellis\Plugin\migrate\source;
 
-use Drupal\migrate\Attribute\MigrateProcess;
 use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
 use Drupal\migrate\Plugin\MigrationInterface;
 
 /**
  * Source plugin for retrieving data via Trellis events.
+ *
+ * @MigrateSource(
+ *   id = "az_trellis_events_api"
+ * )
  */
-#[MigrateProcess('az_trellis_events_api')]
 class AZTrellisEventSource extends SourcePluginBase {
 
   /**

--- a/modules/custom/az_event/az_event_trellis/src/Plugin/views/field/AZEventTrellisViewsField.php
+++ b/modules/custom/az_event/az_event_trellis/src/Plugin/views/field/AZEventTrellisViewsField.php
@@ -136,4 +136,12 @@ class AZEventTrellisViewsField extends BulkForm {
 
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function isWorkspaceSafeForm(array $form, FormStateInterface $form_state): bool {
+    // This field is not backed by an entity like BulkForm expects.
+    return FALSE;
+  }
+
 }


### PR DESCRIPTION
## Description
This PR updates `AZEventTrellisViewsField` to be Workspace aware as per the Parent class (`BulkForm`) which was added in [Add the ability to mark (VBO) actions as workspace-safe](https://www.drupal.org/project/drupal/issues/2986005)in 10.3.

Additionally, a regression is fixed that changed `AZTrellisEventSource` to being a `MigrateProcess` plugin in #3419  

## Related issues
Closes #3556 
Closes #3557 

## How to test

- enable `az_demo`, `az_enterprise_attributes_import`, `az_event_trellis`
- visit `/admin/trellis-event-importer`
- search for an event
- verify the event can be successfully imported via the Import button at the bottom of the form

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
