### PR TITLE
[Branch for issue/3262] Standardize text on the settings form

### DIFF
--- a/modules/custom/az_finder/src/Form/AZFinderSettingsForm.php
+++ b/modules/custom/az_finder/src/Form/AZFinderSettingsForm.php
@@ -144,7 +144,7 @@ class AZFinderSettingsForm extends ConfigFormBase implements ContainerInjectionI
     // Default state select field.
     $form['az_finder_tid_widget']['default_state'] = [
       '#type' => 'select',
-      '#title' => $this->t('Default Display'),
+      '#title' => $this->t('Default Display of Parent Terms'),
       '#description' => $this->t('Choose how taxonomy terms with children should behave by default everywhere.<br />These settings are not context aware, so if you choose collapsed, your term must be using a collapsible element for this to work.'),
       '#weight' => -2,
       '#options' => [
@@ -174,8 +174,8 @@ class AZFinderSettingsForm extends ConfigFormBase implements ContainerInjectionI
       $normalized_session_overrides[$key] = $override;
     }
 
-    // Combine overrides.
-    $overrides = array_merge($config_overrides, $normalized_session_overrides);
+    // Combine overrides. Session overrides will not overwrite existing ones.
+    $overrides = $config_overrides + $normalized_session_overrides;
 
     $form['az_finder_tid_widget']['overrides'] = [
       '#type' => 'container',
@@ -198,7 +198,7 @@ class AZFinderSettingsForm extends ConfigFormBase implements ContainerInjectionI
       ],
       'override' => [
         '#type' => 'submit',
-        '#value' => $this->t('Override'),
+        '#value' => $this->t('Add Override'),
         '#ajax' => [
           'callback' => '::ajaxAddOverride',
           'wrapper' => 'js-overrides-container',
@@ -224,7 +224,7 @@ class AZFinderSettingsForm extends ConfigFormBase implements ContainerInjectionI
     if (!empty($overrides)) {
       $form['az_finder_tid_widget']['overrides']['configure_overrides'] = [
         '#type' => 'item',
-        '#title' => $this->t('Configure Applied Overrides'),
+        '#title' => $this->t('Configure Added Overrides'),
       ];
     }
     // Add override sections.
@@ -279,7 +279,9 @@ class AZFinderSettingsForm extends ConfigFormBase implements ContainerInjectionI
     $form_state->setRebuild(TRUE);
 
     // Optionally, provide feedback or perform additional actions.
-    $this->messenger()->addMessage($this->t('Override created for @view_display.', ['@view_display' => $selected_view_display]));
+    $this->messenger()->addMessage($this->t('Override created for @view_display.', [
+      '@view_display' => $form_state->getCompleteForm()['az_finder_tid_widget']['overrides']['select_view_display_container']['select_view_display']['#options'][$selected_view_display],
+    ]));
   }
 
   /**
@@ -318,9 +320,9 @@ class AZFinderSettingsForm extends ConfigFormBase implements ContainerInjectionI
     if ($key !== ':' && !isset($form['az_finder_tid_widget']['overrides'][$key])) {
       $form['az_finder_tid_widget']['overrides'][$key] = [
         '#type' => 'details',
-        '#title' => $this->t("Override Settings for :view_id - :display_id", [
-          ":view_id" => $view_id,
-          ":display_id" => $display_id,
+        '#title' => $this->t("Override Settings for :view_label (:display_label)", [
+          ":view_label" => $override['view_label'],
+          ":display_label" => $override['display_label'],
         ]),
         '#open' => FALSE,
         '#description' => $this->t('Overrides are grouped by taxonomy vocabulary. Each vocabulary can have its own settings for how filter widgets behave when they have child terms.'),

--- a/modules/custom/az_finder/src/Form/AZFinderSettingsForm.php
+++ b/modules/custom/az_finder/src/Form/AZFinderSettingsForm.php
@@ -167,10 +167,6 @@ class AZFinderSettingsForm extends ConfigFormBase implements ContainerInjectionI
       if (empty($override['view_id'])) {
         continue;
       }
-      // Provide an origin if one is missing.
-      if (!isset($override['origin'])) {
-        $override['origin'] = 'session';
-      }
       $normalized_session_overrides[$key] = $override;
     }
 
@@ -268,7 +264,6 @@ class AZFinderSettingsForm extends ConfigFormBase implements ContainerInjectionI
     $override = [
       'view_id' => $view_id,
       'display_id' => $display_id,
-      'origin' => 'session',
     ];
 
     // Ensure the overrides array is present in the form state.

--- a/modules/custom/az_finder/src/Form/AZFinderSettingsForm.php
+++ b/modules/custom/az_finder/src/Form/AZFinderSettingsForm.php
@@ -320,9 +320,9 @@ class AZFinderSettingsForm extends ConfigFormBase implements ContainerInjectionI
     if ($key !== ':' && !isset($form['az_finder_tid_widget']['overrides'][$key])) {
       $form['az_finder_tid_widget']['overrides'][$key] = [
         '#type' => 'details',
-        '#title' => $this->t("Override Settings for :view_label (:display_label)", [
+        '#title' => $this->t("Override Settings for :view_label (:display_title)", [
           ":view_label" => $override['view_label'],
-          ":display_label" => $override['display_label'],
+          ":display_title" => $override['display_title'],
         ]),
         '#open' => FALSE,
         '#description' => $this->t('Overrides are grouped by taxonomy vocabulary. Each vocabulary can have its own settings for how filter widgets behave when they have child terms.'),

--- a/modules/custom/az_finder/src/Service/AZFinderOverrides.php
+++ b/modules/custom/az_finder/src/Service/AZFinderOverrides.php
@@ -55,7 +55,6 @@ final class AZFinderOverrides {
         'view_label' => $view_config->get('label') ?? '',
         'display_title' => $view_config->get('display.' . $display_id . '.display_title') ?? '',
         'vocabularies' => $display_options['filters']['vocabularies'] ?? [],
-        'origin' => 'config',
       ];
     }
 

--- a/modules/custom/az_finder/src/Service/AZFinderOverrides.php
+++ b/modules/custom/az_finder/src/Service/AZFinderOverrides.php
@@ -52,6 +52,8 @@ final class AZFinderOverrides {
       $overrides[$view_id . ':' . $display_id] = [
         'view_id' => $view_id,
         'display_id' => $display_id,
+        'view_label' => $view_config->get('label') ?? '',
+        'display_label' => $view_config->get('display.' . $display_id . '.display_title') ?? '',
         'vocabularies' => $display_options['filters']['vocabularies'] ?? [],
         'origin' => 'config',
       ];

--- a/modules/custom/az_finder/src/Service/AZFinderOverrides.php
+++ b/modules/custom/az_finder/src/Service/AZFinderOverrides.php
@@ -53,7 +53,7 @@ final class AZFinderOverrides {
         'view_id' => $view_id,
         'display_id' => $display_id,
         'view_label' => $view_config->get('label') ?? '',
-        'display_label' => $view_config->get('display.' . $display_id . '.display_title') ?? '',
+        'display_title' => $view_config->get('display.' . $display_id . '.display_title') ?? '',
         'vocabularies' => $display_options['filters']['vocabularies'] ?? [],
         'origin' => 'config',
       ];

--- a/modules/custom/az_finder/src/Service/AZFinderViewOptions.php
+++ b/modules/custom/az_finder/src/Service/AZFinderViewOptions.php
@@ -76,7 +76,7 @@ final class AZFinderViewOptions {
         $filters = $exposed_form_options['options']['bef']['filter'] ?? [];
         foreach ($filters as $filter_id => $filter_settings) {
           if (isset($filter_settings['plugin_id']) && $filter_settings['plugin_id'] === $plugin_id) {
-            $options[$view->id() . ':' . $display_id] = $view->label() . ' (' . $display_id . ')';
+            $options[$view->id() . ':' . $display_id] = $view->label() . ' (' . $displays[$display_id]['display_title'] . ')';
             break;
           }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
This PR, to be merged into the PR for #3420, makes the following changes to the Finder settings form:

1. Updates the text of view display names to have the format: `View label (View display title)`
   - Note: As part of the changes for this update, the `origin` key has been removed from the `$overrides` arrays in the settings form code. This key did not seem to be used in any way.
3. Other updates to the text for clarity/consistency:
   - Changed dropdown heading from 'Default Display' to 'Default Display of Parent Terms'
   - Changed submit button text from 'Override' to 'Add Override'
   - Changed section heading from 'Configure Applied Overrides' to 'Configure Added Overrides'

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This PR is not directly related to an issue: it is meant to be merged into the [issue/3262](https://github.com/az-digital/az_quickstart/tree/issue/3262) branch.

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3563.probo.build/

1. Log in and go to the [Finder settings page](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3563.probo.build/admin/config/az-quickstart/settings/az-finder)
2. Add some overrides and confirm that the updated view display names are consistent and appropriate
4. Confirm that other text changes are appropriate

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
