### PR TITLE
Closes #3567 Styling adjustments for the AZ Finder exposed form (AZDIGITAL-158)

### DIFF
--- a/modules/custom/az_finder/css/taxonomy-index-tid-widget.css
+++ b/modules/custom/az_finder/css/taxonomy-index-tid-widget.css
@@ -122,10 +122,6 @@
   padding-left: 22px;
 }
 
-.az-bef-checkboxes>li>ul>li>ul {
-  padding-left: 18px;
-}
-
 .az-bef-checkboxes>li>ul {
   padding-left: 6px;
 }

--- a/modules/custom/az_finder/css/taxonomy-index-tid-widget.css
+++ b/modules/custom/az_finder/css/taxonomy-index-tid-widget.css
@@ -1,13 +1,6 @@
-.az-bef-vertical .checkbox {
-  width: 100% !important;
-  display: flex;
-  align-items: center;
-  line-height: 1.25rem;
-  margin-bottom: 0.375rem;
-}
-
 .az-bef-vertical .bef-nested {
   width: 100%;
+  margin-top: 1rem;
 }
 
 .az-bef-vertical>h2 {
@@ -19,7 +12,7 @@
 .az-bef-vertical h5,
 .az-bef-vertical h6 {
   line-height: 1.25rem;
-  margin-bottom: 0.375rem !important;
+  margin-top: 0.75rem !important;
 }
 
 .az-bef-vertical .form-type-textfield {
@@ -64,36 +57,51 @@
   min-width: 100%;
 }
 
-.az-bef-vertical .collapser {
-  font-weight: 500;
-}
-
-.az-bef-vertical .collapser:not(.level-0) {
-  color: unset !important;
-}
-
-.az-bef-vertical li:has(.collapser.level-0) {
-  border-bottom: 1px solid #e9ecef;
-  padding: 1rem 0;
-}
-
 /*
   Note: Using bottom margins and padding within .az-bef-checkboxes may affect
   the smoothness of the collapse and expand animations.
 */
-.az-bef-checkboxes > li:first-child,
-.az-bef-checkboxes > li:not(:has(.collapser)) + li:has(.collapser) {
-  border-top: 1px solid #e9ecef;
-  margin-top: 1rem;
+.az-bef-checkboxes .checkbox {
+  width: 100% !important;
+  display: flex;
+  align-items: center;
+  line-height: 1.25rem;
+  margin-top: 0.75rem;
+  margin-bottom: 0.125rem;
 }
 
+.az-bef-checkboxes .collapser {
+  font-weight: 500;
+}
+
+.az-bef-checkboxes .collapser:not(.level-0) {
+  color: unset !important;
+}
+
+.az-bef-checkboxes li:has(.collapser.level-0) {
+  padding: 1rem 0;
+  border-top: 1px solid #e9ecef;
+}
+
+.az-bef-checkboxes > li:not(:has(.collapser)) + li:has(.collapser) {
+  margin-top: 1.125rem;
+}
+
+.az-bef-checkboxes > li:first-child:not(:has(.collapser)),
 .az-bef-checkboxes > li:has(.collapser) + li:not(:has(.collapser)) {
-  margin-top: 0.75rem;
+  padding-top: 0.25rem;
+  border-top: 1px solid #e9ecef;
+}
+
+.az-bef-checkboxes > li:last-child {
+  margin-bottom: 1rem;
+}
+
+.az-bef-checkboxes > li:last-child:has(.collapser) {
+  margin-bottom: 0.25rem;
 }
 
 .az-bef-checkboxes>li>.checkbox {
-  margin-top: 0.5rem;
-  padding-top: 0.25rem;
   font-size: 1rem;
   font-weight: 500;
   color: #1e5288;
@@ -111,27 +119,19 @@
 }
 
 .az-bef-checkboxes ul>li>ul {
-  padding-left: 20px;
+  padding-left: 24px;
 }
 
 .az-bef-checkboxes>li>ul>li>ul {
-  padding-left: 15px;
+  padding-left: 18px;
 }
 
 .az-bef-checkboxes>li>ul {
-  padding-left: 4px;
+  padding-left: 6px;
 }
 
 .az-bef-checkboxes ul {
   margin-top: 0;
-}
-
-.az-bef-checkboxes > li > ul > li:first-child {
-  margin-top: 0.5rem;
-}
-
-.az-bef-checkboxes > li > ul > li:last-child {
-  margin-bottom: 0;
 }
 
 .js-bef-filter-count {

--- a/modules/custom/az_finder/css/taxonomy-index-tid-widget.css
+++ b/modules/custom/az_finder/css/taxonomy-index-tid-widget.css
@@ -1,11 +1,25 @@
 .az-bef-vertical .checkbox {
   width: 100% !important;
-  line-height: 1.5rem;
+  display: flex;
+  align-items: center;
+  line-height: 1.25rem;
+  margin-bottom: 0.375rem;
+}
+
+.az-bef-vertical .bef-nested {
+  width: 100%;
 }
 
 .az-bef-vertical>h2 {
   margin-top: 3rem !important;
   font-size: 1.5rem;
+}
+
+.az-bef-vertical h4,
+.az-bef-vertical h5,
+.az-bef-vertical h6 {
+  line-height: 1.25rem;
+  margin-bottom: 0.375rem !important;
 }
 
 .az-bef-vertical .form-type-textfield {
@@ -33,12 +47,17 @@
 .js-svg-replace-level-1 svg {
   pointer-events: none;
   display: flex;
-  min-width: 16px;
 }
 
 .js-svg-replace-level-0 svg {
   margin-left: auto;
   min-width: 24px;
+}
+
+.js-svg-replace-level-1 svg {
+  margin-left: -1.5px;
+  margin-right: 5.5px;
+  min-width: 16px;
 }
 
 .az-bef-vertical fieldset {
@@ -58,24 +77,33 @@
   padding: 1rem 0;
 }
 
-.az-bef-ul>li:has(.collapser) {
-  margin-top: 0.5rem;
+/*
+  Note: Using bottom margins and padding within .az-bef-checkboxes may affect
+  the smoothness of the collapse and expand animations.
+*/
+.az-bef-checkboxes > li:first-child,
+.az-bef-checkboxes > li:not(:has(.collapser)) + li:has(.collapser) {
+  border-top: 1px solid #e9ecef;
+  margin-top: 1rem;
 }
 
-.az-bef-ul>li:has(.collapser) li {
-  margin-top: 0.25rem;
+.az-bef-checkboxes > li:has(.collapser) + li:not(:has(.collapser)) {
+  margin-top: 0.75rem;
 }
 
 .az-bef-checkboxes>li>.checkbox {
-  display: block;
-  margin-top: .5rem;
+  margin-top: 0.5rem;
+  padding-top: 0.25rem;
   font-size: 1rem;
   font-weight: 500;
   color: #1e5288;
 }
 
 .az-bef-checkboxes .form-checkbox {
-  margin-top: 0.25rem;
+  display: flex;
+  vertical-align: middle;
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 .az-bef-checkboxes>li>ul>li>.checkbox {
@@ -92,7 +120,18 @@
 
 .az-bef-checkboxes>li>ul {
   padding-left: 4px;
-  margin-top: 5px;
+}
+
+.az-bef-checkboxes ul {
+  margin-top: 0;
+}
+
+.az-bef-checkboxes > li > ul > li:first-child {
+  margin-top: 0.5rem;
+}
+
+.az-bef-checkboxes > li > ul > li:last-child {
+  margin-bottom: 0;
 }
 
 .js-bef-filter-count {

--- a/modules/custom/az_finder/css/taxonomy-index-tid-widget.css
+++ b/modules/custom/az_finder/css/taxonomy-index-tid-widget.css
@@ -119,7 +119,7 @@
 }
 
 .az-bef-checkboxes ul>li>ul {
-  padding-left: 24px;
+  padding-left: 22px;
 }
 
 .az-bef-checkboxes>li>ul>li>ul {

--- a/modules/custom/az_finder/src/Plugin/better_exposed_filters/filter/AZFinderTaxonomyIndexTidWidget.php
+++ b/modules/custom/az_finder/src/Plugin/better_exposed_filters/filter/AZFinderTaxonomyIndexTidWidget.php
@@ -446,7 +446,7 @@ class AZFinderTaxonomyIndexTidWidget extends FilterWidgetBase implements Contain
           $list_title['#tag'] = 'h3';
           $list_title['#attributes']['class'][] = 'text-azurite';
           $list_title['#attributes']['class'][] = 'text-size-h5';
-          $list_title['#attributes']['class'][] = 'm-0';
+          $list_title['#attributes']['class'][] = 'mt-0';
           $list_title['#attributes']['class'][] = 'd-flex';
           $list_title['#attributes']['class'][] = 'align-items-center';
         }
@@ -459,6 +459,7 @@ class AZFinderTaxonomyIndexTidWidget extends FilterWidgetBase implements Contain
           $list_title['#attributes']['class'][] = 'flex-row-reverse';
           $list_title['#attributes']['class'][] = 'justify-content-end';
           $list_title['#attributes']['class'][] = 'align-items-center';
+          $list_title['#attributes']['class'][] = 'mt-0';
         }
         $list_title_link['value'] = $list_title;
         // Apply the modified list title to the element.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
The goal of this PR is to establish a more uniform presentation for the taxonomy term filters in the AZ Finder exposed form.

This PR proposes the following styling changes to the AZ Finder exposed form:

1. Adjust the horizontal alignment of filter items so that collapsible parent terms (with plus/minus buttons) and leaf terms (terms with checkboxes and no children) have a matching layout.
   - Checkbox items have been converted to `display: flex` as part of this change.
   - Similar to the [change we made to footer menu links](https://github.com/az-digital/az_quickstart/issues/1613), the `line-height` of filter items has been reduced to improve the display of multi-line text.
2. Standardize the spacing of nested filter items (whether they are collapsible parent terms or not).
   - Nested filter items are now separated vertically by 12px instead of 4px. This might be considered an improvement to usability/accessibility.
   - The larger top margins for nested parent terms have been removed to allow for a more consistent display of different arrangements of nested terms.
   - Indentation of nested items has been standardized and increased slightly.
3. Standardize the grouping of checkbox items into sections (either a collapsible set of hierarchical items or a flat list of checkbox items). Each section has a top border with a 1rem top margin and a 1.125rem bottom margin around the content. (The bottom spacing looked off to me without the extra 2px.)
4. Adjust margins and padding as necessary to ensure smooth collapse and expand animations.
5. Ensure filter items always use the full width of the exposed form container.


### Release notes
#### (TBD on whether to include a release note for this PR.)
<!--- This section is intended to be deleted if there are no notes. -->

If this change requires release notes: provide a summary of changes, how to 
use this change, and any related links. This content will be pasted in the 
[release notes](https://github.com/az-digital/az_quickstart/releases). Use 
markdown format to ensure proper pasting of information.

Make sure to add the `release notes` label to this PR.

```
Add markdown of release notes here.
```

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3567 
Closes AZDIGITAL-158

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3577.probo.build/

1. Compare the AZ Finder exposed form in the sidebar on the Finder pages with current Quickstart. For example, you can compare with the Probo site for [another PR](https://github.com/az-digital/az_quickstart/pull/3552):
   - [Current Quickstart - Page Finder](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3552.probo.build/finders/pages) vs. [This PR - Page Finder](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3577.probo.build/finders/pages)
   - [Current Quickstart - Event Finder](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3552.probo.build/finders/events) vs. [This PR - Event Finder](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3577.probo.build/finders/events)
   - [Current Quickstart - People Finder](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3552.probo.build/finders/people) vs. [This PR - People Finder](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3577.probo.build/finders/people)
2. Confirm that the appearance of the taxonomy term filters is updated as indicated in the description above.
3. Adding further terms to the relevant vocabularies may help in testing the visual changes.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
