### PR TITLE
Close #3588 Allow newly enabled module config to be overridden.

### DIFF
--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -269,6 +269,13 @@ class QuickstartConfigProvider extends ConfigProviderBase {
     if (!empty($owner[1])) {
       $snapshot_storage = $this->getConfigSnapshotStorage(ConfigSyncSnapshotterInterface::CONFIG_SNAPSHOT_SET, $owner[0], $owner[1]);
       $snap = $snapshot_storage->read($name);
+      // StorageInterface::read() returns FALSE if the config does not exist.
+      // In this case, we can assume that the configuration is not customized
+      // because it is not present in the snapshot, likely because the module
+      // is newly installed.
+      if ($snap === FALSE) {
+        return TRUE;
+      }
     }
     // Guard against missing items.
     $snap = (!empty($snap)) ? $snap : [];
@@ -278,13 +285,6 @@ class QuickstartConfigProvider extends ConfigProviderBase {
       // Prune cache_metadata if present, to not consider it for diffs.
       $active = $this->trimNestedKey($active, 'cache_metadata');
       $snap = $this->trimNestedKey($snap, 'cache_metadata');
-      // If $snap is empty, then we can't compare it to $active.
-      // In this case, we can assume that the configuration is not customized
-      // because it is not present in the snapshot.
-      // This means that the module (config provider) is not yet installed.
-      if (empty($snap)) {
-        return TRUE;
-      }
       // Diff active config and snapshot of module to check for customization.
       $diff = $differ->diff($active, $snap);
       // Overrides only allowed if no changes in diff.

--- a/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
+++ b/modules/custom/az_core/src/Plugin/ConfigProvider/QuickstartConfigProvider.php
@@ -273,7 +273,6 @@ class QuickstartConfigProvider extends ConfigProviderBase {
     // Guard against missing items.
     $snap = (!empty($snap)) ? $snap : [];
     $active = (!empty($active)) ? $active : [];
-
     // Not relevant for user roles. Permissions created dynamically.
     if (strpos($name, 'user.role.') !== 0) {
       // Prune cache_metadata if present, to not consider it for diffs.

--- a/modules/custom/az_core/tests/src/Functional/ConfigOverrideTest.php
+++ b/modules/custom/az_core/tests/src/Functional/ConfigOverrideTest.php
@@ -51,4 +51,32 @@ class ConfigOverrideTest extends BrowserTestBase {
     $this->assertEquals('shibboleth.arizona.edu', $hostname);
   }
 
+  /**
+   * Tests a config override was applied successfully after module install.
+   */
+  public function testConfigOverrideAfterInstall() {
+    // Install the az_mail module.
+    $this->container->get('module_installer')->install(['az_mail']);
+    $config = $this->config('smtp.settings');
+    $this->assertEquals(TRUE, $config->get('smtp_on'));
+    $this->assertEquals('email-smtp.us-west-2.amazonaws.com', $config->get('smtp_host'));
+    $this->assertEquals('', $config->get('smtp_hostbackup'));
+    $this->assertEquals('2587', $config->get('smtp_port'));
+    $this->assertEquals('tls', $config->get('smtp_protocol'));
+    $this->assertEquals(TRUE, $config->get('smtp_autotls'));
+    $this->assertEquals(30, $config->get('smtp_timeout'));
+    $this->assertEquals('', $config->get('smtp_username'));
+    $this->assertEquals('', $config->get('smtp_password'));
+    $this->assertEquals('', $config->get('smtp_from'));
+    $this->assertEquals('', $config->get('smtp_fromname'));
+    $this->assertEquals('', $config->get('smtp_client_hostname'));
+    $this->assertEquals('', $config->get('smtp_client_helo'));
+    $this->assertEquals('0', $config->get('smtp_allowhtml'));
+    $this->assertEquals('', $config->get('smtp_test_address'));
+    $this->assertEquals('', $config->get('smtp_reroute_address'));
+    $this->assertEquals(FALSE, $config->get('smtp_debugging'));
+    $this->assertEquals('php_mail', $config->get('prev_mail_system'));
+    $this->assertEquals(FALSE, $config->get('smtp_keepalive'));
+  }
+
 }


### PR DESCRIPTION
## Description
Not sure if this is correct, but it does allow me to override the smtp.settings via az_mail.


## Related issues
Close #3588 

## How to test
1. Enable az_mail module
2. Go to /admin/config/system/smtp
3. See settings are applied.

Additionally, check the build log for any anomalies.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
