### PR TITLE
Close #3588 Add PHPUnit Test for ConfigProvider on 2.9.x

### DIFF
--- a/modules/custom/az_core/tests/src/Functional/ConfigOverrideTest.php
+++ b/modules/custom/az_core/tests/src/Functional/ConfigOverrideTest.php
@@ -51,4 +51,32 @@ class ConfigOverrideTest extends BrowserTestBase {
     $this->assertEquals('shibboleth.arizona.edu', $hostname);
   }
 
+  /**
+   * Tests a config override was applied successfully after module install.
+   */
+  public function testConfigOverrideAfterInstall() {
+    // Install the az_mail module.
+    $this->container->get('module_installer')->install(['az_mail']);
+    $config = $this->config('smtp.settings');
+    $this->assertEquals(TRUE, $config->get('smtp_on'));
+    $this->assertEquals('email-smtp.us-west-2.amazonaws.com', $config->get('smtp_host'));
+    $this->assertEquals('', $config->get('smtp_hostbackup'));
+    $this->assertEquals('2587', $config->get('smtp_port'));
+    $this->assertEquals('tls', $config->get('smtp_protocol'));
+    $this->assertEquals(TRUE, $config->get('smtp_autotls'));
+    $this->assertEquals(30, $config->get('smtp_timeout'));
+    $this->assertEquals('', $config->get('smtp_username'));
+    $this->assertEquals('', $config->get('smtp_password'));
+    $this->assertEquals('', $config->get('smtp_from'));
+    $this->assertEquals('', $config->get('smtp_fromname'));
+    $this->assertEquals('', $config->get('smtp_client_hostname'));
+    $this->assertEquals('', $config->get('smtp_client_helo'));
+    $this->assertEquals('0', $config->get('smtp_allowhtml'));
+    $this->assertEquals('', $config->get('smtp_test_address'));
+    $this->assertEquals('', $config->get('smtp_reroute_address'));
+    $this->assertEquals(FALSE, $config->get('smtp_debugging'));
+    $this->assertEquals('php_mail', $config->get('prev_mail_system'));
+    $this->assertEquals(FALSE, $config->get('smtp_keepalive'));
+  }
+
 }


### PR DESCRIPTION
## Description

Adding PHPUnit test without fix in order to test whether #3588 exists on 2.9.x

## Related issues

Relates to #3589 

## How to test
Use PHPUnit or look in the Probo logs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [x] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
