### PR TITLE
Closes #3642 Upgrade Drupal core to 10.3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -170,7 +170,7 @@
                 "Add skip-method option to file_copy and download process plugins (2766369)": "https://www.drupal.org/files/issues/2024-05-13/2766369-39.patch",
                 "Move content overview default task link out of content_moderation module (3199682)": "https://www.drupal.org/files/issues/2022-02-10/3199682-11-9-4-x.patch",
                 "Improve migration system performance: statically cache DrupalSqlBase::$systemData (3154156)": "https://www.drupal.org/files/issues/2022-01-24/3154156-12.patch",
-                "filter_autop returns self closing br element with slash, lets alter to br (2350049)": "https://www.drupal.org/files/issues/2024-08-15/2350049-46-reroll-11.x-dev.patch",
+                "filter_autop returns self closing br element with slash, lets alter to br (2350049)": "https://www.drupal.org/files/issues/2024-08-15/2350049-48-reroll-against-11.x.patch",
                 "[10.2 regression] CKEditor 5 breaks when 'Source'/Source editing button is added and 'Manually editable HTML tags' are specified (3410100)": "https://www.drupal.org/files/issues/2024-01-23/drupal-revert-source-editing-validation-tightening-3410100-38.patch",
                 "[Apache only] Wrong file header returned, when converting an image for example to webp (3310963)": "https://www.drupal.org/files/issues/2024-05-15/3310963-32.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -170,7 +170,7 @@
                 "Add skip-method option to file_copy and download process plugins (2766369)": "https://www.drupal.org/files/issues/2024-05-13/2766369-39.patch",
                 "Move content overview default task link out of content_moderation module (3199682)": "https://www.drupal.org/files/issues/2022-02-10/3199682-11-9-4-x.patch",
                 "Improve migration system performance: statically cache DrupalSqlBase::$systemData (3154156)": "https://www.drupal.org/files/issues/2022-01-24/3154156-12.patch",
-                "filter_autop returns self closing br element with slash, lets alter to br (2350049)": "https://gist.githubusercontent.com/bberndt-uaz/43b0d7c2bb3f13d04dab87048f2e3714/raw/d7ce394865dd65f06332cde2ebd1b34842eba3fd/2350049-46-reroll-11.x-dev.patch",
+                "filter_autop returns self closing br element with slash, lets alter to br (2350049)": "https://www.drupal.org/files/issues/2024-08-15/2350049-46-reroll-11.x-dev.patch",
                 "[10.2 regression] CKEditor 5 breaks when 'Source'/Source editing button is added and 'Manually editable HTML tags' are specified (3410100)": "https://www.drupal.org/files/issues/2024-01-23/drupal-revert-source-editing-validation-tightening-3410100-38.patch",
                 "[Apache only] Wrong file header returned, when converting an image for example to webp (3310963)": "https://www.drupal.org/files/issues/2024-05-15/3310963-32.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -170,7 +170,7 @@
                 "Add skip-method option to file_copy and download process plugins (2766369)": "https://www.drupal.org/files/issues/2024-05-13/2766369-39.patch",
                 "Move content overview default task link out of content_moderation module (3199682)": "https://www.drupal.org/files/issues/2022-02-10/3199682-11-9-4-x.patch",
                 "Improve migration system performance: statically cache DrupalSqlBase::$systemData (3154156)": "https://www.drupal.org/files/issues/2022-01-24/3154156-12.patch",
-                "filter_autop returns self closing br element with slash, lets alter to br (2350049)": "https://gist.github.com/bberndt-uaz/43b0d7c2bb3f13d04dab87048f2e3714",
+                "filter_autop returns self closing br element with slash, lets alter to br (2350049)": "https://gist.githubusercontent.com/bberndt-uaz/43b0d7c2bb3f13d04dab87048f2e3714/raw/d7ce394865dd65f06332cde2ebd1b34842eba3fd/2350049-46-reroll-11.x-dev.patch",
                 "[10.2 regression] CKEditor 5 breaks when 'Source'/Source editing button is added and 'Manually editable HTML tags' are specified (3410100)": "https://www.drupal.org/files/issues/2024-01-23/drupal-revert-source-editing-validation-tightening-3410100-38.patch",
                 "[Apache only] Wrong file header returned, when converting an image for example to webp (3310963)": "https://www.drupal.org/files/issues/2024-05-15/3310963-32.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "drupal/config_split": "2.0.1",
         "drupal/config_sync": "3.0.0-alpha3",
         "drupal/config_update": "2.0.0-alpha3",
-        "drupal/core-recommended": "10.3.1",
+        "drupal/core-recommended": "10.3.2",
         "drupal/crop": "2.4.0",
         "drupal/ctools": "*",
         "drupal/date_ap_style": "2.0.1",

--- a/composer.json
+++ b/composer.json
@@ -170,7 +170,7 @@
                 "Add skip-method option to file_copy and download process plugins (2766369)": "https://www.drupal.org/files/issues/2024-05-13/2766369-39.patch",
                 "Move content overview default task link out of content_moderation module (3199682)": "https://www.drupal.org/files/issues/2022-02-10/3199682-11-9-4-x.patch",
                 "Improve migration system performance: statically cache DrupalSqlBase::$systemData (3154156)": "https://www.drupal.org/files/issues/2022-01-24/3154156-12.patch",
-                "filter_autop returns self closing br element with slash, lets alter to br (2350049)": "https://www.drupal.org/files/issues/2024-01-18/2350049-30.patch",
+                "filter_autop returns self closing br element with slash, lets alter to br (2350049)": "https://gist.github.com/bberndt-uaz/43b0d7c2bb3f13d04dab87048f2e3714",
                 "[10.2 regression] CKEditor 5 breaks when 'Source'/Source editing button is added and 'Manually editable HTML tags' are specified (3410100)": "https://www.drupal.org/files/issues/2024-01-23/drupal-revert-source-editing-validation-tightening-3410100-38.patch",
                 "[Apache only] Wrong file header returned, when converting an image for example to webp (3310963)": "https://www.drupal.org/files/issues/2024-05-15/3310963-32.patch"
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Since Dependabot did not create a PR for the most recent Drupal core release, this PR was created to update drupal/core-recommended from 10.3.1 to 10.3.2.

Big thanks to @trackleft for working on this Drupal core issue which needed an updated patch:

- [filter_autop() returns `<br />` but should return `<br>` for HTML5](https://www.drupal.org/project/drupal/issues/2350049)


https://www.drupal.org/project/drupal/releases/10.3.2

> ### Release notes
> This is a patch (bugfix) release of Drupal 10 and is ready for use on production sites. [Learn more about Drupal 10](https://www.drupal.org/about/10).
> 
> Drupal 10.3.x will receive security coverage until June 2025.
> 
> **Important update information**
> 
> If you are updating from 10.2.x or earlier and have the [CKEditor font](https://www.drupal.org/project/ckeditor_font) module installed, you should consider switching to [CKEditor5 Plugin pack](https://www.drupal.org/project/ckeditor5_plugin_pack) for a more up-to-date version of the plugin which is compatible with the CKEditor5 version shipped with Drupal 10.3. If you are updating from Drupal 9, refer to [Preparing your site to upgrade to a newer major version](https://www.drupal.org/docs/upgrading-drupal/prepare-major-upgrade) for tools you can use to check the Drupal 10 compatibility of modules, themes and sites. Then, [upgrade from Drupal 9 to 10](https://www.drupal.org/docs/upgrading-drupal/upgrading-from-drupal-8-or-later/upgrading-from-drupal-9-to-drupal-10). You should also check the [Drupal 10.0.0](https://www.drupal.org/project/drupal/releases/10.0.0) release notes.
> 
> **Important changes in this release**
> 
> - Text formats could not be saved due to config translation validation new in Drupal 10.3. The LogicException has been replaced with a E_USER_DEPRECATED error.
> - A new API has been [added to support backports of database updates](https://www.drupal.org/node/3459876) across major and minor versions. This primarily affects core development, but might also be needed for contributed projects (since [core will support two major versions simultaneously](https://www.drupal.org/blog/drupal-10-will-be-supported-until-the-release-of-drupal-12-in-mid-late-2026) going forward).
> 
>
> **All changes in this release**
> 
> <details>
> <summary><b>Click to expand and view all changes in this release</b></summary>
> <p> </p>
> 
> - [Issue #3447994 by Akhil Babu, Josue2591, thejimbirch, mikelutz, jnicola, b_sharpe: Example recipe isn't functional](https://git.drupalcode.org/project/drupal/commit/38ff4e3ace97310c0c87dc1e5e85786a98a02c8e)
> - [Issue #3466524 by catch: ModuleConfigureRouteTest is slow](https://git.drupalcode.org/project/drupal/commit/a0442b5f2e3ed7321bfd613e273d745651ca5ddd)
> - [Issue #3454092 by mstrelan, nicxvan, catch: Convert WebAssertTest to a Unit test](https://git.drupalcode.org/project/drupal/commit/136e3dcb700b82da7fba6dea7e4d65a104e39b13)
> - [Issue #3368537 by catch, TwoD, alexpott, cmlara, sboden: Ensure trailing whitespace at the end of a cache ID results in a unique cache item](https://git.drupalcode.org/project/drupal/commit/3974f8448e3c7d4bf6fde0ed82cd9c28bef4c825)
> - [Issue #3465353 by mstrelan: ComponentGenerator hardcodes PHP 7.3.0](https://git.drupalcode.org/project/drupal/commit/d47139e75a3b61dbf7e4e45a8b1d4812a1106e81)
> - [Issue #3458177 by mondrake, catch, quietone, godotislate, longwave, larowlan, xjm: Changing plugins from annotations to attributes in contrib leads to error if plugin extends from a missing dependency](https://git.drupalcode.org/project/drupal/commit/eb14e0bd6eb6030d5d4d10beed1ef6a68df5b746)
> - [Issue #3463351 by catch, heddn: Consolidate Umami performance tests](https://git.drupalcode.org/project/drupal/commit/1dec664d6f30297374c5a8e847ea680b0b3eb10c)
> - [Issue #3458177 by mondrake, catch, godotislate, longwave, xjm: Changing plugins from annotations to attributes in contrib leads to error if plugin extends from a missing dependency](https://git.drupalcode.org/project/drupal/commit/27a40bef76a8ba70ad7ccac77894a6cefee7f261)
> - [Issue #3363127 by nod_, Gábor Hojtsy, mherchel: Drupal Displace outputs invalid value for --drupal-displace-offset-right when opening top dialog](https://git.drupalcode.org/project/drupal/commit/6caa8062d0504ddd57af6a91e3cb36ff862e9afe)
> - [Issue #3463456 by catch, smustgrave: Consolidate ckeditor5's FunctionalJavascript tests](https://git.drupalcode.org/project/drupal/commit/c598215b8c55d6d4a0b9ad60997a8f414e805cb1)
> - [Issue #3464581 by quietone, smustgrave: Update deprecation notices in ajax.js](https://git.drupalcode.org/project/drupal/commit/1622ede1b899af660757778187a53efe6cecf07c)
> - [Issue #637538 by pooja_sharma, mr.baileys, AaronBauman, Bhanu951, alexpott, rteijeiro, greggles, pwolanin, meba, Nikhil_110, smustgrave, quietone, casey, naveenvalecha, sime, humansky, dawehner: Module and theme names are not filtered on output](https://git.drupalcode.org/project/drupal/commit/9a57269327d107ba5443fd40ef62fffbfddce03f)
> - [Issue #3462561 by catch, smustgrave: Stop using a data provider in UserPasswordResetTest](https://git.drupalcode.org/project/drupal/commit/387e4e94b3ad5ca079c1a1736a8c367ae59c349e)
> - [Issue #3439836 by pooja_sharma, thebumik, FeyP, vensires, smustgrave, kim.pepper, quietone: Fix File tests that rely on UID1's super user behavior](https://git.drupalcode.org/project/drupal/commit/9eb5ee79ebb22b45be129c076f635671c84d2ead)
> - [Issue #3463479 by catch, nod_, Spokje, larowlan: Merge the build and lint stages in core MR pipelines](https://git.drupalcode.org/project/drupal/commit/d170a1e09d278ce27654143a4855fd9c3aa502d3)
> - [Issue #2360647 by quietone, alexpott, Manuel Garcia, jhodgdon: Documentation in ConfigDependencyManager conflates plugin dependencies and config dependencies](https://git.drupalcode.org/project/drupal/commit/cce51ccfde2b118ca9cac8090aa2e2a695b6f33c)
> - [Issue #3457009 by ankitv18, quietone, joachim: Add input string to exception message thrown in createConnectionOptionsFromUrl()](https://git.drupalcode.org/project/drupal/commit/b8c27098bfb6770ffb862aa869fd25baa4f27068)
> - [Issue #3460654 by pooja_sharma, FeyP, catch: Merge test methods in FieldUIRouteTest for better performance](https://git.drupalcode.org/project/drupal/commit/cc1c5e909b6e3f62974aeb38842657ea70acd39d)
> - [Issue #3428614 by catch, nod_, longwave: Resync .gitlab-ci.yml and .gitignore following Yarn 4 in 11.x](https://git.drupalcode.org/project/drupal/commit/b26e834eb656e1206ba01f0bbd2ad52a97ec5e2c)
> - [Revert "Issue #3428614 by catch, nod_, longwave: Resync .gitlab-ci.yml and .gitignore following Yarn 4 in 11.x"](https://git.drupalcode.org/project/drupal/commit/f2eb0f5213be41760fbbb54e3593edbf72eb60ce)
> - [Issue #3428614 by catch, nod_, longwave: Resync .gitlab-ci.yml and .gitignore following Yarn 4 in 11.x](https://git.drupalcode.org/project/drupal/commit/8b2a6cacf25cf22c19ac00d9bef12224706e8547)
> - [Issue #3236269 by mandclu, quietone, heni_deepak, eojthebrave: Render API overview should include a link to the list of elements](https://git.drupalcode.org/project/drupal/commit/986ae33d4bad82e24531268d55d24b8a6609da0f)
> - [Issue #3314260 by quietone, avpaderno, rakesh.drupal, ravi.shankar, chaitanyadessai, smustgrave, catch, Spokje: Replace t() calls inside of Controllers that do not use StringTranslationTrait](https://git.drupalcode.org/project/drupal/commit/0ce937d2f64c58e3f287bf53be9ffa8c4cf17472)
> - [Issue #3460598 by catch, m4olivei, penyaskito, finnsky: Single directory component CSS asset library not picked up in admin theme immediately after module install without cache clear](https://git.drupalcode.org/project/drupal/commit/56949be14dec19533ed2542fdcd263073e37d91d)
> - [Issue #3439835 by pooja_sharma, thebumik, FeyP, smustgrave, vensires: Fix Field UI tests that rely on UID1's super user behavior](https://git.drupalcode.org/project/drupal/commit/911c2009882c06124786f2b7f4ee8685065ce6ed)
> - [Issue #3458975 by longwave, quietone: GenerateThemeTest::testContribStarterkitDevSnapshotWithGitNotInstalled fails on sqlite](https://git.drupalcode.org/project/drupal/commit/a3e710d7e04f58e96af78754d57b7ce6c26a5422)
> - [Issue #3463594 by alexpott: ImageAdminStylesTest::testAjaxEnabledEffectForm() fails because statusMessageExists() does not wait](https://git.drupalcode.org/project/drupal/commit/b200582f81cdb7f29e61bbfdba0af5b6bf90d591)
> - [Issue #3142928 by ivnish, neclimdul, Wiktor7, mitrpaka, Chi, keha3912, smustgrave, andypost, catch: Status report wrongly warns of APCu memory limit when admin language is not English](https://git.drupalcode.org/project/drupal/commit/2664526bdbf6822aadf67c7d188f1832d6227779)
> - [Issue #3463548 by catch, smustgrave: Consolidate methods on FormElementsLabelsTest](https://git.drupalcode.org/project/drupal/commit/0d664bc8b47af4d3fed97a48f80073e2cb59321d)
> - [Issue #3462098 by Prem Suthar, joachim, quietone: hook_local_tasks_alter() and hook_menu_local_tasks_alter() need mutual @see links](https://git.drupalcode.org/project/drupal/commit/a3075fda43edebd2b6fb9ce6396fce24345482cb)
> - [Issue #3462549 by catch, ankitv18: Optimize TelephoneFieldTest](https://git.drupalcode.org/project/drupal/commit/2328738ae76ca99c65fc23ab81d7726efa469731)
> - [Issue #3119513 by Prem Suthar, imclean, smustgrave: Parameters doc for views "row" should be at the top level of the array](https://git.drupalcode.org/project/drupal/commit/202efea7bd17123a71c991946f7d083a5e4f142f)
> - [Issue #3463569 by alexpott, catch: ToolbarStoredStateTest needs wait after resizing window](https://git.drupalcode.org/project/drupal/commit/243fc5ca9e2f6fe1939b88fa6c2d105824c74d8d)
> - [Issue #3460257 by Grimreaper, smustgrave, quietone: Have a dedicated category for blocks provided by the Navigation module](https://git.drupalcode.org/project/drupal/commit/da2452190d5c6555f4f56202315b961dcf120f8e)
> - [Issue #3463544 by catch: Three more slow functional tests](https://git.drupalcode.org/project/drupal/commit/b6d1fffef3cf8852fe61640b18612a0085dc1c3a)
> - [Issue #3463288 by catch: Consolidate test methods in StandardPerformanceTest](https://git.drupalcode.org/project/drupal/commit/816ac01be9581b29df038d5ce2d725819940a2a3)
> - [Issue #3463329 by alexpott: \Drupal\CorextensionxtensionDiscovery::PHP_FUNCTION_PATTERN is out-of-date](https://git.drupalcode.org/project/drupal/commit/7c9adb2db4211ab55b8a7b524dd6cbfdf1f1b55e)
> - [Issue #3191559 by longwave, Spokje, smustgrave, jhodgdon: [random test failure] Random test fail in EntityReferenceWidgetTest](https://git.drupalcode.org/project/drupal/commit/02507ab71932f2b574c777ab08919c3caeaf0155)
> - [Issue #3305609 by pooja_sharma, joachim: convert TermTest::testParentHandlerSettings() into a kernel test](https://git.drupalcode.org/project/drupal/commit/bcf87a8b8071c843829600219a7d65caad10f9d9)
> - [Issue #3451611 by mfb, xjm, smustgrave, quietone: Fix the format=flowed; delsp=yes encoding of email messages](https://git.drupalcode.org/project/drupal/commit/5be98c43a8aee66fb440e6f8c3eb334779bb8d2d)
> - [Issue #3462759 by catch: Try to rebalance kernel tests between gitlab runners (@group #slow again)](https://git.drupalcode.org/project/drupal/commit/32075e1a5f5be72fc618b467ba37113e015a1a40)
> - [Issue #3454196 by james.williams, longwave: Filter placeholders without arguments are not replaced when HTML corrector filter applied afterwards](https://git.drupalcode.org/project/drupal/commit/883e240ec91161a2efe32791a075ef7aedf1c671)
> - [Issue #3392572 by benjifisher, Liam Morland, ricovandevin, Anybody, smustgrave, quietone, sabrina.liman, carolpettirossi, longwave, alexpott: Add missing category to Drupal\layout_builder\Plugin\Layout\BlankLayout and let modules and themes alter the list of layouts](https://git.drupalcode.org/project/drupal/commit/c082ee7eb265716c966c1136cc256191ee56f0f9)
> - [Issue #3306434 by benjifisher, quietone, Berdir, kopeboy, DYdave, larowlan: Fix access checks for bundle permissions to avoid triggering a config validation error](https://git.drupalcode.org/project/drupal/commit/c3c8f13a747ef2f26cb8cc1eaaab23d8983fa9f4)
> - [Issue #3440848 by mondrake, quietone, daffie: Ensure post transaction callbacks are only at the end of the root Drupal transaction](https://git.drupalcode.org/project/drupal/commit/d322b1324c286da6dbb234ba70b0d7631d33ac94)
> - [Issue #3163127 by scott_euser, Gauravvvv, sd9121, djsagar, ranjith_kumar_k_u, AkshayAdhav, _utsavsharma, sarvjeetsingh, komalk, Nitin shrivastava, ameymudras, pradhumanjain2311, boulaffasae, kostyashupenko, bnjmnm, meena.bisht, ambuj_gupta, sonam.chaturvedi, Sakthivel M, Utkarsh_33, KondratievaS, ressa: Autocomplete input text can visibly overflow under magnifier icon](https://git.drupalcode.org/project/drupal/commit/42a97ff4f7431e6bde152ff4d69c7db2ff0483fe)
> - [Issue #3462338 by Jaydeep_patel, bhaveshdas, quietone: Spacing issue in Home > Search page on Advanced search section](https://git.drupalcode.org/project/drupal/commit/72e4fe38f1996a43112cde0128602b3b0cbdb840)
> - [Issue #3458714 by simohell, shivam_tiwari, amanire, smustgrave: Long string breaks the layout of Claro (reapply fix)](https://git.drupalcode.org/project/drupal/commit/4e93352ccb39c5f0bd0df1e8fe667614335d9e3b)
> - [Issue #3462556 by catch: Consolidate two test methods in NumberFieldTest](https://git.drupalcode.org/project/drupal/commit/9320092df7ee01153588a3acebbd77c27da53fb6)
> - [Issue #3462529 by catch: Mark more tests with @group #slow and remove it from some others](https://git.drupalcode.org/project/drupal/commit/f59d1e0cac19d1930eb74ee2d7dd877847d5c4d8)
> - [Issue #3393441 by markconroy, Gauravvvv, smustgrave, gordon: Stable 9 is trying to override non-existing css files](https://git.drupalcode.org/project/drupal/commit/c92b0230cd298e5702e00521d0afe5f0132f836e)
> - [Issue #3461421 by VinmayiSwamy, ankitv18, joachim, smustgrave: getProcessPlugins() normalises the process array twice](https://git.drupalcode.org/project/drupal/commit/0df8fd45825c7234fb05a3ba50ecf76aecde5d79)
> - [Issue #3460921 by quietone: Fix hook_update_N docs for display of code block, remove unnecessary @see](https://git.drupalcode.org/project/drupal/commit/acd475c7b0b505f25aa1d50b05ccafacebb9d362)
> - [Issue #2719657 by quietone, andypost, Mile23, Spokje, ilya.no, xjm, alexpott, smustgrave: Fix 'Drupal.Commenting.InlineComment.NotCapital' coding standard](https://git.drupalcode.org/project/drupal/commit/d2fb43a83ec42aeafbe77cb2cf7fb3fdf28c3ece)
> - [Issue #3460513 by nishtha.pradhan, Berdir: Avoid TypeError if config entity dependencies are NULL](https://git.drupalcode.org/project/drupal/commit/36c1fe66f9b5115bbf4abb06f928fd2d25ccc5e4)
> - [Issue #3462264 by alexpott: Skip unsupported methods in rest/jsonapi tests in an efficient way](https://git.drupalcode.org/project/drupal/commit/135b0ee7af163433b54dae7a2d7ea69718c28f76)
> - [Issue #3461284 by mherchel, finnsky, quietone, nod_: Prevent simultaneous open/close on simultaneous click/hover](https://git.drupalcode.org/project/drupal/commit/eacdda9692e4e550fe6f97b4d790a2ef7cfd2708)
> - [Issue #3454603 by phenaproxima, thejimbirch, Prashant.c, alexpott: Many core recipes are not idempotent](https://git.drupalcode.org/project/drupal/commit/22972e3764d9c631465d44a8a349dbe48ebfe6ed)
> - [Issue #3461945 by mstrelan, bbrala: Fix instances of floats passed to functions expecting ints](https://git.drupalcode.org/project/drupal/commit/e9eff5cd97f7098b596facc50f92244fae97734b)
> - [Issue #3458782 by catch, ankitv18, longwave, smustgrave: Remove documentation for readmore, logged_in and is_admin from node.html.twig](https://git.drupalcode.org/project/drupal/commit/873b1e7b07c949ba2429bb01ac81469618708699)
> - [Issue #3368071 by tstoeckler, longwave: Installing Content Translation module breaks Rest resources](https://git.drupalcode.org/project/drupal/commit/8451a498adea0cd62dc97303c273a6f1a39856e9)
> - [Issue #3459240 by jurgenhaas, b_sharpe, longwave, quietone: Deprecation message for user_validate_name points to an invalid replacement](https://git.drupalcode.org/project/drupal/commit/3f397e204a4a55d4590a31250ffd1e33ebd1bc48)
> - [Issue #3458966 by apaderno, smustgrave: Correct the punctuation on the description for \Drupal\Tests\UnitTestCase](https://git.drupalcode.org/project/drupal/commit/3841879898ccc7268462665486236c4744ed2d2e)
> - [Issue #3460246 by Prem Suthar, joachim, afeijo: incorrect docs in DateFormatter::format()](https://git.drupalcode.org/project/drupal/commit/0a7a4d5d576a24ecc73f79f8afe9313f35b71bab)
> - [Issue #3376942 by fromme, Kingdutch, smustgrave: Replace usage of generateString with generate in Media module](https://git.drupalcode.org/project/drupal/commit/383f200fcb5047fe5fb2b432d67c3f0f2ae9ee02)
> - [Issue #3313449 by JeffMattson, joachim: QueueWorkerInterface is missing docs for DelayedRequeueException](https://git.drupalcode.org/project/drupal/commit/474bdf241f0ceb2be3af7399199fa775f6a850b8)
> - [Issue #3458431 by scott_euser, quietone: Improve developer experience for 10.3.x upgrade by informing where typed config fails](https://git.drupalcode.org/project/drupal/commit/b3a9492ad241f3dfb0166ea5fab9c0137cd18ca9)
> - [Issue #3156672 by kim.pepper, joegraduate, longwave, PieterDC, smustgrave, tstoeckler, alexpott: ExtensionMimeTypeGuesser breaks other mime_type_guesser services](https://git.drupalcode.org/project/drupal/commit/61cc0660713a9ba21c131d07796715f91e447933)
> - [Issue #3454274 by markconroy, Lillian Bozeman: Do not override class in preprocess_field hook](https://git.drupalcode.org/project/drupal/commit/187c2bf4b375d28380755f2b0b17dce4baa52ce5)
> - [Issue #3452502 by Grimreaper, smustgrave: NodeListBuilder is using mark theme wrongly](https://git.drupalcode.org/project/drupal/commit/fdb36c43ab5158e30199481333ba62a574e57a50)
> - [Issue #3454346 by kristiaanvandeneynde, bbrala, mxr576: JsonApiRequestValidator does not set cacheable metadata when the filter allows the request](https://git.drupalcode.org/project/drupal/commit/8d6cde7902d5711a5b7b6058b15eb358114897a5)
> - [Issue #2998857 by Luke.Leber, e.chatrer, afem, bskibinski, mgifford: a11y: Input type file fields lack aria-describedby to the description](https://git.drupalcode.org/project/drupal/commit/07c0011de53c4e1edcff668a5eada6d34cee7a55)
> - [Issue #3456738 by cmlara, Anybody, andrewbelcher, Berdir, catch: BC break in login auth changes from #3444978](https://git.drupalcode.org/project/drupal/commit/fee6f4e0821415d52f8f0db13dca57baec5fb5dd)
> - [Issue #3108658 by alexpott, mikelutz, catch, xjm, nicxvan, longwave: Handling update path divergence between 11.x and 10.x](https://git.drupalcode.org/project/drupal/commit/ba36155474685544fa6a27f2f56344a8fd6afd7a)
> - [Issue #3449851 by Liam Morland, alexpott, smustgrave, solideogloria, catch, kopeboy: Replace LogicException with trigger_error in LangcodeRequiredIfTranslatableValues constraint](https://git.drupalcode.org/project/drupal/commit/f932d803dd07ebc5481ecf24e68bc0fc4c72366b)
> - [Issue #3458403 by mstrelan: Conditionally disable access to update manager routes](https://git.drupalcode.org/project/drupal/commit/206a3ac2a295e6ac21a6cbe14eb745c2b11d92c3)
> - [Issue #3456425 by mondrake, alexpott: FormStateInterface::setError*() PHPDoc are incorrect](https://git.drupalcode.org/project/drupal/commit/cf46b0dc1176d651095917ca638fcc9b7cf5c07a)
> - [Issue #3458444 by quietone, smustgrave, slashrsm, nod_, brianperry: Remove decoupled menus and media initiatives from MAINTAINERS](https://git.drupalcode.org/project/drupal/commit/24c1497aba09c929f36ba6c54fee76cc74ee0ac2)
> - [Back to dev.](https://git.drupalcode.org/project/drupal/commit/905e231007f65392736c86f61ca89a42c4c4c678)
> </details>
> 

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3642

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3643.probo.build/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [x] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
