### PR TITLE
Close #3658 Add all paragraph migrations as optional dependencies of the news node migration.

### DIFF
--- a/modules/custom/az_migration/migrations/az_node_news.yml
+++ b/modules/custom/az_migration/migrations/az_node_news.yml
@@ -19,6 +19,7 @@ migration_dependencies:
   optional:
     - az_news_tags
     - az_paragraph_callout
+    - az_paragraph_card_deck
     - az_paragraph_carousel
     - az_paragraph_chucks_view
     - az_paragraph_column_image
@@ -35,7 +36,6 @@ migration_dependencies:
     - az_paragraph_plain_text
     - az_paragraph_single_card
     - az_paragraph_well
-    - az_paragraph_card_deck
 
 source:
   plugin: az_node
@@ -91,6 +91,7 @@ process:
           plugin: migration_lookup
           migration:
             - az_paragraph_callout
+            - az_paragraph_card_deck
             - az_paragraph_carousel
             - az_paragraph_chucks_view
             - az_paragraph_column_image
@@ -107,7 +108,6 @@ process:
             - az_paragraph_plain_text
             - az_paragraph_single_card
             - az_paragraph_well
-            - az_paragraph_card_deck
           source: value
           no_stub: true
         -
@@ -119,6 +119,7 @@ process:
           plugin: migration_lookup
           migration:
             - az_paragraph_callout
+            - az_paragraph_card_deck
             - az_paragraph_carousel
             - az_paragraph_chucks_view
             - az_paragraph_column_image

--- a/modules/custom/az_migration/migrations/az_node_news.yml
+++ b/modules/custom/az_migration/migrations/az_node_news.yml
@@ -136,7 +136,6 @@ process:
             - az_paragraph_plain_text
             - az_paragraph_single_card
             - az_paragraph_well
-            - az_paragraph_card_deck
           source: value
           no_stub: true
         -

--- a/modules/custom/az_migration/migrations/az_node_news.yml
+++ b/modules/custom/az_migration/migrations/az_node_news.yml
@@ -17,13 +17,23 @@ migration_dependencies:
     - az_media
     - az_user
   optional:
-    - az_news_tags
-    - az_paragraph_card_deck
+    - az_paragraph_callout
+    - az_paragraph_carousel
+    - az_paragraph_chucks_view
     - az_paragraph_column_image
-    - az_paragraph_contact
     - az_paragraph_extra_info
     - az_paragraph_file_download
+    - az_paragraph_full_width_bg_wrapper
+    - az_paragraph_full_width_media_row
+    - az_paragraph_gallery
     - az_paragraph_headed_text
+    - az_paragraph_html
+    - az_paragraph_jumbotron
+    - az_paragraph_panel_group
+    - az_paragraph_plain_text
+    - az_paragraph_single_card
+    - az_paragraph_well
+    - az_paragraph_card_deck
 
 source:
   plugin: az_node
@@ -78,10 +88,22 @@ process:
         -
           plugin: migration_lookup
           migration:
+            - az_paragraph_callout
+            - az_paragraph_carousel
+            - az_paragraph_chucks_view
             - az_paragraph_column_image
             - az_paragraph_extra_info
             - az_paragraph_file_download
+            - az_paragraph_full_width_bg_wrapper
+            - az_paragraph_full_width_media_row
+            - az_paragraph_gallery
             - az_paragraph_headed_text
+            - az_paragraph_html
+            - az_paragraph_jumbotron
+            - az_paragraph_panel_group
+            - az_paragraph_plain_text
+            - az_paragraph_single_card
+            - az_paragraph_well
             - az_paragraph_card_deck
           source: value
           no_stub: true
@@ -93,10 +115,22 @@ process:
         -
           plugin: migration_lookup
           migration:
+            - az_paragraph_callout
+            - az_paragraph_carousel
+            - az_paragraph_chucks_view
             - az_paragraph_column_image
             - az_paragraph_extra_info
             - az_paragraph_file_download
+            - az_paragraph_full_width_bg_wrapper
+            - az_paragraph_full_width_media_row
+            - az_paragraph_gallery
             - az_paragraph_headed_text
+            - az_paragraph_html
+            - az_paragraph_jumbotron
+            - az_paragraph_panel_group
+            - az_paragraph_plain_text
+            - az_paragraph_single_card
+            - az_paragraph_well
             - az_paragraph_card_deck
           source: value
           no_stub: true

--- a/modules/custom/az_migration/migrations/az_node_news.yml
+++ b/modules/custom/az_migration/migrations/az_node_news.yml
@@ -17,10 +17,12 @@ migration_dependencies:
     - az_media
     - az_user
   optional:
+    - az_news_tags
     - az_paragraph_callout
     - az_paragraph_carousel
     - az_paragraph_chucks_view
     - az_paragraph_column_image
+    - az_paragraph_contact
     - az_paragraph_extra_info
     - az_paragraph_file_download
     - az_paragraph_full_width_bg_wrapper
@@ -92,6 +94,7 @@ process:
             - az_paragraph_carousel
             - az_paragraph_chucks_view
             - az_paragraph_column_image
+            - az_paragraph_contact
             - az_paragraph_extra_info
             - az_paragraph_file_download
             - az_paragraph_full_width_bg_wrapper
@@ -119,6 +122,7 @@ process:
             - az_paragraph_carousel
             - az_paragraph_chucks_view
             - az_paragraph_column_image
+            - az_paragraph_contact
             - az_paragraph_extra_info
             - az_paragraph_file_download
             - az_paragraph_full_width_bg_wrapper


### PR DESCRIPTION
## Description
Added  all of our paragraph migrations as optional dependencies to the az_node_news migration.

## Related issues
Close #3658 

## How to test
Run a migration on a site with overrides to the az_news content type's paragraph reference field that allows using more than the default paragraphs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
