### PR TITLE
Closes #3744 Prevent views using Quickstart Exposed Filters from scrolling when checkboxes are checked

### DIFF
--- a/modules/custom/az_finder/az_finder.services.yml
+++ b/modules/custom/az_finder/az_finder.services.yml
@@ -20,3 +20,5 @@ services:
   logger.channel.az_finder:
     parent: logger.channel_base
     arguments: ['az_finder']
+  az_finder.ajax_response_subscriber:
+    class: Drupal\az_finder\EventSubscriber\AZFinderAjaxResponseSubscriber

--- a/modules/custom/az_finder/src/EventSubscriber/AZFinderAjaxResponseSubscriber.php
+++ b/modules/custom/az_finder/src/EventSubscriber/AZFinderAjaxResponseSubscriber.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\az_finder\EventSubscriber;
+
+use Drupal\views\Ajax\ViewAjaxResponse;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Modify AJAX responses for views using the Quickstart Exposed Filters plugin.
+ */
+class AZFinderAjaxResponseSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::RESPONSE][] = ['onResponse'];
+    return $events;
+  }
+
+  /**
+   * Removes scrollTop AJAX commands for views with Quickstart Exposed Filters.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The event to process.
+   */
+  public function onResponse(ResponseEvent $event) {
+    $response = $event->getResponse();
+
+    // Only modify commands if this is an AJAX response for a view using
+    // Quickstart Exposed Filters for the exposed form.
+    if ($response instanceof ViewAjaxResponse &&
+      $response->getView()->display_handler->getOption('exposed_form')['type'] === 'az_better_exposed_filters') {
+      $commands = &$response->getCommands();
+      foreach ($commands as $key => $value) {
+        if ($value['command'] === 'scrollTop') {
+          unset($commands[$key]);
+          // Only one scrollTop command is expected.
+          return;
+        }
+      }
+    }
+  }
+
+}

--- a/modules/custom/az_finder/src/EventSubscriber/AZFinderAjaxResponseSubscriber.php
+++ b/modules/custom/az_finder/src/EventSubscriber/AZFinderAjaxResponseSubscriber.php
@@ -33,14 +33,16 @@ class AZFinderAjaxResponseSubscriber implements EventSubscriberInterface {
 
     // Only modify commands if this is an AJAX response for a view using
     // Quickstart Exposed Filters for the exposed form.
-    if ($response instanceof ViewAjaxResponse &&
-      $response->getView()->display_handler->getOption('exposed_form')['type'] === 'az_better_exposed_filters') {
-      $commands = &$response->getCommands();
-      foreach ($commands as $key => $value) {
-        if ($value['command'] === 'scrollTop') {
-          unset($commands[$key]);
-          // Only one scrollTop command is expected.
-          return;
+    if ($response instanceof ViewAjaxResponse) {
+      $exposedForm = $response->getView()->display_handler->getOption('exposed_form');
+      if (is_array($exposedForm) && $exposedForm['type'] === 'az_better_exposed_filters') {
+        $commands = &$response->getCommands();
+        foreach ($commands as $key => $value) {
+          if ($value['command'] === 'scrollTop') {
+            unset($commands[$key]);
+            // Only one scrollTop command is expected.
+            return;
+          }
         }
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Adds an Event Subscriber to the AZ Finder module to prevent views using the Quickstart Exposed Form from automatically scrolling to the top of the view content each time a checkbox filter is checked or unchecked.

#### Questions

1. Should we provide an option for this behavior in the AZ Finder settings?
   - We will not provide an option at this time. There is a drupal.org issue for this that currently "needs work": [Make Views AJAX scroll to top optional](https://www.drupal.org/project/drupal/issues/3273068). For now, we will implement the fix in this PR without adding a configurable option, since we may want to replace our fix with the Drupal core functionality in the future.

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3744

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3745.probo.build

1. Compare the scrolling behavior when using filters on pages using the Finder. For example:
   - Try selecting "Psychology" on the People Finder page: [This PR's Probo](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3745.probo.build/finders/people) / [Probo for another PR](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3736.probo.build/finders/people)
   - Try selecting "Training" on the Event Finder page: [This PR's Probo](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3745.probo.build/finders/events) / [Probo for another PR](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3736.probo.build/finders/events)
3. Set up another view with Quickstart Exposed Filters and confirm that the automatic scrolling does not occur.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
