### PR TITLE
Close #3765 Change top-level Quickstart toolbar link to an internal page instead of an external page.

### DIFF
--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -44,7 +44,7 @@ function az_core_toolbar() {
     'tab' => [
       '#type' => 'link',
       '#title' => t('Quickstart 2'),
-      '#url' => Url::fromRoute('<nolink>'),
+      '#url' => Url::fromRoute('az_core.az_quickstart'),
       '#attributes' => [
         'title' => t('AZ Quickstart 2'),
         'class' => [

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -46,6 +46,7 @@ function az_core_toolbar() {
       '#title' => t('Quickstart 2'),
       '#url' => Url::fromRoute('az_core.az_quickstart'),
       '#attributes' => [
+        'target' => t('_blank'),
         'title' => t('AZ Quickstart 2'),
         'class' => [
           'toolbar-item',

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -50,9 +50,6 @@ function az_core_toolbar() {
         'class' => [
           'toolbar-item',
         ],
-        'style' => [
-          'display: block;',
-        ],
       ],
     ],
     'tray' => [

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -44,12 +44,14 @@ function az_core_toolbar() {
     'tab' => [
       '#type' => 'link',
       '#title' => t('Quickstart 2'),
-      '#url' => Url::fromUri('https://quickstart.arizona.edu'),
+      '#url' => Url::fromRoute('<nolink>'),
       '#attributes' => [
-        'target' => t('_blank'),
         'title' => t('AZ Quickstart 2'),
         'class' => [
           'toolbar-item',
+        ],
+        'style' => [
+          'display: block;',
         ],
       ],
     ],


### PR DESCRIPTION
## Description
I've updated the link to be an internal route.

We may want to update the bottom of this page https://quickstart.arizona.edu/site-admin/navigating-administration-section

## Related issues
Close #3765 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
