### PR TITLE
Closes #3773 Styling issues with Box style Text on Media paragraphs

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/config/install/core.entity_view_display.paragraph.az_text_media.default.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/config/install/core.entity_view_display.paragraph.az_text_media.default.yml
@@ -47,7 +47,7 @@ third_party_settings:
         effect: none
         speed: fast
         id: ''
-        classes: az-full-width-row
+        classes: 'd-flex az-full-width-row'
         show_empty_fields: false
       label: Row
     group_az_title:

--- a/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
@@ -21,12 +21,12 @@
 .layout-sidebar-second .full-width-background {
     max-width: calc(100vw - var(--scrollbar-width));
 }
-.region-content .full-width-background {
+.region .full-width-background {
     margin-left: var(--full-width-left-distance);
     margin-right: var(--full-width-right-distance);
     overflow: hidden;
 }
-.region-content .az-full-width-row {
+.region .az-full-width-row {
     display: -ms-flexbox;
     display: flex;
     -ms-flex-wrap: wrap;
@@ -34,7 +34,7 @@
     margin-right: -15px;
     margin-left: -15px;
 }
-.region-content .az-full-width-column-content {
+.region .az-full-width-column-content {
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
     -ms-flex-positive: 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Resolves potential styling issues with Box style Text on Media paragraphs with the following changes:

1. Update the view display for Text on Media paragraphs so that the `.az-full-width-row` div will have `display: flex` regardless of whether or not the paragraph is full-width.
2. Update the `az_paragraphs_full_width` CSS library to allow the full-width paragraph styling to apply to any region, not just the Content region.

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 - #3773

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3774.probo.build

1. Create a page with a Text on Media paragraph as the only page element. Use the following settings:
   - Do NOT check the "Full width" checkbox
   - Set the Content style to Box style
   - Set the Space Around Content setting to a large value such as 8 rem
2. Save the page and confirm that the height of the paragraph is correct.
   - Example page: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3774.probo.build/standard-width-box-style-text-media
3. Create a new flexible block with a Text on Media paragraph using the Box style.
4. In Block Layout, add the block to a region other than "Content" (such as Content Top or Full width content bottom).
5. Visit a page where the block is present and again confirm that the height of the paragraph is correct and the width of the content (the "box" of the box style) is correct.
   - Example page: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3774.probo.build/box-style-text-media-content-top-region


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
