### PR TITLE
Closes #3817 Full-width paragraphs may have wrong width when not in the Content region

### DIFF
--- a/modules/custom/az_paragraphs/css/az_paragraphs_az_text_background.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_az_text_background.css
@@ -1,5 +1,5 @@
 /* Styles for az_text_background paragraph type. */
 
-.region-content .background-wrapper.full-width-background {
+.region .background-wrapper.full-width-background {
   width: initial;
 }

--- a/modules/custom/az_paragraphs/css/az_paragraphs_az_text_media.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_az_text_media.css
@@ -33,10 +33,6 @@
   margin-top: -5em;
   padding: 2em;
 }
-.full-width-background {
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
-}
 .az-video-background .bg-video-player-control {
   position: absolute;
   bottom: 0;

--- a/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
@@ -12,6 +12,8 @@
 }
 .full-width-background {
     max-width: calc(100vw - var(--scrollbar-width));
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
 }
 /* See https://github.com/az-digital/az_quickstart/pull/1365 */
 .sidebar_first {
@@ -44,9 +46,6 @@
     width: 100%;
     padding-right: 15px;
     padding-left: 15px;
-}
-.region:not(.region-content) .background-wrapper {
-    width:initial;
 }
 .az-aspect-ratio.full-width-background .container {
     bottom: 0;

--- a/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
@@ -11,7 +11,7 @@
     }
 }
 .full-width-background {
-    max-width: calc(100vw - var(--scrollbar-width));
+    max-width: calc(100vw);
 }
 /* See https://github.com/az-digital/az_quickstart/pull/1365 */
 .sidebar_first {
@@ -21,10 +21,13 @@
 .layout-sidebar-second .full-width-background {
     max-width: calc(100vw - var(--scrollbar-width));
 }
-.region .full-width-background {
+.region-content .full-width-background {
     margin-left: var(--full-width-left-distance);
     margin-right: var(--full-width-right-distance);
     overflow: hidden;
+}
+.region:not(.region-content) .background-wrapper {
+    width:initial;
 }
 .region .az-full-width-row {
     display: -ms-flexbox;
@@ -34,7 +37,7 @@
     margin-right: -15px;
     margin-left: -15px;
 }
-.region .az-full-width-column-content {
+.region-content .az-full-width-column-content {
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
     -ms-flex-positive: 1;

--- a/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
@@ -45,6 +45,9 @@
     padding-right: 15px;
     padding-left: 15px;
 }
+.region:not(.region-content) .background-wrapper {
+    width:initial;
+}
 .az-aspect-ratio.full-width-background .container {
     bottom: 0;
     top: 0;

--- a/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
+++ b/modules/custom/az_paragraphs/css/az_paragraphs_full_width.css
@@ -11,7 +11,7 @@
     }
 }
 .full-width-background {
-    max-width: calc(100vw);
+    max-width: calc(100vw - var(--scrollbar-width));
 }
 /* See https://github.com/az-digital/az_quickstart/pull/1365 */
 .sidebar_first {
@@ -25,9 +25,6 @@
     margin-left: var(--full-width-left-distance);
     margin-right: var(--full-width-right-distance);
     overflow: hidden;
-}
-.region:not(.region-content) .background-wrapper {
-    width:initial;
 }
 .region .az-full-width-row {
     display: -ms-flexbox;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
This pull request makes the following changes:

1. In az_paragraphs_full_width.css, reverts a couple changes to selectors made in #3774, so that some specific full-width background styling is applied only to the Content region. (The `.region .az-full-width-row` rule is the only exception.)
   - Note: I'm not sure if the styling from the `.region-content .az-full-width-column-content` rule is ever applied: other rules seem to override everything in that rule.
2. To fix an issue with full-width Text with Background paragraphs not using the full width of the page, (a) apply the styling in az_paragraphs_az_text_background.css to all regions instead of just the Content region and (b) move some necessary full-width background styling from az_paragraphs_az_text_media.css to az_paragraphs_full_width.css.


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 - #3817

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3818.probo.build

Check existing demo pages along with the following:

1. https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3818.probo.build/text-media-full-width-blocks
2. https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3818.probo.build/text-media-standard-width-blocks
3. https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3818.probo.build/text-media-all-blocks
4. https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3818.probo.build/text-background-full-width-blocks
5. https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3818.probo.build/text-background-standard-width-blocks
6. https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3818.probo.build/text-background-all-blocks
7. https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-3818.probo.build/full-width-combo-test

Follow-up issue:
 - #3820 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
