### PR TITLE
Close #1479 exclude Drupal 6 migrations from appearing when running drush migrate:status

### DIFF
--- a/modules/custom/az_migration/az_migration.module
+++ b/modules/custom/az_migration/az_migration.module
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @file
+ * Contains az_migration.module.
+ */
+
+/**
+ * Implements hook_migration_plugins_aler().
+ */
+function az_migration_migration_plugins_alter(array &$migrations) {
+  $migrations = array_filter($migrations, function (array $migration) {
+      $tags = isset($migration['migration_tags']) ? (array) $migration['migration_tags'] : [];
+      return !in_array('Drupal 6', $tags);
+  });
+}

--- a/modules/custom/az_migration/az_migration.module
+++ b/modules/custom/az_migration/az_migration.module
@@ -10,7 +10,7 @@
  */
 function az_migration_migration_plugins_alter(array &$migrations) {
   $migrations = array_filter($migrations, function (array $migration) {
-      $tags = isset($migration['migration_tags']) ? (array) $migration['migration_tags'] : [];
-      return !in_array('Drupal 6', $tags);
+    $tags = isset($migration['migration_tags']) ? (array) $migration['migration_tags'] : [];
+    return !in_array('Drupal 6', $tags);
   });
 }

--- a/modules/custom/az_migration/az_migration.module
+++ b/modules/custom/az_migration/az_migration.module
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Contains az_migration.module.


### PR DESCRIPTION
## Description
Reduce unhelpful error messages when developing migrations from drupal 7 Quickstart 1.

## Related issues
Close #1479 

## How to test
1. Ensure that the d7-kitten site is awake
2. In Probo log into ssh shell
3. Change directory
`cd /var/www/html/sites/migration`
4. Drush migrate status
`drush migrate:status`


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
