### PR TITLE
Fixes #3823 Card Widget Deprecation Notices

### DIFF
--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -170,7 +170,7 @@ class AZCardWidget extends WidgetBase {
 
       // Check and see if there's a valid link to preview.
       if ($item->link_title || $item->link_uri) {
-        if (str_starts_with($item->link_uri, '/' . PublicStream::basePath())) {
+        if (!empty($item->link_uri) && str_starts_with($item->link_uri, '/' . PublicStream::basePath())) {
           // Link to public file: use fromUri() to get the URL.
           $link_url = Url::fromUri(urldecode('base:' . $item->link_uri));
         }


### PR DESCRIPTION
## Description
Generation of Card widget previews currently does not check if the URL is set before using it. This PR updates the check to verify if the value is present.

## Related issues
#3823 

## How to test

- Enable `az_demo`
- Visit a node which contains cards, such as `/pages/card-decks`, or create a new page.
- Edit (or add) a card deck
- Create a card which has a link title, but no link URL.
- Save the page
- Edit the page
- Reopen the card deck
- Open and Collapse the individual card several times
- Check `/admin/reports/dblog`
- Verify that `Deprecated function: str_starts_with(): Passing null to parameter #1 ($haystack) of type string is deprecated` is not being generated
- Check for any regressions in card preview functionality
- Verify that a Card Link URL to a public file still works correctly, e.g. `/sites/default/files/placeduck01.jpg`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
