### PR TITLE
Closes #3003: Add menu parent to chosen settings

### DIFF
--- a/modules/custom/az_core/config/quickstart/chosen.settings.yml
+++ b/modules/custom/az_core/config/quickstart/chosen.settings.yml
@@ -4,7 +4,7 @@ disable_search_threshold: 0
 minimum_width: 150
 max_shown_results: null
 use_relative_width: false
-jquery_selector: 'select:visible,select#edit-field-az-page-category'
+jquery_selector: 'select:visible,select#edit-field-az-page-category,select#edit-menu-menu-parent'
 search_contains: true
 disable_search: false
 allow_single_deselect: false


### PR DESCRIPTION
## Description
Adds a jQuery selector to Chosen: when creating or editing a node that has a main menu option, the dropdown will now use Chosen instead of the regular dropdown menu.

Nodes already in the main menu already get Chosen applied to the dropdown menu. This PR therefore adds parity.

### Before
![image](https://github.com/user-attachments/assets/af23c0a0-b819-4c47-b36f-9c24b0db7f6b)

### After
![image](https://github.com/user-attachments/assets/0856e9ac-0bb8-4894-9c61-407ac070dcca)

## Related issues
Closes #3003 

## How to test

1. Visit `/node/add/az_flexible_page`.
2. Open "Menu settings" accordion in the sidebar.
3. Checkmark "Provide a menu link."
4. Click open the "Parent menu" dropdown and see that it uses Chosen module.

## Width Considerations
The width of the Chosen dropdown menu for Main menu selecting may look too narrow. That's due to default Chosen settings currently setting "Minimum width of widget" to 150px. Instead of the associated CSS using `min-width`, it sets a fixed `width`.

The minimum width might be set when the Chosen menu is in an area that hasn't been visibly displayed yet. It seems to calculate a width properly for a node's Main menu selector when that node is already in the menu.

Options to fix:
A. An issue and patch could be created for Chosen to change `width` to `min-width` in the CSS. 
B. Minimum width could be set to a relative percentage (e.g., 30 with "Use relative width" enabled).
C. Minimum width could be unset and left blank, where `width: auto` will then get applied.

It might be good to address this in a separate issue to improve usability since it is a global change.

### Example of node's menu Chosen width already in menu
![image](https://github.com/user-attachments/assets/e030c35b-ed6c-4c44-8506-2acffeaced13)

## Types of changes
Minor enhancement.

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [x] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [x] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
