### PR TITLE
Fixes #3974 Broken Coding Standards Sniffs

### DIFF
--- a/modules/custom/az_core/src/Drush/Commands/AZEntityListCommands.php
+++ b/modules/custom/az_core/src/Drush/Commands/AZEntityListCommands.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\az_core\Drush\Commands;
 
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drush\Attributes\Usage;
 use Drush\Attributes\FieldLabels;
 use Drush\Attributes\DefaultFields;
 use Drush\Attributes\Command;
-use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drush\Commands\DrushCommands;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/modules/custom/az_core/src/Drush/Commands/AZEntityListCommands.php
+++ b/modules/custom/az_core/src/Drush/Commands/AZEntityListCommands.php
@@ -6,10 +6,10 @@ namespace Drupal\az_core\Drush\Commands;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drush\Attributes\Usage;
-use Drush\Attributes\FieldLabels;
-use Drush\Attributes\DefaultFields;
 use Drush\Attributes\Command;
+use Drush\Attributes\DefaultFields;
+use Drush\Attributes\FieldLabels;
+use Drush\Attributes\Usage;
 use Drush\Commands\DrushCommands;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/modules/custom/az_core/src/Drush/Commands/AZEntityListCommands.php
+++ b/modules/custom/az_core/src/Drush/Commands/AZEntityListCommands.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\az_core\Drush\Commands;
 
-use CLI\Usage;
-use CLI\FieldLabels;
-use CLI\DefaultFields;
-use CLI\Command;
+use Drush\Attributes\Usage;
+use Drush\Attributes\FieldLabels;
+use Drush\Attributes\DefaultFields;
+use Drush\Attributes\Command;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drush\Commands\DrushCommands;

--- a/modules/custom/az_core/src/Drush/Commands/AZEntityListCommands.php
+++ b/modules/custom/az_core/src/Drush/Commands/AZEntityListCommands.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\az_core\Drush\Commands;
 
+use CLI\Usage;
+use CLI\FieldLabels;
+use CLI\DefaultFields;
+use CLI\Command;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -47,22 +50,22 @@ final class AZEntityListCommands extends DrushCommands {
    * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
    *   A table with a row for each asset type and count.
    */
-  #[CLI\Command(name: 'az-entity-list:list', aliases: ['ael'])]
-  #[CLI\DefaultFields(fields: [
+  #[Command(name: 'az-entity-list:list', aliases: ['ael'])]
+  #[DefaultFields(fields: [
     'entity_type',
     'bundle',
     'count',
     'entity_type_provider',
   ])]
-  #[CLI\FieldLabels(labels: [
+  #[FieldLabels(labels: [
     'entity_type' => 'Entity type',
     'bundle' => 'Bundle',
     'count' => 'Count',
     'entity_type_provider' => 'Entity Type Provider',
   ])]
-  #[CLI\Usage(name: 'drush az-entity-list:list', description: "List entities enabled on an Arizona Quickstart site.")]
+  #[Usage(name: 'drush az-entity-list:list', description: "List entities enabled on an Arizona Quickstart site.")]
 
-    public function list(array $options = ['format' => 'table']): RowsOfFields {
+  public function list(array $options = ['format' => 'table']): RowsOfFields {
     $all_results = [];
     $entity_types = array_keys($this->entityTypeManager->getDefinitions());
 
@@ -86,42 +89,42 @@ final class AZEntityListCommands extends DrushCommands {
     }
 
     return new RowsOfFields($all_results);
-    }
+  }
 
-    /**
-     * List entity bundles enabled on an Arizona Quickstart site.
-     */
-    private function getBundleTypes(string $entity_type): array {
-      try {
-        $entity_type_definition = $this->entityTypeManager->getDefinition($entity_type);
-        if ($bundle = $entity_type_definition->getBundleEntityType()) {
-          $bundles = $this->entityTypeManager->getStorage($bundle)->loadMultiple();
-          return array_keys($bundles);
-        }
-      }
-      catch (\Exception $e) {
-      }
-      return [$entity_type];
-
-    }
-
-    /**
-     * Get the count of entities for a given entity type and bundle.
-     */
-    private function getEntityCount(string $entity_type, string $bundle): int {
-      try {
-        $entity_type_definition = $this->entityTypeManager->getDefinition($entity_type);
-        $bundle_field = $entity_type_definition->getKey('bundle');
-        $query = $this->entityTypeManager->getStorage($entity_type)->getQuery();
-        $query->accessCheck(FALSE);
-        if ($bundle_field) {
-          $query->condition($bundle_field, $bundle);
-        }
-        return $query->count()->execute();
-      }
-      catch (\Exception $e) {
-        return 0;
+  /**
+   * List entity bundles enabled on an Arizona Quickstart site.
+   */
+  private function getBundleTypes(string $entity_type): array {
+    try {
+      $entity_type_definition = $this->entityTypeManager->getDefinition($entity_type);
+      if ($bundle = $entity_type_definition->getBundleEntityType()) {
+        $bundles = $this->entityTypeManager->getStorage($bundle)->loadMultiple();
+        return array_keys($bundles);
       }
     }
+    catch (\Exception $e) {
+    }
+    return [$entity_type];
+
+  }
+
+  /**
+   * Get the count of entities for a given entity type and bundle.
+   */
+  private function getEntityCount(string $entity_type, string $bundle): int {
+    try {
+      $entity_type_definition = $this->entityTypeManager->getDefinition($entity_type);
+      $bundle_field = $entity_type_definition->getKey('bundle');
+      $query = $this->entityTypeManager->getStorage($entity_type)->getQuery();
+      $query->accessCheck(FALSE);
+      if ($bundle_field) {
+        $query->condition($bundle_field, $bundle);
+      }
+      return $query->count()->execute();
+    }
+    catch (\Exception $e) {
+      return 0;
+    }
+  }
 
 }

--- a/modules/custom/az_publication/az_publication.module
+++ b/modules/custom/az_publication/az_publication.module
@@ -500,12 +500,12 @@ function _az_publication_publication_date_object(EntityInterface $entity) {
   $slices = 3;
   // Depending on date type, we should send fewer date components to CSL.
   switch ($date_type) {
-    case 'year';
+    case 'year':
       $slices = 1;
       break;
 
-    case 'month';
-    case 'season';
+    case 'month':
+    case 'season':
       $slices = 2;
       break;
 
@@ -610,13 +610,13 @@ function _az_publication_form_revisions(array &$form, FormStateInterface $form_s
 
     // Gather settings based on type.
     switch ($date_type) {
-      case 'month';
-      case 'season';
+      case 'month':
+      case 'season':
         $format = 'Y-m';
         $viewmode = 'months';
         break;
 
-      case 'year';
+      case 'year':
         $format = 'Y';
         $viewmode = 'years';
         break;


### PR DESCRIPTION
This PR attempts to address newly broken coding standards issues that came about because of the new release of Drupal/coder


## Related issues
Closes #3974 

## How to test
Verify that publication date functionality and entity list drush command was not impacted.
Especially, does the entity list drush command still continue to function in Quickstart 2.11.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
