### PR TITLE
[Branch for 3891-vimeo-remote] Various suggestions for Vimeo Text on Media support

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/az_paragraphs_text_media.libraries.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/az_paragraphs_text_media.libraries.yml
@@ -9,5 +9,6 @@ az_paragraphs_text_media.vimeo:
   js:
     js/az_paragraphs_az_text_media_vimeo.js: {}
   dependencies:
-    - core/jquery
     - core/drupalSettings
+    - core/jquery
+    - core/once

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/config/install/core.entity_view_display.paragraph.az_text_media.preview.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/config/install/core.entity_view_display.paragraph.az_text_media.preview.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.paragraph.preview
     - field.field.paragraph.az_text_media.field_az_media
     - field.field.paragraph.az_text_media.field_az_text_area
     - field.field.paragraph.az_text_media.field_az_title
@@ -15,11 +16,15 @@ third_party_settings:
     group_az_container:
       children:
         - group_az_full_width_row
+      label: Container
       parent_name: ''
+      region: content
       weight: 1
       format_type: html_element
-      region: content
       format_settings:
+        classes: container
+        show_empty_fields: false
+        id: ''
         element: div
         show_label: false
         label_element: h3
@@ -27,18 +32,18 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-        id: ''
-        classes: container
-        show_empty_fields: false
-      label: Container
     group_az_full_width_row:
       children:
         - group_az_column
+      label: Row
       parent_name: group_az_container
+      region: content
       weight: 20
       format_type: html_element
-      region: content
       format_settings:
+        classes: 'd-flex az-full-width-row'
+        show_empty_fields: false
+        id: ''
         element: div
         show_label: false
         label_element: h3
@@ -46,18 +51,18 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-        id: ''
-        classes: 'd-flex az-full-width-row'
-        show_empty_fields: false
-      label: Row
     group_az_title:
       children:
         - field_az_title
+      label: Title
       parent_name: group_az_content_wrapper
+      region: content
       weight: 21
       format_type: html_element
-      region: content
       format_settings:
+        classes: 'bold mt-0'
+        show_empty_fields: false
+        id: ''
         element: h2
         show_label: false
         label_element: h3
@@ -65,21 +70,18 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-        id: ''
-        classes: 'bold mt-0'
-        show_empty_fields: false
-      label: Title
     group_az_content:
       children:
         - group_az_content_wrapper
+      label: Content
       parent_name: group_az_column
+      region: content
       weight: 21
       format_type: html_element
-      region: content
       format_settings:
+        classes: ''
         show_empty_fields: false
         id: ''
-        classes: ''
         element: div
         show_label: false
         label_element: h3
@@ -87,18 +89,18 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-      label: Content
     group_az_column:
       children:
         - group_az_content
+      label: Column
       parent_name: group_az_full_width_row
+      region: content
       weight: 20
       format_type: html_element
-      region: content
       format_settings:
+        classes: ''
         show_empty_fields: false
         id: ''
-        classes: ''
         element: div
         show_label: false
         label_element: h3
@@ -106,16 +108,19 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-      label: Column
     group_az_content_wrapper:
       children:
         - group_az_title
         - field_az_text_area
+      label: 'Content Wrapper'
       parent_name: group_az_content
+      region: content
       weight: 20
       format_type: html_element
-      region: content
       format_settings:
+        classes: az-full-width-column-content-wrapper
+        show_empty_fields: false
+        id: ''
         element: div
         show_label: false
         label_element: h3
@@ -123,19 +128,13 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-        id: ''
-        classes: az-full-width-column-content-wrapper
-        show_empty_fields: false
-      label: 'Content Wrapper'
-id: paragraph.az_text_media.default
+id: paragraph.az_text_media.preview
 targetEntityType: paragraph
 bundle: az_text_media
-mode: default
+mode: preview
 content:
   field_az_media:
     type: az_background_media
-    weight: 0
-    region: content
     label: hidden
     settings:
       image_style: az_full_width_background
@@ -147,23 +146,25 @@ content:
         attachment: scroll
         repeat: no-repeat
         size: cover
-        selector: '#[paragraph:type:target_id]-[paragraph:id]'
         important: false
-      autoplay_remote_video: true
+        selector: '#[paragraph:type:target_id]-[paragraph:id]'
+      autoplay_remote_video: 0
     third_party_settings: {  }
+    weight: 0
+    region: content
   field_az_text_area:
-    weight: 22
+    type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: text_default
+    weight: 22
     region: content
   field_az_title:
     type: string
-    weight: 21
-    region: content
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    weight: 21
+    region: content
 hidden: {  }

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.es6.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.es6.js
@@ -26,8 +26,9 @@
           width: $(window).width(),
           ratio: 16 / 9,
           autoplay: true,
-          background: true,
+          controls: 0,
           loop: true,
+          muted: true,
           playButtonClass: 'az-video-play',
           pauseButtonClass: 'az-video-pause',
           minimumSupportedWidth: 600,
@@ -60,10 +61,10 @@
               id: vimeoId,
               width: options.width,
               height: Math.ceil(options.width / options.ratio),
-              autoplay: options.autoplay,
-              background: options.background,
-              muted: options.mute,
+              autoplay: thisContainer.dataset.autoplay === 'true',
+              controls: 0,
               loop: options.loop,
+              muted: options.muted,
             });
 
             // Event listener for starting play.

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.es6.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.es6.js
@@ -1,6 +1,23 @@
-(($, Drupal) => {
+(($, Drupal, once) => {
   Drupal.behaviors.az_vimeo_video_bg = {
     attach(context, settings) {
+      // Error messaging function
+      function vimeoError(error) {
+        switch (error.name) {
+          case 'PasswordError':
+            console.log('The Vimeo video is password-protected.');
+            break;
+          case 'PrivacyError':
+            console.log('The Vimeo video is private.');
+            break;
+          default:
+            console.log(
+              `Some errors occurred with the Vimeo video: ${error.name}`,
+            );
+            break;
+        }
+      }
+
       if (window.screen && window.screen.width > 768) {
         // @see https://developer.vimeo.com/player/sdk/basics
         // Defaults
@@ -19,6 +36,7 @@
         const bgVideoParagraphs = document.getElementsByClassName(
           'az-js-vimeo-video-background',
         );
+
         // Load Vimeo API
         const tag = document.createElement('script');
         tag.src = 'https://player.vimeo.com/api/player.js';
@@ -30,7 +48,7 @@
           $.each(bgVideoParagraphs, (index) => {
             const thisContainer = bgVideoParagraphs[index];
             const parentParagraph = thisContainer.parentNode;
-            const vimeoId = thisContainer.dataset.vimeoId2;
+            const vimeoId = thisContainer.dataset.vimeoVideoId;
             bgVideos[vimeoId] = $.extend({}, defaults, thisContainer);
             const options = bgVideos[vimeoId];
             const videoPlayer =
@@ -48,78 +66,42 @@
               loop: options.loop,
             });
 
-            // Event Listeners
+            // Event listener for starting play.
             thisContainer.player.on('play', () => {
               parentParagraph.classList.add('az-video-playing');
-              parentParagraph.classList.remove('az-video-paused');
-            });
-
-            thisContainer.player.on('pause', () => {
-              parentParagraph.classList.add('az-video-paused');
-              parentParagraph.classList.remove('az-video-playing');
-            });
-
-            thisContainer.player.on('ended', () => {
-              if (options.repeat) {
-                thisContainer.player.setCurrentTime(0).then(() => {
-                  thisContainer.player.play();
-                });
-              }
             });
 
             // Play Button
-            const playButton =
-              bgVideoParagraphs[index].getElementsByClassName(
-                'az-video-play',
-              )[0];
-            playButton.addEventListener('click', (event) => {
-              event.preventDefault();
-              bgVideoParagraphs[index].player
-                .play()
-                .then(() => {
-                  // the video is playing
-                })
-                .catch((error) => {
-                  switch (error.name) {
-                    case 'PasswordError':
-                      window.alert('the video is password-protected');
-                      break;
-                    case 'PrivacyError':
-                      window.alert('the video is private');
-                      break;
-                    default:
-                      console.log(`Some errors occurred: ${error.name}`);
-                      break;
-                  }
-                });
-            });
+            const playButtons = once(
+              'play-once',
+              bgVideoParagraphs[index].getElementsByClassName('az-video-play'),
+            );
+            if (playButtons[0]) {
+              playButtons[0].addEventListener('click', (event) => {
+                event.preventDefault();
+                bgVideoParagraphs[index].player
+                  .play()
+                  .catch((error) => vimeoError(error));
+                parentParagraph.classList.add('az-video-playing');
+                parentParagraph.classList.remove('az-video-paused');
+              });
+            }
 
             // Pause Button
-            const pauseButton =
-              bgVideoParagraphs[index].getElementsByClassName(
-                'az-video-pause',
-              )[0];
-            pauseButton.addEventListener('click', (event) => {
-              event.preventDefault();
-              bgVideoParagraphs[index].player
-                .pause()
-                .then(() => {
-                  // the video is paused
-                })
-                .catch((error) => {
-                  switch (error.name) {
-                    case 'PasswordError':
-                      window.alert('the video is password-protected');
-                      break;
-                    case 'PrivacyError':
-                      window.alert('the video is private');
-                      break;
-                    default:
-                      window.alert(`Some errors occurred: ${error.name}`);
-                      break;
-                  }
-                });
-            });
+            const pauseButtons = once(
+              'pause-once',
+              bgVideoParagraphs[index].getElementsByClassName('az-video-pause'),
+            );
+            if (pauseButtons[0]) {
+              pauseButtons[0].addEventListener('click', (event) => {
+                event.preventDefault();
+                bgVideoParagraphs[index].player
+                  .pause()
+                  .catch((error) => vimeoError(error));
+                parentParagraph.classList.add('az-video-paused');
+                parentParagraph.classList.remove('az-video-playing');
+              });
+            }
           });
         };
 
@@ -139,7 +121,7 @@
             return;
           }
           thisPlayer.style.zIndex = -100;
-          const vimeoId = container.dataset.vimeoId2;
+          const vimeoId = container.dataset.vimeoVideoId;
           const width = container.offsetWidth;
           const height = container.offsetHeight;
           const { ratio } = bgVideos[vimeoId];
@@ -186,4 +168,4 @@
       }
     },
   };
-})(jQuery, Drupal, drupalSettings);
+})(jQuery, Drupal, once);

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.js
@@ -73,7 +73,6 @@
             if (pauseButtons[0]) {
               pauseButtons[0].addEventListener('click', function (event) {
                 event.preventDefault();
-                console.log('click pause');
                 bgVideoParagraphs[index].player.pause().catch(function (error) {
                   return vimeoError(error);
                 });

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.js
@@ -26,8 +26,9 @@
           width: $(window).width(),
           ratio: 16 / 9,
           autoplay: true,
-          background: true,
+          controls: 0,
           loop: true,
+          muted: true,
           playButtonClass: 'az-video-play',
           pauseButtonClass: 'az-video-pause',
           minimumSupportedWidth: 600
@@ -50,10 +51,10 @@
               id: vimeoId,
               width: options.width,
               height: Math.ceil(options.width / options.ratio),
-              autoplay: options.autoplay,
-              background: options.background,
-              muted: options.mute,
-              loop: options.loop
+              autoplay: thisContainer.dataset.autoplay === 'true',
+              controls: 0,
+              loop: options.loop,
+              muted: options.muted
             });
             thisContainer.player.on('play', function () {
               parentParagraph.classList.add('az-video-playing');

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.js
@@ -4,23 +4,32 @@
 * https://www.drupal.org/node/2815083
 * @preserve
 **/
-function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
-function _regeneratorRuntime() { "use strict"; _regeneratorRuntime = function _regeneratorRuntime() { return e; }; var t, e = {}, r = Object.prototype, n = r.hasOwnProperty, o = Object.defineProperty || function (t, e, r) { t[e] = r.value; }, i = "function" == typeof Symbol ? Symbol : {}, a = i.iterator || "@@iterator", c = i.asyncIterator || "@@asyncIterator", u = i.toStringTag || "@@toStringTag"; function define(t, e, r) { return Object.defineProperty(t, e, { value: r, enumerable: !0, configurable: !0, writable: !0 }), t[e]; } try { define({}, ""); } catch (t) { define = function define(t, e, r) { return t[e] = r; }; } function wrap(t, e, r, n) { var i = e && e.prototype instanceof Generator ? e : Generator, a = Object.create(i.prototype), c = new Context(n || []); return o(a, "_invoke", { value: makeInvokeMethod(t, r, c) }), a; } function tryCatch(t, e, r) { try { return { type: "normal", arg: t.call(e, r) }; } catch (t) { return { type: "throw", arg: t }; } } e.wrap = wrap; var h = "suspendedStart", l = "suspendedYield", f = "executing", s = "completed", y = {}; function Generator() {} function GeneratorFunction() {} function GeneratorFunctionPrototype() {} var p = {}; define(p, a, function () { return this; }); var d = Object.getPrototypeOf, v = d && d(d(values([]))); v && v !== r && n.call(v, a) && (p = v); var g = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(p); function defineIteratorMethods(t) { ["next", "throw", "return"].forEach(function (e) { define(t, e, function (t) { return this._invoke(e, t); }); }); } function AsyncIterator(t, e) { function invoke(r, o, i, a) { var c = tryCatch(t[r], t, o); if ("throw" !== c.type) { var u = c.arg, h = u.value; return h && "object" == _typeof(h) && n.call(h, "__await") ? e.resolve(h.__await).then(function (t) { invoke("next", t, i, a); }, function (t) { invoke("throw", t, i, a); }) : e.resolve(h).then(function (t) { u.value = t, i(u); }, function (t) { return invoke("throw", t, i, a); }); } a(c.arg); } var r; o(this, "_invoke", { value: function value(t, n) { function callInvokeWithMethodAndArg() { return new e(function (e, r) { invoke(t, n, e, r); }); } return r = r ? r.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg(); } }); } function makeInvokeMethod(e, r, n) { var o = h; return function (i, a) { if (o === f) throw Error("Generator is already running"); if (o === s) { if ("throw" === i) throw a; return { value: t, done: !0 }; } for (n.method = i, n.arg = a;;) { var c = n.delegate; if (c) { var u = maybeInvokeDelegate(c, n); if (u) { if (u === y) continue; return u; } } if ("next" === n.method) n.sent = n._sent = n.arg;else if ("throw" === n.method) { if (o === h) throw o = s, n.arg; n.dispatchException(n.arg); } else "return" === n.method && n.abrupt("return", n.arg); o = f; var p = tryCatch(e, r, n); if ("normal" === p.type) { if (o = n.done ? s : l, p.arg === y) continue; return { value: p.arg, done: n.done }; } "throw" === p.type && (o = s, n.method = "throw", n.arg = p.arg); } }; } function maybeInvokeDelegate(e, r) { var n = r.method, o = e.iterator[n]; if (o === t) return r.delegate = null, "throw" === n && e.iterator.return && (r.method = "return", r.arg = t, maybeInvokeDelegate(e, r), "throw" === r.method) || "return" !== n && (r.method = "throw", r.arg = new TypeError("The iterator does not provide a '" + n + "' method")), y; var i = tryCatch(o, e.iterator, r.arg); if ("throw" === i.type) return r.method = "throw", r.arg = i.arg, r.delegate = null, y; var a = i.arg; return a ? a.done ? (r[e.resultName] = a.value, r.next = e.nextLoc, "return" !== r.method && (r.method = "next", r.arg = t), r.delegate = null, y) : a : (r.method = "throw", r.arg = new TypeError("iterator result is not an object"), r.delegate = null, y); } function pushTryEntry(t) { var e = { tryLoc: t[0] }; 1 in t && (e.catchLoc = t[1]), 2 in t && (e.finallyLoc = t[2], e.afterLoc = t[3]), this.tryEntries.push(e); } function resetTryEntry(t) { var e = t.completion || {}; e.type = "normal", delete e.arg, t.completion = e; } function Context(t) { this.tryEntries = [{ tryLoc: "root" }], t.forEach(pushTryEntry, this), this.reset(!0); } function values(e) { if (e || "" === e) { var r = e[a]; if (r) return r.call(e); if ("function" == typeof e.next) return e; if (!isNaN(e.length)) { var o = -1, i = function next() { for (; ++o < e.length;) if (n.call(e, o)) return next.value = e[o], next.done = !1, next; return next.value = t, next.done = !0, next; }; return i.next = i; } } throw new TypeError(_typeof(e) + " is not iterable"); } return GeneratorFunction.prototype = GeneratorFunctionPrototype, o(g, "constructor", { value: GeneratorFunctionPrototype, configurable: !0 }), o(GeneratorFunctionPrototype, "constructor", { value: GeneratorFunction, configurable: !0 }), GeneratorFunction.displayName = define(GeneratorFunctionPrototype, u, "GeneratorFunction"), e.isGeneratorFunction = function (t) { var e = "function" == typeof t && t.constructor; return !!e && (e === GeneratorFunction || "GeneratorFunction" === (e.displayName || e.name)); }, e.mark = function (t) { return Object.setPrototypeOf ? Object.setPrototypeOf(t, GeneratorFunctionPrototype) : (t.__proto__ = GeneratorFunctionPrototype, define(t, u, "GeneratorFunction")), t.prototype = Object.create(g), t; }, e.awrap = function (t) { return { __await: t }; }, defineIteratorMethods(AsyncIterator.prototype), define(AsyncIterator.prototype, c, function () { return this; }), e.AsyncIterator = AsyncIterator, e.async = function (t, r, n, o, i) { void 0 === i && (i = Promise); var a = new AsyncIterator(wrap(t, r, n, o), i); return e.isGeneratorFunction(r) ? a : a.next().then(function (t) { return t.done ? t.value : a.next(); }); }, defineIteratorMethods(g), define(g, u, "Generator"), define(g, a, function () { return this; }), define(g, "toString", function () { return "[object Generator]"; }), e.keys = function (t) { var e = Object(t), r = []; for (var n in e) r.push(n); return r.reverse(), function next() { for (; r.length;) { var t = r.pop(); if (t in e) return next.value = t, next.done = !1, next; } return next.done = !0, next; }; }, e.values = values, Context.prototype = { constructor: Context, reset: function reset(e) { if (this.prev = 0, this.next = 0, this.sent = this._sent = t, this.done = !1, this.delegate = null, this.method = "next", this.arg = t, this.tryEntries.forEach(resetTryEntry), !e) for (var r in this) "t" === r.charAt(0) && n.call(this, r) && !isNaN(+r.slice(1)) && (this[r] = t); }, stop: function stop() { this.done = !0; var t = this.tryEntries[0].completion; if ("throw" === t.type) throw t.arg; return this.rval; }, dispatchException: function dispatchException(e) { if (this.done) throw e; var r = this; function handle(n, o) { return a.type = "throw", a.arg = e, r.next = n, o && (r.method = "next", r.arg = t), !!o; } for (var o = this.tryEntries.length - 1; o >= 0; --o) { var i = this.tryEntries[o], a = i.completion; if ("root" === i.tryLoc) return handle("end"); if (i.tryLoc <= this.prev) { var c = n.call(i, "catchLoc"), u = n.call(i, "finallyLoc"); if (c && u) { if (this.prev < i.catchLoc) return handle(i.catchLoc, !0); if (this.prev < i.finallyLoc) return handle(i.finallyLoc); } else if (c) { if (this.prev < i.catchLoc) return handle(i.catchLoc, !0); } else { if (!u) throw Error("try statement without catch or finally"); if (this.prev < i.finallyLoc) return handle(i.finallyLoc); } } } }, abrupt: function abrupt(t, e) { for (var r = this.tryEntries.length - 1; r >= 0; --r) { var o = this.tryEntries[r]; if (o.tryLoc <= this.prev && n.call(o, "finallyLoc") && this.prev < o.finallyLoc) { var i = o; break; } } i && ("break" === t || "continue" === t) && i.tryLoc <= e && e <= i.finallyLoc && (i = null); var a = i ? i.completion : {}; return a.type = t, a.arg = e, i ? (this.method = "next", this.next = i.finallyLoc, y) : this.complete(a); }, complete: function complete(t, e) { if ("throw" === t.type) throw t.arg; return "break" === t.type || "continue" === t.type ? this.next = t.arg : "return" === t.type ? (this.rval = this.arg = t.arg, this.method = "return", this.next = "end") : "normal" === t.type && e && (this.next = e), y; }, finish: function finish(t) { for (var e = this.tryEntries.length - 1; e >= 0; --e) { var r = this.tryEntries[e]; if (r.finallyLoc === t) return this.complete(r.completion, r.afterLoc), resetTryEntry(r), y; } }, catch: function _catch(t) { for (var e = this.tryEntries.length - 1; e >= 0; --e) { var r = this.tryEntries[e]; if (r.tryLoc === t) { var n = r.completion; if ("throw" === n.type) { var o = n.arg; resetTryEntry(r); } return o; } } throw Error("illegal catch attempt"); }, delegateYield: function delegateYield(e, r, n) { return this.delegate = { iterator: values(e), resultName: r, nextLoc: n }, "next" === this.method && (this.arg = t), y; } }, e; }
-function asyncGeneratorStep(n, t, e, r, o, a, c) { try { var i = n[a](c), u = i.value; } catch (n) { return void e(n); } i.done ? t(u) : Promise.resolve(u).then(r, o); }
-function _asyncToGenerator(n) { return function () { var t = this, e = arguments; return new Promise(function (r, o) { var a = n.apply(t, e); function _next(n) { asyncGeneratorStep(a, r, o, _next, _throw, "next", n); } function _throw(n) { asyncGeneratorStep(a, r, o, _next, _throw, "throw", n); } _next(void 0); }); }; }
-(function ($, Drupal) {
+(function ($, Drupal, once) {
   Drupal.behaviors.az_vimeo_video_bg = {
     attach: function attach(context, settings) {
+      function vimeoError(error) {
+        switch (error.name) {
+          case 'PasswordError':
+            console.log('The Vimeo video is password-protected.');
+            break;
+          case 'PrivacyError':
+            console.log('The Vimeo video is private.');
+            break;
+          default:
+            console.log("Some errors occurred with the Vimeo video: ".concat(error.name));
+            break;
+        }
+      }
       if (window.screen && window.screen.width > 768) {
         var defaults = {
-          ratio: 16 / 9,
           vimeoId: '',
-          mute: true,
-          repeat: true,
           width: $(window).width(),
+          ratio: 16 / 9,
+          autoplay: true,
+          background: true,
+          loop: true,
           playButtonClass: 'az-video-play',
           pauseButtonClass: 'az-video-pause',
-          start: 0,
           minimumSupportedWidth: 600
         };
         var bgVideos = settings.azFieldsMedia.bgVideos;
@@ -32,7 +41,7 @@ function _asyncToGenerator(n) { return function () { var t = this, e = arguments
           $.each(bgVideoParagraphs, function (index) {
             var thisContainer = bgVideoParagraphs[index];
             var parentParagraph = thisContainer.parentNode;
-            var vimeoId = thisContainer.dataset.vimeoId2;
+            var vimeoId = thisContainer.dataset.vimeoVideoId;
             bgVideos[vimeoId] = $.extend({}, defaults, thisContainer);
             var options = bgVideos[vimeoId];
             var videoPlayer = thisContainer.getElementsByClassName('az-video-player')[0];
@@ -41,108 +50,59 @@ function _asyncToGenerator(n) { return function () { var t = this, e = arguments
               id: vimeoId,
               width: options.width,
               height: Math.ceil(options.width / options.ratio),
-              autoplay: true,
-              muted: options.mute,
-              loop: options.repeat,
+              autoplay: options.autoplay,
               background: options.background,
-              title: options.title,
-              byline: options.byline,
-              portrait: options.portrait
+              muted: options.mute,
+              loop: options.loop
             });
             thisContainer.player.on('play', function () {
               parentParagraph.classList.add('az-video-playing');
-              parentParagraph.classList.remove('az-video-paused');
             });
-            thisContainer.player.on('pause', function () {
-              parentParagraph.classList.add('az-video-paused');
-              parentParagraph.classList.remove('az-video-playing');
-            });
-            thisContainer.player.on('ended', function () {
-              if (options.repeat) {
-                thisContainer.player.setCurrentTime(0).then(function () {
-                  thisContainer.player.play();
+            var playButtons = once('play-once', bgVideoParagraphs[index].getElementsByClassName('az-video-play'));
+            if (playButtons[0]) {
+              playButtons[0].addEventListener('click', function (event) {
+                event.preventDefault();
+                bgVideoParagraphs[index].player.play().catch(function (error) {
+                  return vimeoError(error);
                 });
-              }
-            });
-            var playButton = bgVideoParagraphs[index].getElementsByClassName('az-video-play')[0];
-            playButton.addEventListener('click', function () {
-              var _ref = _asyncToGenerator(_regeneratorRuntime().mark(function _callee(event) {
-                return _regeneratorRuntime().wrap(function _callee$(_context) {
-                  while (1) switch (_context.prev = _context.next) {
-                    case 0:
-                      event.preventDefault();
-                      bgVideoParagraphs[index].player.play().then(function () {}).catch(function (error) {
-                        switch (error.name) {
-                          case 'PasswordError':
-                            window.alert('the video is password-protected');
-                            break;
-                          case 'PrivacyError':
-                            window.alert('the video is private');
-                            break;
-                          default:
-                            console.log("Some errors occurred: ".concat(error.name));
-                            break;
-                        }
-                      });
-                    case 2:
-                    case "end":
-                      return _context.stop();
-                  }
-                }, _callee);
-              }));
-              return function (_x) {
-                return _ref.apply(this, arguments);
-              };
-            }());
-            var pauseButton = bgVideoParagraphs[index].getElementsByClassName('az-video-pause')[0];
-            pauseButton.addEventListener('click', function () {
-              var _ref2 = _asyncToGenerator(_regeneratorRuntime().mark(function _callee2(event) {
-                return _regeneratorRuntime().wrap(function _callee2$(_context2) {
-                  while (1) switch (_context2.prev = _context2.next) {
-                    case 0:
-                      event.preventDefault();
-                      bgVideoParagraphs[index].player.pause().then(function () {}).catch(function (error) {
-                        switch (error.name) {
-                          case 'PasswordError':
-                            window.alert('the video is password-protected');
-                            break;
-                          case 'PrivacyError':
-                            window.alert('the video is private');
-                            break;
-                          default:
-                            window.alert("Some errors occurred: ".concat(error.name));
-                            break;
-                        }
-                      });
-                    case 2:
-                    case "end":
-                      return _context2.stop();
-                  }
-                }, _callee2);
-              }));
-              return function (_x2) {
-                return _ref2.apply(this, arguments);
-              };
-            }());
+                parentParagraph.classList.add('az-video-playing');
+                parentParagraph.classList.remove('az-video-paused');
+              });
+            }
+            var pauseButtons = once('pause-once', bgVideoParagraphs[index].getElementsByClassName('az-video-pause'));
+            if (pauseButtons[0]) {
+              pauseButtons[0].addEventListener('click', function (event) {
+                event.preventDefault();
+                console.log('click pause');
+                bgVideoParagraphs[index].player.pause().catch(function (error) {
+                  return vimeoError(error);
+                });
+                parentParagraph.classList.add('az-video-paused');
+                parentParagraph.classList.remove('az-video-playing');
+              });
+            }
           });
         };
         var setDimensions = function setDimensions(container) {
           var parentParagraph = container.parentNode;
-          var vimeoId = container.dataset.vimeoId2;
-          var thisPlayer = container.getElementsByClassName('az-video-player')[0].firstChild;
-          thisPlayer.style.zIndex = -100;
+          var parentHeight = parentParagraph.offsetHeight;
+          parentHeight = "".concat(parentHeight.toString(), "px");
+          container.style.height = parentHeight;
           var style = container.dataset.style;
+          if (style === 'bottom') {
+            container.style.top = 0;
+          }
+          var thisPlayer = container.getElementsByClassName('az-video-player')[0].firstChild;
+          if (thisPlayer === null) {
+            return;
+          }
+          thisPlayer.style.zIndex = -100;
+          var vimeoId = container.dataset.vimeoVideoId;
           var width = container.offsetWidth;
           var height = container.offsetHeight;
           var ratio = bgVideos[vimeoId].ratio;
           var pWidth = Math.ceil(height * ratio);
           var pHeight = Math.ceil(width / ratio);
-          var parentHeight = parentParagraph.offsetHeight;
-          parentHeight = "".concat(parentHeight.toString(), "px");
-          container.style.height = parentHeight;
-          if (style === 'bottom') {
-            container.style.top = 0;
-          }
           var widthMinuspWidthdividedbyTwo = (width - pWidth) / 2;
           widthMinuspWidthdividedbyTwo = "".concat(widthMinuspWidthdividedbyTwo.toString(), "px");
           var pHeightRatio = (height - pHeight) / 2;
@@ -173,4 +133,4 @@ function _asyncToGenerator(n) { return function () { var t = this, e = arguments
       }
     }
   };
-})(jQuery, Drupal, drupalSettings);
+})(jQuery, Drupal, once);

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_youtube.es6.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_youtube.es6.js
@@ -130,6 +130,9 @@
 
         window.onPlayerReady = (event) => {
           const id = event.target.getVideoData().video_id;
+          if (bgVideos[id].dataset.autoplay === 'false') {
+            return;
+          }
           if (bgVideos[id].mute) {
             event.target.mute();
           }

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_youtube.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_youtube.js
@@ -111,6 +111,9 @@
         };
         window.onPlayerReady = function (event) {
           var id = event.target.getVideoData().video_id;
+          if (bgVideos[id].dataset.autoplay === 'false') {
+            return;
+          }
           if (bgVideos[id].mute) {
             event.target.mute();
           }

--- a/modules/custom/az_paragraphs/src/Plugin/Field/FieldFormatter/AZBackgroundMediaFormatter.php
+++ b/modules/custom/az_paragraphs/src/Plugin/Field/FieldFormatter/AZBackgroundMediaFormatter.php
@@ -122,7 +122,7 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
     ];
     $form['autoplay_remote_video'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Autoplay Remote Video'),
+      '#title' => $this->t('Autoplay remote video'),
       '#default_value' => $settings['autoplay_remote_video'],
       '#description' => $this->t('Uncheck this setting to prevent remote video from playing automatically (such as on the "Preview" view mode).'),
     ];

--- a/modules/custom/az_paragraphs/src/Plugin/Field/FieldFormatter/AZBackgroundMediaFormatter.php
+++ b/modules/custom/az_paragraphs/src/Plugin/Field/FieldFormatter/AZBackgroundMediaFormatter.php
@@ -86,6 +86,7 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
   public static function defaultSettings(): array {
     return [
       'image_style' => '',
+      'autoplay_remote_video' => TRUE,
       'css_settings' => [
         'z_index' => 'auto',
         'color' => '#FFFFFF',
@@ -118,6 +119,12 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
       '#type' => 'select',
       '#options' => $responsive_image_style_options,
       '#default_value' => $this->getSetting('image_style'),
+    ];
+    $form['autoplay_remote_video'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Autoplay Remote Video'),
+      '#default_value' => $settings['autoplay_remote_video'],
+      '#description' => $this->t('Uncheck this setting to prevent remote video from playing automatically (such as on the "Preview" view mode).'),
     ];
     // Fieldset for css settings.
     $form['css_settings'] = [
@@ -271,6 +278,7 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
     else {
       $summary[] = $this->t('Original image style');
     }
+    $summary[] = $this->t('Autoplay Remote Video: @style', ['@style' => empty($settings['autoplay_remote_video']) ? 'No' : 'Yes']);
     $summary[] = Markup::create('<p></p><strong>CSS settings:</strong>');
     if (isset($settings['css_settings']['selector'])) {
       $summary[] = $this->t('CSS selector: @selector', ['@selector' => $settings['css_settings']['selector']]);
@@ -522,6 +530,7 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
             'data-youtubeid' => $video_oembed_id,
             'data-style' => $settings['style'],
             'data-parentid' => HTML::getId($settings['css_settings']['selector']),
+            'data-autoplay' => $settings['autoplay_remote_video'] ? 'true' : 'false',
           ],
           'child' => $background_media,
           '#attached' => $attached_library,
@@ -553,6 +562,7 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
             'data-vimeo-video-id' => $video_oembed_id,
             'data-style' => $settings['style'],
             'data-parentid' => HTML::getId($settings['css_settings']['selector']),
+            'data-autoplay' => $settings['autoplay_remote_video'] ? 'true' : 'false',
           ],
           'child' => $background_media,
           '#attached' => $attached_library,

--- a/modules/custom/az_paragraphs/src/Plugin/Field/FieldFormatter/AZBackgroundMediaFormatter.php
+++ b/modules/custom/az_paragraphs/src/Plugin/Field/FieldFormatter/AZBackgroundMediaFormatter.php
@@ -278,7 +278,7 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
     else {
       $summary[] = $this->t('Original image style');
     }
-    $summary[] = $this->t('Autoplay Remote Video: @style', ['@style' => empty($settings['autoplay_remote_video']) ? 'No' : 'Yes']);
+    $summary[] = $this->t('Autoplay remote video: @style', ['@style' => empty($settings['autoplay_remote_video']) ? 'No' : 'Yes']);
     $summary[] = Markup::create('<p></p><strong>CSS settings:</strong>');
     if (isset($settings['css_settings']['selector'])) {
       $summary[] = $this->t('CSS selector: @selector', ['@selector' => $settings['css_settings']['selector']]);

--- a/modules/custom/az_paragraphs/src/Plugin/Field/FieldFormatter/AZBackgroundMediaFormatter.php
+++ b/modules/custom/az_paragraphs/src/Plugin/Field/FieldFormatter/AZBackgroundMediaFormatter.php
@@ -478,22 +478,9 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
     if ($settings['style'] === 'bottom') {
       $css_settings['selector'] = $css_settings['selector'] . ' .text-on-video';
     }
-    if ($provider === 'YouTube') {
+    if ($provider === 'YouTube' || $provider === 'Vimeo') {
       $source_url = $media->get('field_media_az_oembed_video')->value;
       $video_oembed_id = $this->videoEmbedHelper->getYoutubeIdFromUrl($source_url);
-      $attached_library = [
-        'library' => 'az_paragraphs_text_media/az_paragraphs_text_media.youtube',
-        'drupalSettings' => [
-          'azFieldsMedia' => [
-            'bgVideos' => [
-              $video_oembed_id => [
-                'videoId' => $video_oembed_id,
-                'start' => 0,
-              ],
-            ],
-          ],
-        ],
-      ];
       $responsive_image_style_element = [
         '#theme' => 'az_responsive_background_image',
         '#selector' => $css_settings['selector'],
@@ -508,23 +495,69 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
         '#uri' => $file_uri,
         '#z_index' => $css_settings['z_index'],
       ];
-      $background_video = [
-        '#type' => 'html_tag',
-        '#tag' => 'div',
-        '#allowed_tags' => ['iframe', 'img'],
-        '#attributes' => [
-          'id' => [$video_oembed_id . '-bg-video-container'],
-          'class' => [
-            'az-video-background',
-            'az-js-video-background',
+      if ($provider === 'YouTube') {
+        $attached_library = [
+          'library' => 'az_paragraphs_text_media/az_paragraphs_text_media.youtube',
+          'drupalSettings' => [
+            'azFieldsMedia' => [
+              'bgVideos' => [
+                $video_oembed_id => [
+                  'videoId' => $video_oembed_id,
+                  'start' => 0,
+                ],
+              ],
+            ],
           ],
-          'data-youtubeid' => $video_oembed_id,
-          'data-style' => $settings['style'],
-          'data-parentid' => HTML::getId($settings['css_settings']['selector']),
-        ],
-        'child' => $background_media,
-        '#attached' => $attached_library,
-      ];
+        ];
+        $background_video = [
+          '#type' => 'html_tag',
+          '#tag' => 'div',
+          '#allowed_tags' => ['iframe', 'img'],
+          '#attributes' => [
+            'id' => [$video_oembed_id . '-bg-video-container'],
+            'class' => [
+              'az-video-background',
+              'az-js-video-background',
+            ],
+            'data-youtubeid' => $video_oembed_id,
+            'data-style' => $settings['style'],
+            'data-parentid' => HTML::getId($settings['css_settings']['selector']),
+          ],
+          'child' => $background_media,
+          '#attached' => $attached_library,
+        ];
+      }
+      elseif ($provider === 'Vimeo') {
+        $attached_library = [
+          'library' => 'az_paragraphs_text_media/az_paragraphs_text_media.vimeo',
+          'drupalSettings' => [
+            'azFieldsMedia' => [
+              'bgVideos' => [
+                $video_oembed_id => [
+                  'videoId' => $video_oembed_id,
+                ],
+              ],
+            ],
+          ],
+        ];
+        $background_video = [
+          '#type' => 'html_tag',
+          '#tag' => 'div',
+          '#allowed_tags' => ['iframe', 'img'],
+          '#attributes' => [
+            'id' => [$video_oembed_id . '-bg-video-container'],
+            'class' => [
+              'az-video-background',
+              'az-js-vimeo-video-background',
+            ],
+            'data-vimeo-video-id' => $video_oembed_id,
+            'data-style' => $settings['style'],
+            'data-parentid' => HTML::getId($settings['css_settings']['selector']),
+          ],
+          'child' => $background_media,
+          '#attached' => $attached_library,
+        ];
+      }
 
       if ($settings['style'] !== 'bottom') {
         $az_background_media[] = $responsive_image_style_element;
@@ -561,95 +594,9 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
           ],
         ];
         $az_background_media[] = $text_on_bottom;
-
       }
     }
-    elseif ($provider === 'Vimeo') {
-      $source_url = $media->get('field_media_az_oembed_video')->value;
-      $video_oembed_id = $this->videoEmbedHelper->getYoutubeIdFromUrl($source_url);
-      $attached_library = [
-        'library' => 'az_paragraphs_text_media/az_paragraphs_text_media.vimeo',
-        'drupalSettings' => [
-          'azFieldsMedia' => [
-            'bgVideos' => [
-              $video_oembed_id => [
-                'videoId' => $video_oembed_id,
-                'start' => 0,
-              ],
-            ],
-          ],
-        ],
-      ];
-      $responsive_image_style_element = [
-        '#theme' => 'az_responsive_background_image',
-        '#selector' => $css_settings['selector'],
-        '#repeat' => $css_settings['repeat'],
-        '#important' => $css_settings['important'],
-        '#color' => $css_settings['color'],
-        '#x' => $css_settings['x'],
-        '#y' => $css_settings['y'],
-        '#size' => $css_settings['size'],
-        '#attachment' => $css_settings['attachment'],
-        '#responsive_image_style_id' => $settings['image_style'],
-        '#uri' => $file_uri,
-        '#z_index' => $css_settings['z_index'],
-      ];
-      $background_video = [
-        '#type' => 'html_tag',
-        '#tag' => 'div',
-        '#allowed_tags' => ['iframe', 'img'],
-        '#attributes' => [
-          'id' => [$video_oembed_id . '-bg-video-container'],
-          'class' => [
-            'az-video-background',
-            'az-js-vimeo-video-background',
-          ],
-          'data-vimeo-id2' => $video_oembed_id,
-          'data-style' => $settings['style'],
-          'data-parentid' => HTML::getId($settings['css_settings']['selector']),
-        ],
-        'child' => $background_media,
-        '#attached' => $attached_library,
-      ];
 
-      if ($settings['style'] !== 'bottom') {
-        $az_background_media[] = $responsive_image_style_element;
-        $az_background_media[] = $background_video;
-        if ($settings['text_media_spacing'] === 'az-aspect-ratio' && isset($settings['full_width']) && $settings['full_width'] === 'full-width-background') {
-          $image_renderable = [
-            '#theme' => 'responsive_image_formatter',
-            '#responsive_image_style_id' => 'az_full_width_background',
-            '#item' => $media->get('thumbnail'),
-            '#item_attributes' => [
-              'class' => ['img-fluid', ' w-100', 'invisible'],
-            ],
-          ];
-          $az_background_media[] = $image_renderable;
-        }
-      }
-      elseif ($settings['style'] === 'bottom') {
-        $image_renderable = [
-          '#theme' => 'responsive_image_formatter',
-          '#responsive_image_style_id' => 'az_full_width_background',
-          '#item' => $media->get('thumbnail'),
-          '#item_attributes' => [
-            'class' => ['img-fluid'],
-          ],
-        ];
-        $text_on_bottom = [
-          '#type' => 'html_tag',
-          '#tag' => 'div',
-          'img' => $image_renderable,
-          'style' => $responsive_image_style_element,
-          'video' => $background_video,
-          '#attributes' => [
-            'class' => ['text-on-media-bottom', 'text-on-video'],
-          ],
-        ];
-        $az_background_media[] = $text_on_bottom;
-
-      }
-    }
     return $az_background_media;
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
This PR is a branch of the `3891-vimeo-remote-video-is-not-supported-as-a-text-on-media-background` branch as tracked in this PR:
 - #3981 

This PR is intended to compile some suggestions for that branch:

- Rename the data attribute for the vimeo ID (while still avoiding the name `data-vimeo-id` to prevent an extra iframe from being loaded by the Vimeo player SDK).
- Consolidate some code in AZBackgroundMediaFormatter.php which is the same for both YouTube and Vimeo videos.
- Add the use of core/once to the Vimeo JS code to prevent multiple event listeners from being added to play and pause buttons.
- In the JS code, move the error messaging to a separate function.
- Prevent both Vimeo and YouTube videos from playing on node edit pages by introducing a new `autoplay_remote_video` setting for Text on Media paragraphs. This setting is disabled for the preview display of Text on Media paragraphs.

Remaining issues:

- In Chrome on macOS (both standard and incognito windows), the play/pause buttons often do not work on Vimeo Text on Media backgrounds when logged in. This issue does not appear for me with Firefox or Safari on macOS. I was able to reproduce the issue in Chrome on Windows 10.
  - I think we could go ahead and merge this and address this issue in the main PR.
- ~~Vimeo and YouTube Text on Media backgrounds play in the paragraph preview on the edit page~~


## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4000.probo.build

- https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4000.probo.build/vimeo-test
- https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4000.probo.build/youtube-test