### PR TITLE
Fixes #4010 Remote Images for API Integrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,8 @@
         "drupal/pathauto": "1.13.0",
         "drupal/quick_node_clone": "1.17.0",
         "drupal/redirect": "1.11.0",
+        "drupal/remote_stream_wrapper": "2.1.0",
+        "drupal/remote_stream_wrapper_widget": "1.4.0",
         "drupal/role_delegation": "1.3.0",
         "drupal/schema_metatag": "3.0.3",
         "drupal/search_exclude": "3.0.0-beta1",
@@ -194,6 +196,9 @@
             },
             "drupal/role_delegation": {
                 "Restrict access to cancel/remove accounts with non-assignable roles (3299201)": "https://www.drupal.org/files/issues/2022-07-25/3299201-4.patch"
+            },
+            "drupal/remote_stream_wrapper": {
+                "Image styles setting extension cause access denied (3068898)": "https://www.drupal.org/files/issues/2024-12-02/3068898-12.patch"
             },
             "drupal/search_exclude": {
                 "Request for a Views Handler (2882683)": "https://www.drupal.org/files/issues/2023-06-29/request_for_a_views-2882683-14_0.patch"

--- a/modules/custom/az_person/az_person_profiles_import/az_person_profiles_import.info.yml
+++ b/modules/custom/az_person/az_person_profiles_import/az_person_profiles_import.info.yml
@@ -12,3 +12,4 @@ dependencies:
   - node
   - path
   - pathauto
+  - remote_stream_wrapper

--- a/modules/custom/az_person/az_person_profiles_import/migrations/az_person_profiles_import.yml
+++ b/modules/custom/az_person/az_person_profiles_import/migrations/az_person_profiles_import.yml
@@ -42,6 +42,10 @@ source:
     -
       name: degrees
       selector: 'Degrees'
+    -
+      name: image_url
+      label: 'Image URL'
+      selector: 'Person/photo_url'
 
 process:
   nid:

--- a/modules/custom/az_person/az_person_profiles_import/src/EventSubscriber/AZPersonProfilesImportEventSubscriber.php
+++ b/modules/custom/az_person/az_person_profiles_import/src/EventSubscriber/AZPersonProfilesImportEventSubscriber.php
@@ -103,7 +103,6 @@ class AZPersonProfilesImportEventSubscriber implements EventSubscriberInterface 
             $media = $person->field_az_media_image->entity;
             // Media entity needs to be updated.
             if ($media) {
-              \Drupal::logger('my_module')->notice("we are updating");
               // @todo cleanup this field access do be configured by process plugin.
               // @phpstan-ignore-next-line
               $media->field_media_az_image->target_id = $file->id();


### PR DESCRIPTION
This draft PR provides a mechanism for using remote images for API integrations, via remote stream wrappers. This means that the original image is not stored locally, and instead fetched as needed, with only computed image derivatives for styles being actually stored on the site.

This was part of a proof of concept investigation about whether we should potentially try to avoid fetching local copies of external images; the alternative to this approach is fetching each external image via queued download and also periodically needing to determine if the local image and the remote image match and remain in sync.

Presently this functionality of creating the remote image takes place in an event subscriber; before this PR leaves draft status it should be converted to a process plugin.

**Todo:**

- [ ] Move functionality to process plugin
- [ ] Trellis event images

**Note:** in testing, one potential issue I've noticed with this approach is that Trellis event image URLs are extremely lengthy. We would need a solution for URLs which are too long for the uri path in the files managed table.

## Related issues
#4010 

## How to test

- enable `az_http` and `az_person_profiles_import`
- login
- visit `/admin/config/az-quickstart/settings/az-person-profiles-import`
- enter your profiles API token
- visit `/admin/content/profiles/import`
- import several NetIDs of faculty which have profile photos in the Profiles site
- view imported people
- Verify that the images work
- Verify that `/admin/content/files` contains links to the original photo, off-site
- Verify that computed image derivatives on content pages contain links to on-site URLs with a folder structure that mimics the url

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
