### PR TITLE
Fixes #3938 Update Trellis events only if content changes

### DIFF
--- a/modules/custom/az_event/az_event_trellis/config/install/migrate_queue_importer.cron_migration.az_event_trellis.yml
+++ b/modules/custom/az_event/az_event_trellis/config/install/migrate_queue_importer.cron_migration.az_event_trellis.yml
@@ -8,6 +8,6 @@ id: az_event_trellis
 label: 'Quickstart Trellis Events'
 migration: az_trellis_events
 time: 43200
-update: true
+update: false
 sync: false
 ignore_dependencies: 0

--- a/modules/custom/az_event/az_event_trellis/src/Plugin/migrate/source/AZTrellisEventSource.php
+++ b/modules/custom/az_event/az_event_trellis/src/Plugin/migrate/source/AZTrellisEventSource.php
@@ -6,6 +6,7 @@ namespace Drupal\az_event_trellis\Plugin\migrate\source;
 
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
+use Drupal\migrate\Row;
 
 /**
  * Source plugin for retrieving data via Trellis events.
@@ -101,6 +102,16 @@ class AZTrellisEventSource extends SourcePluginBase {
     // Return an iterable.
     $obj = new \ArrayObject($results);
     return $obj->getIterator();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepareRow(Row $row) {
+    // Trellis IDs from source configuration can affect the hash of the row.
+    $row->setSourceProperty('trellis_ids', []);
+    // Perform normal source plugin hashing.
+    return parent::prepareRow($row);
   }
 
   /**

--- a/modules/custom/az_event/az_event_trellis/src/Plugin/views/field/AZEventTrellisViewsField.php
+++ b/modules/custom/az_event/az_event_trellis/src/Plugin/views/field/AZEventTrellisViewsField.php
@@ -121,7 +121,7 @@ class AZEventTrellisViewsField extends BulkForm {
       }
       $options = [
         'limit' => 0,
-        'update' => 1,
+        'update' => 0,
         'force' => 0,
         'configuration' => [
           'source' => [


### PR DESCRIPTION
This PR addresses an issue in the trellis event importer that causes events that have been imported to continually be updated, even if they have not changed. This should not be the case, because the migration uses `track_changes: true`

## Description
The issue stems from two separate behaviors:

- When drupal migrations run in update mode, they set all rows in the id map to `NEEDS_UPDATE`, and this ignores the track changes behavior. Consequently, this PR avoids running the migrations in update mode. They were previously being run this way both in the periodic queue migration, and the manual import form, resulting in rows being flagged for update.
- At other times, migrations could also be forced to update because lists of trellis event ids in the source plugin could cause alterations to the hash values used for `track_changes`. This PR unsets the trellis event id array, since it is only used by the source plugin and not needed for the individual rows.

## Related issues
Closes #3938 

## How to test

- enable `az_enterprise_attributes_import` and `az_event_trellis`
- import several events from `/admin/trellis-event-importer` choose one you have access to edit
- run the migration: `drush migrate:import az_trellis_events`
- verify no events are updated
- import one new event
- run the migration
- verify no new events are updated
- Update one event you have access to
- clear cache with `drush cr` (to void the trellis helper guzzle cache)
- run the migration with `drush migrate:import az_trellis_events`
- verify the changed event is updated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
