### PR TITLE
[Branch for 3891-vimeo-remote] Further suggestions for Vimeo Text on Media support 

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.es6.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.es6.js
@@ -1,121 +1,34 @@
 (($, Drupal, once) => {
   Drupal.behaviors.az_vimeo_video_bg = {
     attach(context, settings) {
-      // Error messaging function
-      function vimeoError(error) {
-        switch (error.name) {
-          case 'PasswordError':
-            console.log('The Vimeo video is password-protected.');
-            break;
-          case 'PrivacyError':
-            console.log('The Vimeo video is private.');
-            break;
-          default:
-            console.log(
-              `Some errors occurred with the Vimeo video: ${error.name}`,
-            );
-            break;
+      function initVimeoBackgrounds() {
+        // Set default aspect ratio for Vimeo videos.
+        const defaultAspectRatio = 16 / 9;
+
+        // Error messaging function
+        function vimeoError(error) {
+          switch (error.name) {
+            case 'PasswordError':
+              console.log('The Vimeo video is password-protected.');
+              break;
+            case 'PrivacyError':
+              console.log('The Vimeo video is private.');
+              break;
+            default:
+              console.log(
+                `Some errors occurred with the Vimeo video: ${error.name}`,
+              );
+              break;
+          }
         }
-      }
-
-      if (window.screen && window.screen.width > 768) {
-        // @see https://developer.vimeo.com/player/sdk/basics
-        // Defaults
-        const defaults = {
-          vimeoId: '',
-          width: $(window).width(),
-          ratio: 16 / 9,
-          autopause: false,
-          autoplay: true,
-          controls: 0,
-          loop: true,
-          muted: true,
-          playButtonClass: 'az-video-play',
-          pauseButtonClass: 'az-video-pause',
-          minimumSupportedWidth: 600,
-        };
-        const { bgVideos } = settings.azFieldsMedia;
-        const bgVideoParagraphs = document.getElementsByClassName(
-          'az-js-vimeo-video-background',
-        );
-
-        // Load Vimeo API
-        const tag = document.createElement('script');
-        tag.src = 'https://player.vimeo.com/api/player.js';
-        document.head.appendChild(tag);
-
-        // Methods
-        // Ensure Vimeo API is loaded before proceeding
-        tag.onload = () => {
-          $.each(bgVideoParagraphs, (index) => {
-            const thisContainer = bgVideoParagraphs[index];
-            const parentParagraph = thisContainer.parentNode;
-            const vimeoId = thisContainer.dataset.vimeoVideoId;
-            bgVideos[vimeoId] = $.extend({}, defaults, thisContainer);
-            const options = bgVideos[vimeoId];
-            const videoPlayer =
-              thisContainer.getElementsByClassName('az-video-player')[0];
-            const VimeoPlayer = window.Vimeo;
-
-            // Initialize Vimeo Player
-            thisContainer.player = new VimeoPlayer.Player(videoPlayer, {
-              id: vimeoId,
-              width: options.width,
-              height: Math.ceil(options.width / options.ratio),
-              autopause: options.autopause,
-              autoplay: thisContainer.dataset.autoplay === 'true',
-              controls: 0,
-              loop: options.loop,
-              muted: options.muted,
-            });
-
-            // Event listener for starting play.
-            thisContainer.player.on('bufferend', () => {
-              parentParagraph.classList.add('az-video-playing');
-            });
-
-            // Play Button
-            const playButtons = once(
-              'play-once',
-              bgVideoParagraphs[index].getElementsByClassName('az-video-play'),
-            );
-            if (playButtons[0]) {
-              playButtons[0].addEventListener('click', (event) => {
-                event.preventDefault();
-                bgVideoParagraphs[index].player
-                  .play()
-                  .catch((error) => vimeoError(error));
-                parentParagraph.classList.add('az-video-playing');
-                parentParagraph.classList.remove('az-video-paused');
-              });
-            }
-
-            // Pause Button
-            const pauseButtons = once(
-              'pause-once',
-              bgVideoParagraphs[index].getElementsByClassName('az-video-pause'),
-            );
-            if (pauseButtons[0]) {
-              pauseButtons[0].addEventListener('click', (event) => {
-                event.preventDefault();
-                bgVideoParagraphs[index].player
-                  .pause()
-                  .catch((error) => vimeoError(error));
-                parentParagraph.classList.add('az-video-paused');
-                parentParagraph.classList.remove('az-video-playing');
-              });
-            }
-          });
-        };
 
         // Resize Logic
-        const setDimensions = (container) => {
+        function setDimensions(container) {
           const parentParagraph = container.parentNode;
           let parentHeight = parentParagraph.offsetHeight;
           parentHeight = `${parentHeight.toString()}px`;
           container.style.height = parentHeight;
-          const { style } = container.dataset;
-          if (style === 'bottom') {
+          if (container.dataset.style === 'bottom') {
             container.style.top = 0;
           }
           const thisPlayer =
@@ -124,23 +37,21 @@
             return;
           }
           thisPlayer.style.zIndex = -100;
-          const vimeoId = container.dataset.vimeoVideoId;
           const width = container.offsetWidth;
           const height = container.offsetHeight;
-          const { ratio } = bgVideos[vimeoId];
-          const pWidth = Math.ceil(height * ratio); // get new player width
-          const pHeight = Math.ceil(width / ratio); // get new player height
-          let widthMinuspWidthdividedbyTwo = (width - pWidth) / 2;
-          widthMinuspWidthdividedbyTwo = `${widthMinuspWidthdividedbyTwo.toString()}px`;
+          const pWidth = Math.ceil(height * defaultAspectRatio); // get new player width
+          const pHeight = Math.ceil(width / defaultAspectRatio); // get new player height
+          let widthMinuspWidthDividedByTwo = (width - pWidth) / 2;
+          widthMinuspWidthDividedByTwo = `${widthMinuspWidthDividedByTwo.toString()}px`;
           let pHeightRatio = (height - pHeight) / 2;
           pHeightRatio = `${pHeightRatio.toString()}px`;
           // when screen aspect ratio differs from video,
           // video must center and underlay one dimension.
-          if (width / ratio < height) {
+          if (width / defaultAspectRatio < height) {
             // if new video height < window height (gap underneath)
             thisPlayer.width = pWidth;
             thisPlayer.height = height;
-            thisPlayer.style.left = widthMinuspWidthdividedbyTwo;
+            thisPlayer.style.left = widthMinuspWidthDividedByTwo;
             thisPlayer.style.top = 0;
             // player width is greater, offset left; reset top
           } else {
@@ -151,24 +62,104 @@
             thisPlayer.style.top = pHeightRatio;
             thisPlayer.style.left = 0;
           }
-        };
+        }
 
-        // Resize handler updates width, height and offset
-        // of player after resize/init.
-        const resize = () => {
-          $.each(bgVideoParagraphs, (index) => {
-            setDimensions(bgVideoParagraphs[index]);
+        if (window.screen && window.screen.width > 768) {
+          // @see https://developer.vimeo.com/player/sdk/basics
+          // Defaults
+          const defaults = {
+            vimeoId: '',
+            autopause: false,
+            autoplay: true,
+            controls: 0,
+            loop: true,
+            muted: true,
+            playButtonClass: 'az-video-play',
+            pauseButtonClass: 'az-video-pause',
+          };
+          const { bgVideos } = settings.azFieldsMedia;
+          const bgVideoParagraphs = document.getElementsByClassName(
+            'az-js-vimeo-video-background',
+          );
+
+          // Load Vimeo API
+          const tag = document.createElement('script');
+          tag.src = 'https://player.vimeo.com/api/player.js';
+          document.head.appendChild(tag);
+
+          // Methods
+          // Ensure Vimeo API is loaded before proceeding
+          tag.onload = () => {
+            $.each(bgVideoParagraphs, (index) => {
+              const thisContainer = bgVideoParagraphs[index];
+              const parentParagraph = thisContainer.parentNode;
+              const vimeoId = thisContainer.dataset.vimeoVideoId;
+              bgVideos[vimeoId] = $.extend({}, defaults, thisContainer);
+              const options = bgVideos[vimeoId];
+              const videoPlayer =
+                thisContainer.getElementsByClassName('az-video-player')[0];
+              const VimeoPlayer = window.Vimeo;
+
+              // Initialize Vimeo Player
+              thisContainer.player = new VimeoPlayer.Player(videoPlayer, {
+                id: vimeoId,
+                autopause: options.autopause,
+                autoplay: thisContainer.dataset.autoplay === 'true',
+                controls: 0,
+                loop: options.loop,
+                muted: options.muted,
+              });
+
+              // Event listener for starting play.
+              thisContainer.player.on('bufferend', () => {
+                setDimensions(thisContainer);
+                parentParagraph.classList.add('az-video-playing');
+              });
+
+              // Play Button
+              const playButtons =
+                thisContainer.getElementsByClassName('az-video-play');
+              if (playButtons[0]) {
+                playButtons[0].addEventListener('click', (event) => {
+                  event.preventDefault();
+                  thisContainer.player
+                    .play()
+                    .catch((error) => vimeoError(error));
+                  parentParagraph.classList.add('az-video-playing');
+                  parentParagraph.classList.remove('az-video-paused');
+                });
+              }
+
+              // Pause Button
+              const pauseButtons =
+                thisContainer.getElementsByClassName('az-video-pause');
+              if (pauseButtons[0]) {
+                pauseButtons[0].addEventListener('click', (event) => {
+                  event.preventDefault();
+                  thisContainer.player
+                    .pause()
+                    .catch((error) => vimeoError(error));
+                  parentParagraph.classList.add('az-video-paused');
+                  parentParagraph.classList.remove('az-video-playing');
+                });
+              }
+            });
+          };
+
+          // Resize handler updates width, height and offset
+          // of player after resize/init.
+          const resize = () => {
+            $.each(bgVideoParagraphs, (index) => {
+              setDimensions(bgVideoParagraphs[index]);
+            });
+          };
+          $(window).on('resize.bgVideo', () => {
+            resize();
           });
-        };
-
-        // Event Handlers
-        $(window).on('load', () => {
-          resize();
-        });
-        $(window).on('resize.bgVideo', () => {
-          resize();
-        });
+        }
       }
+
+      once('vimeoTextOnMedia-init', 'body').forEach(initVimeoBackgrounds());
     },
   };
 })(jQuery, Drupal, once);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
This PR is a branch of the `3891-vimeo-remote-video-is-not-supported-as-a-text-on-media-background` branch as tracked in this PR:
 - #3981 

This PR updates the Vimeo Text on Media JavaScript to resolve issues with sizing of the video iframe element.

- Wrap the behavior JS in a once call so that it is only called once (it was being run 5 times). The once calls for the play and pause buttons are no longer needed.
- Convert setDimensions to a standard function and use it for the initial sizing of the player (after the "bufferend" event) rather than using a separate sizing process
- Move `ratio` property from options to a `defaultRatio` variable (since Vimeo doesn't have a `ratio` property)
- Removed the window onload handler since it never seemed to be called
- Other miscellaneous changes

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4083.probo.build
Test page: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4083.probo.build/brian-test-page
