### PR TITLE
Closes #4118 Refactor Text on Media YouTube JavaScript library

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/az_paragraphs_text_media.libraries.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/az_paragraphs_text_media.libraries.yml
@@ -2,12 +2,10 @@ az_paragraphs_text_media.youtube:
   js:
     js/az_paragraphs_az_text_media_youtube.js: {}
   dependencies:
-    - core/jquery
-    - core/drupalSettings
+    - core/once
 
 az_paragraphs_text_media.vimeo:
   js:
     js/az_paragraphs_az_text_media_vimeo.js: {}
   dependencies:
-    - core/drupalSettings
     - core/once

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_youtube.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_youtube.js
@@ -4,145 +4,134 @@
 * https://www.drupal.org/node/2815083
 * @preserve
 **/
-(function ($, Drupal) {
+(function (Drupal, once) {
   Drupal.behaviors.az_youtube_video_bg = {
-    attach: function attach(context, settings) {
-      if (window.screen && window.screen.width > 768) {
-        var defaults = {
-          ratio: 16 / 9,
-          videoId: '',
-          mute: true,
-          repeat: true,
-          width: $(window).width(),
-          playButtonClass: 'az-video-play',
-          pauseButtonClass: 'az-video-pause',
-          muteButtonClass: 'az-video-mute',
-          volumeUpClass: 'az-video-volume-up',
-          volumeDownClass: 'az-video-volume-down',
-          increaseVolumeBy: 10,
-          start: 0,
-          minimumSupportedWidth: 600
-        };
-        var bgVideos = settings.azFieldsMedia.bgVideos;
-        var bgVideoParagraphs = document.getElementsByClassName('az-js-video-background');
-        var tag = document.createElement('script');
-        var firstScriptTag = document.getElementsByTagName('script')[0];
-        tag.src = 'https://www.youtube.com/iframe_api';
-        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-        window.onYouTubeIframeAPIReady = function () {
-          $.each(bgVideoParagraphs, function (index) {
-            var thisContainer = bgVideoParagraphs[index];
-            var parentId = thisContainer.dataset.parentid;
-            var parentParagraph = document.getElementById(parentId);
-            var youtubeId = thisContainer.dataset.youtubeid;
-            bgVideos[youtubeId] = $.extend({}, defaults, thisContainer);
-            var options = bgVideos[youtubeId];
-            var videoPlayer = thisContainer.getElementsByClassName('az-video-player')[0];
-            var YouTubePlayer = window.YT;
-            thisContainer.player = new YouTubePlayer.Player(videoPlayer, {
-              width: options.width,
-              height: Math.ceil(options.width / options.ratio),
-              videoId: youtubeId,
-              playerVars: {
-                modestbranding: 1,
-                controls: 0,
-                showinfo: 0,
-                rel: 0,
-                wmode: 'transparent'
-              },
-              events: {
-                onReady: window.onPlayerReady,
-                onStateChange: window.onPlayerStateChange
-              }
+    attach: function attach(context) {
+      function initYouTubeBackgrounds() {
+        if (window.screen && window.screen.width > 768) {
+          var defaultSettings = {
+            loop: true,
+            mute: true,
+            pauseButtonClass: 'az-video-pause',
+            playButtonClass: 'az-video-play',
+            ratio: 16 / 9,
+            width: document.documentElement.clientWidth
+          };
+          var bgVideoSettings = {};
+          var tag = document.createElement('script');
+          var firstScriptTag = document.getElementsByTagName('script')[0];
+          tag.src = 'https://www.youtube.com/iframe_api';
+          firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+          var bgVideoParagraphs = document.getElementsByClassName('az-js-video-background');
+          window.onYouTubeIframeAPIReady = function () {
+            Array.from(bgVideoParagraphs).forEach(function (element) {
+              var parentParagraph = document.getElementById(element.dataset.parentid);
+              var youtubeId = element.dataset.youtubeid;
+              bgVideoSettings[youtubeId] = {
+                autoplay: element.dataset.autoplay === 'true',
+                start: element.dataset.start
+              };
+              var videoPlayer = element.getElementsByClassName('az-video-player')[0];
+              var youTubePlayer = window.YT;
+              element.player = new youTubePlayer.Player(videoPlayer, {
+                width: defaultSettings.width,
+                height: Math.ceil(defaultSettings.width / defaultSettings.ratio),
+                videoId: youtubeId,
+                playerVars: {
+                  controls: 0,
+                  enablejsapi: 1,
+                  origin: window.location.origin,
+                  rel: 0
+                },
+                events: {
+                  onReady: window.onPlayerReady,
+                  onStateChange: window.onPlayerStateChange
+                }
+              });
+              var playButton = element.getElementsByClassName('az-video-play')[0];
+              playButton.addEventListener('click', function (event) {
+                event.preventDefault();
+                element.player.playVideo();
+                parentParagraph.classList.remove('az-video-paused');
+                parentParagraph.classList.add('az-video-playing');
+              });
+              var pauseButton = element.getElementsByClassName('az-video-pause')[0];
+              pauseButton.addEventListener('click', function (event) {
+                event.preventDefault();
+                element.player.pauseVideo();
+                parentParagraph.classList.remove('az-video-playing');
+                parentParagraph.classList.add('az-video-paused');
+              });
             });
-            var playButton = bgVideoParagraphs[index].getElementsByClassName('az-video-play')[0];
-            playButton.addEventListener('click', function (event) {
-              event.preventDefault();
-              bgVideoParagraphs[index].player.playVideo();
-              parentParagraph.classList.remove('az-video-paused');
-              parentParagraph.classList.add('az-video-playing');
+          };
+          var setDimensions = function setDimensions(container) {
+            container.style.height = "".concat(container.parentNode.offsetHeight, "px");
+            if (container.dataset.style === 'bottom') {
+              container.style.top = 0;
+            }
+            var thisPlayer = container.getElementsByClassName('az-video-player')[0];
+            if (thisPlayer === null) {
+              return;
+            }
+            thisPlayer.style.zIndex = -100;
+            var width = container.offsetWidth;
+            var height = container.offsetHeight;
+            var pWidth = Math.ceil(height * defaultSettings.ratio);
+            var pHeight = Math.ceil(width / defaultSettings.ratio);
+            var widthMinuspWidthDividedByTwo = (width - pWidth) / 2;
+            widthMinuspWidthDividedByTwo = "".concat(widthMinuspWidthDividedByTwo.toString(), "px");
+            var pHeightRatio = "".concat((height - pHeight) / 2, "px");
+            if (width / defaultSettings.ratio < height) {
+              thisPlayer.width = pWidth;
+              thisPlayer.height = height;
+              thisPlayer.style.left = widthMinuspWidthDividedByTwo;
+              thisPlayer.style.top = 0;
+            } else {
+              thisPlayer.height = pHeight;
+              thisPlayer.width = width;
+              thisPlayer.style.top = pHeightRatio;
+              thisPlayer.style.left = 0;
+            }
+          };
+          var resize = function resize() {
+            Array.from(bgVideoParagraphs).forEach(function (element) {
+              setDimensions(element);
             });
-            var pauseButton = bgVideoParagraphs[index].getElementsByClassName('az-video-pause')[0];
-            pauseButton.addEventListener('click', function (event) {
-              event.preventDefault();
-              bgVideoParagraphs[index].player.pauseVideo();
-              parentParagraph.classList.remove('az-video-playing');
-              parentParagraph.classList.add('az-video-paused');
-            });
-          });
-        };
-        var setDimensions = function setDimensions(container) {
-          var parentParagraph = container.parentNode;
-          var youtubeId = container.dataset.youtubeid;
-          var thisPlayer = container.getElementsByClassName('az-video-player')[0];
-          thisPlayer.style.zIndex = -100;
-          var style = container.dataset.style;
-          var width = container.offsetWidth;
-          var height = container.offsetHeight;
-          var ratio = bgVideos[youtubeId].ratio;
-          var pWidth = Math.ceil(height * ratio);
-          var pHeight = Math.ceil(width / ratio);
-          var parentHeight = parentParagraph.offsetHeight;
-          parentHeight = "".concat(parentHeight.toString(), "px");
-          container.style.height = parentHeight;
-          if (style === 'bottom') {
-            container.style.top = 0;
-          }
-          var widthMinuspWidthdividedbyTwo = (width - pWidth) / 2;
-          widthMinuspWidthdividedbyTwo = "".concat(widthMinuspWidthdividedbyTwo.toString(), "px");
-          var pHeightRatio = (height - pHeight) / 2;
-          pHeightRatio = "".concat(pHeightRatio.toString(), "px");
-          if (width / ratio < height) {
-            thisPlayer.width = pWidth;
-            thisPlayer.height = height;
-            thisPlayer.style.left = widthMinuspWidthdividedbyTwo;
-            thisPlayer.style.top = 0;
-          } else {
-            thisPlayer.height = pHeight;
-            thisPlayer.width = width;
-            thisPlayer.style.top = pHeightRatio;
-            thisPlayer.style.left = 0;
-          }
-        };
-        var resize = function resize() {
-          $.each(bgVideoParagraphs, function (index) {
-            setDimensions(bgVideoParagraphs[index]);
-          });
-        };
-        window.onPlayerReady = function (event) {
-          var id = event.target.getVideoData().video_id;
-          if (bgVideos[id].dataset.autoplay === 'false') {
-            return;
-          }
-          if (bgVideos[id].mute) {
-            event.target.mute();
-          }
-          event.target.seekTo(bgVideos[id].start);
-          event.target.playVideo();
-          var azVideoPlayEvent = new Event('azVideoPlay');
-          dispatchEvent(azVideoPlayEvent);
-        };
-        window.onPlayerStateChange = function (event) {
-          var id = event.target.getVideoData().video_id;
-          var stateChangeContainer = document.getElementById("".concat(id, "-bg-video-container"));
-          var parentid = stateChangeContainer.dataset.parentid;
-          var parentContainer = document.getElementById(parentid);
-          if (event.data === 0 && bgVideos[id].repeat) {
-            stateChangeContainer.player.seekTo(bgVideos[id].start);
-          }
-          if (event.data === 1) {
+          };
+          window.onPlayerReady = function (event) {
+            var id = event.target.options.videoId;
+            if (!bgVideoSettings[id].autoplay) {
+              return;
+            }
+            if (defaultSettings.mute) {
+              event.target.mute();
+            }
+            event.target.seekTo(bgVideoSettings[id].start);
+            event.target.playVideo();
+            dispatchEvent(new Event('azVideoPlay'));
+          };
+          window.onPlayerStateChange = function (event) {
+            var id = event.target.options.videoId;
+            var stateChangeContainer = document.getElementById("".concat(id, "-bg-video-container"));
+            var parentContainer = document.getElementById(stateChangeContainer.dataset.parentid);
+            if (event.data === 0 && defaultSettings.loop) {
+              stateChangeContainer.player.seekTo(bgVideoSettings[id].start);
+            }
+            if (event.data === 1) {
+              resize();
+              parentContainer.classList.add('az-video-playing');
+              parentContainer.classList.remove('az-video-loading');
+            }
+          };
+          window.addEventListener('load', function () {
             resize();
-            parentContainer.classList.add('az-video-playing');
-            parentContainer.classList.remove('az-video-loading');
-          }
-        };
-        $(window).on('load', function () {
-          resize();
-        });
-        $(window).on('resize.bgVideo', function () {
-          resize();
-        });
+          });
+          window.addEventListener('resize', function () {
+            resize();
+          });
+        }
       }
+      once('youTubeTextOnMedia-init', 'body').forEach(initYouTubeBackgrounds, context);
     }
   };
-})(jQuery, Drupal, drupalSettings);
+})(Drupal, once);

--- a/modules/custom/az_paragraphs/src/Plugin/Field/FieldFormatter/AZBackgroundMediaFormatter.php
+++ b/modules/custom/az_paragraphs/src/Plugin/Field/FieldFormatter/AZBackgroundMediaFormatter.php
@@ -506,16 +506,6 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
       if ($provider === 'YouTube') {
         $attached_library = [
           'library' => 'az_paragraphs_text_media/az_paragraphs_text_media.youtube',
-          'drupalSettings' => [
-            'azFieldsMedia' => [
-              'bgVideos' => [
-                $video_oembed_id => [
-                  'videoId' => $video_oembed_id,
-                  'start' => 0,
-                ],
-              ],
-            ],
-          ],
         ];
         $background_video = [
           '#type' => 'html_tag',
@@ -531,6 +521,7 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
             'data-style' => $settings['style'],
             'data-parentid' => HTML::getId($settings['css_settings']['selector']),
             'data-autoplay' => $settings['autoplay_remote_video'] ? 'true' : 'false',
+            'data-start' => '0',
           ],
           'child' => $background_media,
           '#attached' => $attached_library,
@@ -539,15 +530,6 @@ class AZBackgroundMediaFormatter extends EntityReferenceFormatterBase implements
       elseif ($provider === 'Vimeo') {
         $attached_library = [
           'library' => 'az_paragraphs_text_media/az_paragraphs_text_media.vimeo',
-          'drupalSettings' => [
-            'azFieldsMedia' => [
-              'bgVideos' => [
-                $video_oembed_id => [
-                  'videoId' => $video_oembed_id,
-                ],
-              ],
-            ],
-          ],
         ];
         $background_video = [
           '#type' => 'html_tag',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
This PR makes the following changes to the Text on Media module:

1. Removes the jQuery and drupalSettings dependencies from the Text on Media YouTube JavaScript library.
2. Updates the library to use Drupal core's once functionality (currently the JS is running 5 times on page load).
3. Separates settings into "defaultSettings" and video-specific "bgVideoSettings":
   - `autoplay` is kept as a video-specific setting. It is not added as a playerVar so that we can explicitly control the video playing (and mute it first).
   - `start` is always 0, but it is kept as a video-specific setting which we could manipulate in the future if desired.
   - `mute` is always true and it is kept as a default setting in the JS.
4. Removes unused default video settings and deprecated YouTube playerVars.
5. Cleans up various variables.
6. Removes the drupalSettings dependency from the Text on Media Vimeo JavaScript library. (It was already removed from the JS.)


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 - #4118 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Confirm that all functionality of Text on Media YouTube backgrounds continues to work as it did as before.

Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4126.probo.build

Text on Media page comparison: [Another Probo (current Quickstart)](https://e2693ba0-8d7f-4632-a433-8e6258564575.probo.build/pages/text-media) / [This PR's Probo](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4126.probo.build/pages/text-media)
My test page comparison: [Another Probo (current Quickstart)](https://e2693ba0-8d7f-4632-a433-8e6258564575.probo.build/brian-test-page) / [This PR's Probo](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4126.probo.build/brian-test-page)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [x] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
