### PR TITLE
Fixes #4158 Profiles-imported Person photos should not be editable.

### DIFF
--- a/modules/custom/az_person/az_person.module
+++ b/modules/custom/az_person/az_person.module
@@ -65,6 +65,7 @@ function az_person_form_node_az_person_edit_form_alter(&$form, FormStateInterfac
           $disabled_fields = [
             'field_az_fname',
             'field_az_lname',
+            'field_az_media_image',
             'field_az_netid',
             'field_az_email',
             'field_az_phones',


### PR DESCRIPTION
This PR adds `field_az_media_image` to the list of fields that cannot be edited for Persons imported from the profiles API. This was not previously necessary until #4010 because there was no way for a Profile API Person to receive a photo on import.

## Related issues
#4158 

## How to test
**Profiles Integration (requires Profiles API token to test)**
- enable `az_person_profiles_import` and `az_http`
- `drush cr`
- visit `/admin/config/az-quickstart/settings/az-person-profiles-import` 
- Add your profiles API token
- visit `/admin/content/profiles/import`
- Import several netids. Import a mix of ones that have faculty profiles images and some that do not
- edit an imported person with a photo
- verify that the photo cannot be **removed** (X icon)
  - it is intended that you can still click the edit pencil widget and edit the details of the photo, such as alt text, etc. This is editing the media entity, not the person.
- visit a person without a photo
- verify that the `Add Media` button is greyed out
- Add a CAS account for one of the users that was imported. Give them the role of `Profile Editor`
- Visit their user account and masquerade as them
- Click their account name in the toolbar and click 'Edit my web page`
- Verify there is no pencil icon and that they cannot edit or remove the photo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
