### PR TITLE
Closes #4190: Add a recurrence description to pages for recurring events

### DIFF
--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -125,50 +125,62 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
       /** @var \Drupal\Core\Field\FieldItemList $event_dates */
       $event_dates = $entity->field_az_event_date;
       $number_of_occurrences = $event_dates->count();
-      if ($number_of_occurrences > 1) {
-        // Prepare the recurrence description text using the Recurr library.
-        $rule_index = $event_dates[0]->getValue()['rrule'];
-        /** @var \Drupal\smart_date_recur\Entity\SmartDateRule $smart_date_rule */
-        $smart_date_rule = \Drupal::entityTypeManager()->getStorage('smart_date_rule')->load($rule_index);
-        $start_date = (new \DateTime)->setTimestamp($smart_date_rule->get('start')[0]->getString());
-        $recurr_rule = new Rule($smart_date_rule->getRule(), $start_date);
-
-        // Always set "until" to match the last occurrence's end date/time.
-        /** @var \Drupal\smart_date\Plugin\Field\FieldType\SmartDateItem $last_occurrence */
-        $last_occurrence = $event_dates[$number_of_occurrences - 1];
-        $recurr_rule->setUntil((new \DateTime)->setTimestamp($last_occurrence->get('end_value')->getString()));
-
-        // Use the event's language if possible.
-        $event_langcode = $entity->language()->getId();
-        if ($event_langcode !== 'en') {
-          try {
-            $recurr_translator = new Translator($event_langcode);
-            $recurr_text_transformer = new TextTransformer($recurr_translator);
-          }
-          catch (InvalidArgumentException $e) {
-            // No translation available for this langcode: fall back to 'en'.
-            $recurr_text_transformer = new TextTransformer();
+      if ($number_of_occurrences <= 1) {
+        // Add to Calendar button for an event with a single occurrence.
+        foreach ($entity->field_az_event_date as $item) {
+          if (($item->value >= $now) || (!empty($item->end_value) && ($item->end_value >= $now))) {
+            $build['field_az_event_date'][] = [
+              '#theme' => 'az_event_calendar_add_button',
+              '#title' => $entity->getTitle(),
+              '#start_date' => $item->value ?? '',
+              '#end_date' => $item->end_value ?? '',
+              '#description' => $entity->field_az_body->value ?? '',
+              '#location' => $entity->field_az_location->title ?? '',
+              '#modal' => Html::getUniqueId('calendar-link-modal'),
+              '#attributes' => ['class' => 'mt-3'],
+            ];
+            break;
           }
         }
-        else {
-          $recurr_text_transformer = new TextTransformer();
+      }
+      else {
+        // Create occurrence_items array and sort items by start value.
+        $occurrence_items = $event_dates->getValue();
+        $event_rrules = [];
+        foreach ($occurrence_items as $key => $value) {
+          $occurrence_items[$key]['render'] = $build['field_az_event_date'][$key];
+          // Build an array of recurrence rules used by the event.
+          if (isset($occurrence_items[$key]['rrule']) && !in_array($occurrence_items[$key]['rrule'], $event_rrules)) {
+            $event_rrules[] = $occurrence_items[$key]['rrule'];
+          }
+        }
+        usort($occurrence_items, function ($a, $b) {
+          if (!empty($a['value']) && !empty($b['value'])) {
+            return $a['value'] <=> $b['value'];
+          }
+        });
+
+        // If there is only 1 recurrence, prepare the recurrence text.
+        $recurrence_text = '';
+        if (count($event_rrules) === 1) {
+          $recurrence_text = az_event_get_recurrence_text(
+            $event_rrules[0],
+            $occurrence_items[$number_of_occurrences - 1],
+            $entity->language()->getId(),
+          );
         }
 
-        // Transform the recurrence rule to text.
-        $recurrence_text = ucfirst($recurr_text_transformer->transform($recurr_rule));
-
-        // Initialize the accordion body render array.
+        // Initialize the occurrences modal render array.
         $occurrences_modal = [];
         $item_index = 0;
 
-        // Add any upcoming occurrences to the accordion body.
+        // Add any upcoming occurrences to the modal render array.
         $next_occurrence = NULL;
         $add_to_calendar_button = NULL;
-        /** @var \Drupal\smart_date\Plugin\Field\FieldType\SmartDateItem $item */
-        foreach ($entity->field_az_event_date as $item) {
-          if (!empty($item->end_value) && $item->end_value > $now) {
+        foreach ($occurrence_items as $key => $item) {
+          if (!empty($item['end_value']) && $item['end_value'] > $now) {
             if (!isset($next_occurrence)) {
-              $next_occurrence = $item->getName();
+              $next_occurrence = $key;
               $upcoming_events_heading = t("Upcoming Events");
               $occurrences_modal[$item_index++] = [
                 '#markup' => "<h3 class='h5 mt-0'>{$upcoming_events_heading}</h3>",
@@ -177,35 +189,35 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
               $add_to_calendar_button = [
                 '#theme' => 'az_event_calendar_add_button',
                 '#title' => $entity->getTitle(),
-                '#start_date' => $item->value ?? '',
-                '#end_date' => $item->end_value ?? '',
+                '#start_date' => $item['value'] ?? '',
+                '#end_date' => $item['end_value'] ?? '',
                 '#description' => $entity->field_az_body->value ?? '',
                 '#location' => $entity->field_az_location->title ?? '',
                 '#modal' => Html::getUniqueId('calendar-link-modal'),
                 '#attributes' => ['class' => 'mb-2'],
               ];
             }
-            $occurrences_modal[$item_index++] = $build['field_az_event_date'][$item->getName()];
+            $occurrences_modal[$item_index++] = $occurrence_items[$key]['render'];
           }
         }
 
-        // Add any past occurrences to the accordion body.
+        // Add any past occurrences to the modal render array.
         if (!isset($next_occurrence) || $next_occurrence !== 0) {
           $past_events_heading = t("Past Events");
           $occurrences_modal[$item_index++] = [
             '#markup' => "<h3 class='h5" . (isset($next_occurrence) ? '' : ' mt-0') . "'>{$past_events_heading}</h3>",
           ];
           for ($i = 0; $i < ($next_occurrence ?? $number_of_occurrences); $i++) {
-            $occurrences_modal[$item_index++] = $build['field_az_event_date'][$i];
+            $occurrences_modal[$item_index++] = $occurrence_items[$i]['render'];
           }
         }
 
-        // Replace/unset the items in the render array for the field.
+        // Replace/unset the items in the field_az_event_date render array.
         $item_index = 0;
         if (isset($next_occurrence)) {
-          $build['field_az_event_date'][$item_index] = $build['field_az_event_date'][$next_occurrence];
+          $build['field_az_event_date'][$item_index] = $occurrence_items[$next_occurrence]['render'];
           $next_event_text = t("Next event");
-          $build['field_az_event_date'][$item_index]['#prefix'] = "<div class='mb-2'><strong>{$next_event_text}:</strong> ";
+          $build['field_az_event_date'][$item_index]['#prefix'] = "<div class='mb-" . (empty($recurrence_text) ? '3' : '2') . "'><strong>{$next_event_text}:</strong> ";
           $build['field_az_event_date'][$item_index++]['#suffix'] = '</div>';
         }
         if (!empty($recurrence_text)) {
@@ -227,27 +239,52 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
           unset($build['field_az_event_date'][$i]);
         }
       }
-      else {
-        // Add to Calendar button for an event with a single occurrence.
-        foreach ($entity->field_az_event_date as $item) {
-          if (($item->value >= $now) || (!empty($item->end_value) && ($item->end_value >= $now))) {
-            $build['field_az_event_date'][] = [
-              '#theme' => 'az_event_calendar_add_button',
-              '#title' => $entity->getTitle(),
-              '#start_date' => $item->value ?? '',
-              '#end_date' => $item->end_value ?? '',
-              '#description' => $entity->field_az_body->value ?? '',
-              '#location' => $entity->field_az_location->title ?? '',
-              '#modal' => Html::getUniqueId('calendar-link-modal'),
-              '#attributes' => ['class' => 'mt-3'],
-            ];
-            break;
-          }
-        }
-      }
     }
   }
+}
 
+/**
+ * Returns human-readable description of a Smart Date recurrence rule.
+ *
+ * @param string $rule_index
+ *   The index of the Smart Date recurrence rule.
+ * @param array $last_occurrence
+ *   The last chronological event occurrence (may not be in the recurrence).
+ * @param string $event_langcode
+ *   The langcode of the event to which the recurrence belongs.
+ *
+ * @return string
+ *   A text description of the recurrence.
+ */
+function az_event_get_recurrence_text(string $rule_index, array $last_occurrence, string $event_langcode) {
+  $recurrence_text = '';
+
+  /** @var \Drupal\smart_date_recur\Entity\SmartDateRule $smart_date_rule */
+  $smart_date_rule = \Drupal::entityTypeManager()->getStorage('smart_date_rule')->load($rule_index);
+  $start_date = (new \DateTime)->setTimestamp($smart_date_rule->get('start')[0]->getString());
+  $recurr_rule = new Rule($smart_date_rule->getRule(), $start_date);
+
+  // Always set "until" to match the last occurrence's end date/time.
+  $recurr_rule->setUntil((new \DateTime)->setTimestamp($last_occurrence['end_value']));
+
+  // Use the event's language if possible.
+  if ($event_langcode !== 'en') {
+    try {
+      $recurr_translator = new Translator($event_langcode);
+      $recurr_text_transformer = new TextTransformer($recurr_translator);
+    }
+    catch (InvalidArgumentException $e) {
+      // No translation available for this langcode: fall back to 'en'.
+      $recurr_text_transformer = new TextTransformer();
+    }
+  }
+  else {
+    $recurr_text_transformer = new TextTransformer();
+  }
+
+  // Transform the recurrence rule to text.
+  $recurrence_text = ucfirst($recurr_text_transformer->transform($recurr_rule));
+  return $recurrence_text;
 }
 
 /**

--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -122,13 +122,19 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
         $rule_index = $event_dates[0]->getValue()['rrule'];
         /** @var \Drupal\smart_date_recur\Entity\SmartDateRule $smart_date_rule */
         $smart_date_rule = \Drupal::entityTypeManager()->getStorage('smart_date_rule')->load($rule_index);
-        $recurr_rule = new Rule($smart_date_rule->getRule(), new \DateTime());
+        $start_date = (new \DateTime)->setTimestamp($smart_date_rule->get('start')[0]->getString());
+        $recurr_rule = new Rule($smart_date_rule->getRule(), $start_date);
 
-        $default_langcode = \Drupal::languageManager()->getDefaultLanguage()->getId();
-        if ($default_langcode !== 'en') {
-          // Use the site's default language if possible.
+        // Always set "until" to match the last occurrence's end date/time.
+        /** @var \Drupal\smart_date\Plugin\Field\FieldType\SmartDateItem $last_occurrence */
+        $last_occurrence = $event_dates[$number_of_occurrences - 1];
+        $recurr_rule->setUntil((new \DateTime)->setTimestamp($last_occurrence->get('end_value')->getString()));
+
+        // Use the event's language if possible.
+        $event_langcode = $entity->language()->getId();
+        if ($event_langcode !== 'en') {
           try {
-            $recurr_translator = new Translator($default_langcode);
+            $recurr_translator = new Translator($event_langcode);
             $recurr_text_transformer = new TextTransformer($recurr_translator);
           }
           catch (InvalidArgumentException $e) {
@@ -142,10 +148,6 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
 
         // Transform the recurrence rule to text.
         $recurrence_text = ucfirst($recurr_text_transformer->transform($recurr_rule));
-        if ($default_langcode === 'en') {
-          // Replace "times" with "occurrences" for consistency.
-          $recurrence_text = str_replace('time', 'occurrence', $recurrence_text);
-        }
 
         // Initialize the accordion body build array.
         $accordion_body = $build['field_az_event_date'];
@@ -175,7 +177,7 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
                 '#description' => $entity->field_az_body->value ?? '',
                 '#location' => $entity->field_az_location->title ?? '',
                 '#modal' => Html::getUniqueId('calendar-link-modal'),
-                '#attributes' => ['class' => 'pb-1 mb-4'],
+                '#attributes' => ['class' => 'mb-card'],
               ];
             }
             $accordion_body[$item_index++] = $build['field_az_event_date'][$item->getName()];
@@ -194,7 +196,7 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
         }
 
         // Replace/unset the items in the build array for the field.
-        $item_index = !empty($recurrence_text) ? 1 : 0;
+        $item_index = 0;
         if (isset($next_occurrence)) {
           $build['field_az_event_date'][$item_index] = $build['field_az_event_date'][$next_occurrence];
           $next_event_text = t("Next event");
@@ -202,9 +204,13 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
           $build['field_az_event_date'][$item_index]['#suffix'] = '</div>';
           $item_index++;
           if (isset($add_to_calendar_button)) {
-            $build['field_az_event_date'][$item_index] = $add_to_calendar_button;
-            $item_index++;
+            $build['field_az_event_date'][$item_index++] = $add_to_calendar_button;
           }
+        }
+        if (!empty($recurrence_text)) {
+          $build['field_az_event_date'][$item_index++] = [
+            '#markup' => "<p class='mb-4'>{$recurrence_text}</p>",
+          ];
         }
         $build['field_az_event_date'][$item_index++] = [
           '#theme' => 'az_accordion',
@@ -217,11 +223,6 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
         ];
         for ($i = $item_index; $i < $number_of_occurrences; $i++) {
           unset($build['field_az_event_date'][$i]);
-        }
-        if (!empty($recurrence_text)) {
-          $build['field_az_event_date'][0] = [
-            '#markup' => "<p>{$recurrence_text}</p>",
-          ];
         }
       }
       else {

--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -152,10 +152,12 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
         // Initialize the accordion body render array.
         $accordion_body = [
           '#theme' => 'field',
+          '#title' => 'Event Occurrences',
           '#label_display' => 'hidden',
           '#field_name' => 'field_az_event_date_accordion',
-          '#field_type' => 'smartdate',
-          '#formatter' => 'daterange_ap_style',
+          '#field_type' => 'text',
+          "#entity_type" => 'node',
+          "#bundle" => 'az_event',
           '#is_multiple' => 'true',
           '#cache' => $build['field_az_event_date']['#cache'],
         ];

--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -122,9 +122,9 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
     // For the full content view mode, modify the display of recurring events.
     if (($view_mode === 'full') && ($entity instanceof NodeInterface)) {
       $now = \Drupal::time()->getCurrentTime();
-      /** @var \Drupal\Core\Field\FieldItemList $event_dates */
-      $event_dates = $entity->field_az_event_date;
-      $number_of_occurrences = $event_dates->count();
+      /** @var \Drupal\Core\Field\FieldItemList $event_date_field */
+      $event_date_field = $entity->field_az_event_date;
+      $number_of_occurrences = $event_date_field->count();
       if ($number_of_occurrences <= 1) {
         // Add to Calendar button for an event with a single occurrence.
         foreach ($entity->field_az_event_date as $item) {
@@ -145,13 +145,19 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
       }
       else {
         // Create occurrence_items array and sort items by start value.
-        $occurrence_items = $event_dates->getValue();
+        $occurrence_items = $event_date_field->getValue();
         $event_rrules = [];
+        $are_occurrences_modified = FALSE;
         foreach ($occurrence_items as $key => $value) {
           $occurrence_items[$key]['render'] = $build['field_az_event_date'][$key];
           // Build an array of recurrence rules used by the event.
-          if (isset($occurrence_items[$key]['rrule']) && !in_array($occurrence_items[$key]['rrule'], $event_rrules)) {
-            $event_rrules[] = $occurrence_items[$key]['rrule'];
+          if (isset($occurrence_items[$key]['rrule'])) {
+            if (!in_array($occurrence_items[$key]['rrule'], $event_rrules)) {
+              $event_rrules[] = $occurrence_items[$key]['rrule'];
+            }
+          }
+          else {
+            $are_occurrences_modified = TRUE;
           }
         }
         usort($occurrence_items, function ($a, $b) {
@@ -162,12 +168,24 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
 
         // If there is only 1 recurrence, prepare the recurrence text.
         $recurrence_text = '';
+        $modified_text_markup = '';
         if (count($event_rrules) === 1) {
           $recurrence_text = az_event_get_recurrence_text(
             $event_rrules[0],
             $occurrence_items[$number_of_occurrences - 1],
             $entity->language()->getId(),
           );
+          // If the date field only has a recurring item, check for overrides.
+          if (!$are_occurrences_modified) {
+            /** @var \Drupal\smart_date_recur\Entity\SmartDateRule $smart_date_rule */
+            $smart_date_rule = \Drupal::entityTypeManager()->getStorage('smart_date_rule')->load($event_rrules[0]);
+            $are_occurrences_modified = empty($smart_date_rule->getRuleOverrides()) ? FALSE : TRUE;
+          }
+          // Add help text if occurrences do not match the recurrence exactly.
+          if ($are_occurrences_modified) {
+            $modified_text = t("View all occurrences for exact dates and times.");
+            $modified_text_markup = "<span class='d-block font-italic'>* {$modified_text}</span>";
+          }
         }
 
         // Initialize the occurrences modal render array.
@@ -222,7 +240,7 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
         }
         if (!empty($recurrence_text)) {
           $build['field_az_event_date'][$item_index++] = [
-            '#markup' => "<p class='mb-3'>{$recurrence_text}</p>",
+            '#markup' => "<p class='mb-3'>{$recurrence_text}{$modified_text_markup}</p>",
           ];
         }
         if (isset($next_occurrence) && isset($add_to_calendar_button)) {

--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -34,6 +34,14 @@ function az_event_theme($existing, $type, $theme, $path) {
       ],
       'render element' => 'children',
     ],
+    'az_event_view_occurrences_button' => [
+      'variables' => [
+        'title' => NULL,
+        'items' => NULL,
+        'modal' => NULL,
+        'attributes' => NULL,
+      ],
+    ],
     'field__node__az_event' => [
       'template' => 'field--node--az-event',
       'base hook' => 'field',
@@ -150,17 +158,7 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
         $recurrence_text = ucfirst($recurr_text_transformer->transform($recurr_rule));
 
         // Initialize the accordion body render array.
-        $accordion_body = [
-          '#theme' => 'field',
-          '#title' => 'Event Occurrences',
-          '#label_display' => 'hidden',
-          '#field_name' => 'field_az_event_date_accordion',
-          '#field_type' => 'text',
-          "#entity_type" => 'node',
-          "#bundle" => 'az_event',
-          '#is_multiple' => 'true',
-          '#cache' => $build['field_az_event_date']['#cache'],
-        ];
+        $occurrences_modal = [];
         $item_index = 0;
 
         // Add any upcoming occurrences to the accordion body.
@@ -172,7 +170,7 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
             if (!isset($next_occurrence)) {
               $next_occurrence = $item->getName();
               $upcoming_events_heading = t("Upcoming Events");
-              $accordion_body[$item_index++] = [
+              $occurrences_modal[$item_index++] = [
                 '#markup' => "<h3 class='h5 mt-0'>{$upcoming_events_heading}</h3>",
               ];
               // Add to Calendar button for an event with multiple occurrences.
@@ -184,21 +182,21 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
                 '#description' => $entity->field_az_body->value ?? '',
                 '#location' => $entity->field_az_location->title ?? '',
                 '#modal' => Html::getUniqueId('calendar-link-modal'),
-                '#attributes' => ['class' => 'mb-card'],
+                '#attributes' => ['class' => 'mb-2'],
               ];
             }
-            $accordion_body[$item_index++] = $build['field_az_event_date'][$item->getName()];
+            $occurrences_modal[$item_index++] = $build['field_az_event_date'][$item->getName()];
           }
         }
 
         // Add any past occurrences to the accordion body.
         if (!isset($next_occurrence) || $next_occurrence !== 0) {
           $past_events_heading = t("Past Events");
-          $accordion_body[$item_index++] = [
+          $occurrences_modal[$item_index++] = [
             '#markup' => "<h3 class='h5" . (isset($next_occurrence) ? '' : ' mt-0') . "'>{$past_events_heading}</h3>",
           ];
           for ($i = 0; $i < ($next_occurrence ?? $number_of_occurrences); $i++) {
-            $accordion_body[$item_index++] = $build['field_az_event_date'][$i];
+            $occurrences_modal[$item_index++] = $build['field_az_event_date'][$i];
           }
         }
 
@@ -209,23 +207,21 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
           $next_event_text = t("Next event");
           $build['field_az_event_date'][$item_index]['#prefix'] = "<div class='mb-2'><strong>{$next_event_text}:</strong> ";
           $build['field_az_event_date'][$item_index++]['#suffix'] = '</div>';
-          if (isset($add_to_calendar_button)) {
-            $build['field_az_event_date'][$item_index++] = $add_to_calendar_button;
-          }
         }
         if (!empty($recurrence_text)) {
           $build['field_az_event_date'][$item_index++] = [
-            '#markup' => "<p class='mb-4'>{$recurrence_text}</p>",
+            '#markup' => "<p class='mb-3'>{$recurrence_text}</p>",
           ];
         }
+        if (isset($next_occurrence) && isset($add_to_calendar_button)) {
+          $build['field_az_event_date'][$item_index++] = $add_to_calendar_button;
+        }
         $build['field_az_event_date'][$item_index++] = [
-          '#theme' => 'az_accordion',
-          '#title' => t("View all occurrences"),
-          '#body' => $accordion_body,
-          '#attributes' => ['class' => 'accordion'],
-          '#accordion_item_id' => "event-" . $entity->id(),
-          '#collapsed' => 'collapse',
-          '#aria_expanded' => 'false',
+          '#theme' => 'az_event_view_occurrences_button',
+          '#title' => $entity->getTitle(),
+          '#items' => $occurrences_modal,
+          '#modal' => Html::getUniqueId('occurrences-modal'),
+          '#attributes' => ['class' => 'mb-2'],
         ];
         for ($i = $item_index; $i < $number_of_occurrences; $i++) {
           unset($build['field_az_event_date'][$i]);

--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -13,6 +13,9 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\node\Entity\NodeType;
 use Drupal\node\NodeInterface;
+use Recurr\Rule;
+use Recurr\Transformer\TextTransformer;
+use Recurr\Transformer\Translator;
 
 /**
  * Implements hook_theme().
@@ -115,6 +118,35 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
       $event_dates = $entity->field_az_event_date;
       $number_of_occurrences = $event_dates->count();
       if ($number_of_occurrences > 1) {
+        // Prepare the recurrence description text using the Recurr library.
+        $rule_index = $event_dates[0]->getValue()['rrule'];
+        /** @var \Drupal\smart_date_recur\Entity\SmartDateRule $smart_date_rule */
+        $smart_date_rule = \Drupal::entityTypeManager()->getStorage('smart_date_rule')->load($rule_index);
+        $recurr_rule = new Rule($smart_date_rule->getRule(), new \DateTime());
+
+        $default_langcode = \Drupal::languageManager()->getDefaultLanguage()->getId();
+        if ($default_langcode !== 'en') {
+          // Use the site's default language if possible.
+          try {
+            $recurr_translator = new Translator($default_langcode);
+            $recurr_text_transformer = new TextTransformer($recurr_translator);
+          }
+          catch (InvalidArgumentException $e) {
+            // No translation available for this langcode: fall back to 'en'.
+            $recurr_text_transformer = new TextTransformer();
+          }
+        }
+        else {
+          $recurr_text_transformer = new TextTransformer();
+        }
+
+        // Transform the recurrence rule to text.
+        $recurrence_text = ucfirst($recurr_text_transformer->transform($recurr_rule));
+        if ($default_langcode === 'en') {
+          // Replace "times" with "occurrences" for consistency.
+          $recurrence_text = str_replace('time', 'occurrence', $recurrence_text);
+        }
+
         // Initialize the accordion body build array.
         $accordion_body = $build['field_az_event_date'];
         foreach ($entity->field_az_event_date as $item) {
@@ -143,7 +175,7 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
                 '#description' => $entity->field_az_body->value ?? '',
                 '#location' => $entity->field_az_location->title ?? '',
                 '#modal' => Html::getUniqueId('calendar-link-modal'),
-                '#attributes' => ['class' => 'mb-4'],
+                '#attributes' => ['class' => 'pb-1 mb-4'],
               ];
             }
             $accordion_body[$item_index++] = $build['field_az_event_date'][$item->getName()];
@@ -162,11 +194,11 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
         }
 
         // Replace/unset the items in the build array for the field.
-        $item_index = 0;
+        $item_index = !empty($recurrence_text) ? 1 : 0;
         if (isset($next_occurrence)) {
           $build['field_az_event_date'][$item_index] = $build['field_az_event_date'][$next_occurrence];
           $next_event_text = t("Next event");
-          $build['field_az_event_date'][$item_index]['#prefix'] = "<div class='mb-3'><strong>{$next_event_text}:</strong> ";
+          $build['field_az_event_date'][$item_index]['#prefix'] = "<div class='mb-2'><strong>{$next_event_text}:</strong> ";
           $build['field_az_event_date'][$item_index]['#suffix'] = '</div>';
           $item_index++;
           if (isset($add_to_calendar_button)) {
@@ -185,6 +217,11 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
         ];
         for ($i = $item_index; $i < $number_of_occurrences; $i++) {
           unset($build['field_az_event_date'][$i]);
+        }
+        if (!empty($recurrence_text)) {
+          $build['field_az_event_date'][0] = [
+            '#markup' => "<p>{$recurrence_text}</p>",
+          ];
         }
       }
       else {

--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -149,11 +149,16 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
         // Transform the recurrence rule to text.
         $recurrence_text = ucfirst($recurr_text_transformer->transform($recurr_rule));
 
-        // Initialize the accordion body build array.
-        $accordion_body = $build['field_az_event_date'];
-        foreach ($entity->field_az_event_date as $item) {
-          unset($accordion_body[$item->getName()]);
-        }
+        // Initialize the accordion body render array.
+        $accordion_body = [
+          '#theme' => 'field',
+          '#label_display' => 'hidden',
+          '#field_name' => 'field_az_event_date_accordion',
+          '#field_type' => 'smartdate',
+          '#formatter' => 'daterange_ap_style',
+          '#is_multiple' => 'true',
+          '#cache' => $build['field_az_event_date']['#cache'],
+        ];
         $item_index = 0;
 
         // Add any upcoming occurrences to the accordion body.
@@ -195,14 +200,13 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
           }
         }
 
-        // Replace/unset the items in the build array for the field.
+        // Replace/unset the items in the render array for the field.
         $item_index = 0;
         if (isset($next_occurrence)) {
           $build['field_az_event_date'][$item_index] = $build['field_az_event_date'][$next_occurrence];
           $next_event_text = t("Next event");
           $build['field_az_event_date'][$item_index]['#prefix'] = "<div class='mb-2'><strong>{$next_event_text}:</strong> ";
-          $build['field_az_event_date'][$item_index]['#suffix'] = '</div>';
-          $item_index++;
+          $build['field_az_event_date'][$item_index++]['#suffix'] = '</div>';
           if (isset($add_to_calendar_button)) {
             $build['field_az_event_date'][$item_index++] = $add_to_calendar_button;
           }

--- a/modules/custom/az_event/templates/az-event-calendar-add-button.html.twig
+++ b/modules/custom/az_event/templates/az-event-calendar-add-button.html.twig
@@ -10,9 +10,9 @@
 
 <div{{ attributes }}>
   {# Button trigger modal #}
-  <button type="button" class="btn btn-hollow-primary btn-sm d-flex mr-2" data-toggle="modal" data-target="#{{ modal }}">
-    <span class="material-icons-sharp mr-2">event</span>
-    <span class="my-auto" style="text-transform: none">{{ 'Add to Calendar'|t }}</span>
+  <button type="button" class="btn btn-hollow-primary btn-sm d-flex mr-2" style="text-transform: none" data-toggle="modal" data-target="#{{ modal }}">
+    <span aria-hidden="true" class="material-icons-sharp mr-2">event</span>
+    <span class="my-auto">{{ 'Add to Calendar'|t }}</span>
   </button>
 
   {# Modal #}

--- a/modules/custom/az_event/templates/az-event-calendar-add-button.html.twig
+++ b/modules/custom/az_event/templates/az-event-calendar-add-button.html.twig
@@ -10,9 +10,9 @@
 
 <div{{ attributes }}>
   {# Button trigger modal #}
-  <button type="button" class="btn btn-hollow-primary btn-sm text-capitalize d-flex mr-2" data-toggle="modal" data-target="#{{ modal }}">
+  <button type="button" class="btn btn-hollow-primary btn-sm d-flex mr-2" data-toggle="modal" data-target="#{{ modal }}">
     <span class="material-icons-sharp mr-2">event</span>
-    <span class="my-auto">{{ 'Add to Calendar'|t }}</span>
+    <span class="my-auto" style="text-transform: none">{{ 'Add to Calendar'|t }}</span>
   </button>
 
   {# Modal #}

--- a/modules/custom/az_event/templates/az-event-calendar-add-button.html.twig
+++ b/modules/custom/az_event/templates/az-event-calendar-add-button.html.twig
@@ -6,22 +6,22 @@
 * @ingroup themeable
 */
 #}
-{% set attributes = attributes.addClass('clear-both') %}
 {% set links = calendar_links(title, date(start_date), date(end_date), FALSE, description, location) %}
 
 <div{{ attributes }}>
-  <!-- Button trigger modal -->
-  <button type="button" class="btn btn-hollow-primary btn-sm text-capitalize" data-toggle="modal" data-target="#{{ modal }}">
-    <span class="material-icons-sharp mr-2 align-bottom">calendar_month</span>{{ 'Add to Calendar'|t }}
+  {# Button trigger modal #}
+  <button type="button" class="btn btn-hollow-primary btn-sm text-capitalize d-flex mr-2" data-toggle="modal" data-target="#{{ modal }}">
+    <span class="material-icons-sharp mr-2">event</span>
+    <span class="my-auto">{{ 'Add to Calendar'|t }}</span>
   </button>
 
-  <!-- Modal -->
+  {# Modal #}
   <div id="{{ modal }}" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="{{ modal }}-label" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
       <div class="modal-content">
         <div class="modal-header px-0 mx-3">
           <div>
-            <h5 class="modal-title mt-1 mb-2" id="{{ modal }}-label">{{ 'Add Event to Calendar'|t }}</h5>
+            <h2 class="h5 modal-title mt-1 mb-2" id="{{ modal }}-label">{{ 'Add Event to Calendar'|t }}</h2>
             <p class="mb-0">{{ title }}</p>
             <p class="mb-0">{{ start_date|date('g:i a, F j, Y') }}</p>
           </div>

--- a/modules/custom/az_event/templates/az-event-view-occurrences-button.html.twig
+++ b/modules/custom/az_event/templates/az-event-view-occurrences-button.html.twig
@@ -8,9 +8,9 @@
 #}
 <div{{ attributes }}>
   {# Button trigger modal #}
-  <button type="button" class="btn btn-hollow-primary btn-sm text-capitalize d-flex" data-toggle="modal" data-target="#{{ modal }}">
+  <button type="button" class="btn btn-hollow-primary btn-sm d-flex" data-toggle="modal" data-target="#{{ modal }}">
     <span class="material-icons-sharp mr-2">event_repeat</span>
-    <span class="my-auto">{{ 'View All Occurrences'|t }}</span>
+    <span class="my-auto" style="text-transform: none">{{ 'View All Occurrences'|t }}</span>
   </button>
 
   {# Modal #}

--- a/modules/custom/az_event/templates/az-event-view-occurrences-button.html.twig
+++ b/modules/custom/az_event/templates/az-event-view-occurrences-button.html.twig
@@ -8,9 +8,9 @@
 #}
 <div{{ attributes }}>
   {# Button trigger modal #}
-  <button type="button" class="btn btn-hollow-primary btn-sm d-flex" data-toggle="modal" data-target="#{{ modal }}">
-    <span class="material-icons-sharp mr-2">event_repeat</span>
-    <span class="my-auto" style="text-transform: none">{{ 'View All Occurrences'|t }}</span>
+  <button type="button" class="btn btn-hollow-primary btn-sm d-flex" style="text-transform: none" data-toggle="modal" data-target="#{{ modal }}">
+    <span aria-hidden="true" class="material-icons-sharp mr-2">event_repeat</span>
+    <span class="my-auto">{{ 'View All Occurrences'|t }}</span>
   </button>
 
   {# Modal #}

--- a/modules/custom/az_event/templates/az-event-view-occurrences-button.html.twig
+++ b/modules/custom/az_event/templates/az-event-view-occurrences-button.html.twig
@@ -1,0 +1,36 @@
+{#
+/**
+* @file
+* Default theme implementation to display a View All Occurrences button.
+*
+* @ingroup themeable
+*/
+#}
+<div{{ attributes }}>
+  {# Button trigger modal #}
+  <button type="button" class="btn btn-hollow-primary btn-sm text-capitalize d-flex" data-toggle="modal" data-target="#{{ modal }}">
+    <span class="material-icons-sharp mr-2">event_repeat</span>
+    <span class="my-auto">{{ 'View All Occurrences'|t }}</span>
+  </button>
+
+  {# Modal #}
+  <div id="{{ modal }}" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="{{ modal }}-label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <div class="modal-header px-0 mx-3 pb-2">
+          <div>
+            <h2 class="h5 modal-title mt-1 mb-2" id="{{ modal }}-label">{{ title }}</h2>
+          </div>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body mb-1">
+          {% for item in items %}
+            <div>{{ item }}</div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/modules/custom/az_event/templates/field--node--az-event.html.twig
+++ b/modules/custom/az_event/templates/field--node--az-event.html.twig
@@ -41,7 +41,11 @@
   {% if multiple %}
     <div{{ attributes.addClass(classes, 'field__items') }}>
       {% for item in items %}
-        <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+        {% if item.content['#modal'] %}
+          <div{{ item.attributes.addClass('d-inline-block') }}>{{ item.content }}</div>
+        {% else %}
+          <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+        {% endif %}
       {% endfor %}
     </div>
   {% else %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
This PR does the following:
 - Adds a short description of the recurrence on the page for a recurring event.
   - This description will always end with "until <end_date>", where <end_date> is the date of the final occurrence.
   - If recurrence instances have been modified or if additional single occurrences have been added to the event date field, help text stating "View all occurrences for exact dates and times." will be added below the recurrence description.
   - The description will be automatically translated to the language of the event if that translation is supported by the [Recurr library](/simshaun/recurr).
 - Changes the "View all occurrences" accordion to be a modal triggered by a button, just like the "Add to Calendar" modal.
 - Updates the heading elements of both modals to be h2 instead of h5.
 - Updates the modal buttons to use flex to provide better vertical centering of elements (especially if sites may override the size of material icons).

Questions:
1. When a recurring event uses "ends after X times" and has had occurrences removed, should the event page reflect the original rule or the actual, final number of occurrences?
   - (Apr 4, 2025) ~~Yes, change the number of occurrences to the actual number.~~ The recurrence description now always uses the format showing the end date, per @joshuasosa's suggestion below.
2. If occurrences have been removed, should a note be added to the recurrence description as well (e.g., "Some occurrences modified")?
   - (Apr 4, 2025) Yes, include some sort of message noting that the recurrence has been modified.
   - (Update Apr 4, 2025) Is this message no longer necessary, now that the text always uses the "until X date" format?
   - (Update Apr 11, 2025) A message has been added stating, "View all occurrences for exact dates and times."
3. (From @danahertzberg) Should the recurrence description line come first and the next event line second?
   - If so, is it OK to remove the boldface from "Next event"? (I think removing it would be best.)
   - (Apr 9, 2025) For now, we'll leave the current order, but further feedback is welcome!
4. (From @joshuasosa) Should the list of occurrences in the "View all occurrences" modal show the date first followed by the time?
   - I think we should make this change either for the entire display (full content) or for all event date/times throughout the site.
   - (Apr 9, 2025) Per AZ Digital discussion, changing the date format would be a question related to our brand guidelines and AP style. This change would need to be discussed as part of a follow-up issue.
5. Does the following make sense when an editor uses "Add another item" to set multiple event date field values?
   - If there is one recurring event with one or more single event: the "next event" text and recurrence description are displayed as usual (potentially with an "event modified" message).
   - If there are no recurring events or multiple recurring events, the "next event" text is displayed but the recurrence description is NOT displayed.
   - (Apr 9, 2025) Per AZ Digital discussion, this behavior will work.

To do:
- [x]  - Handle multiple event date field values (including combinations of recurring and non-recurring events)
- [x]  - Sort list of occurrences when there are multiple event date field values
- [x]  - Any remaining styling improvements
- [x]  - Accessibility review

Follow-up issues:
 - Allow for adding any occurrence to a calendar
 - Add `aria-hidden="true"` to other instances of Material icons in Quickstart
 - Change date formats?

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 - #4190 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4196.probo.build

1. Confirm that pages for recurring events display a text description of the recurrence with an acceptable style.
2. Confirm that when a recurring event is set to end after X occurrences, the event page has a recurrence description that indicates the last occurrence date instead.
3. Confirm that when a recurring event is set to end on a date that is different from the last occurrence date, the event page has a recurrence description that indicates the last occurrence date instead.
4. Confirm that occurrences are always listed chronologically.
5. Confirm that pages for single events are unchanged.

Example events:

- Some future instances, some past, many occurrences: [Weekend Canyon Running Training](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4196.probo.build/events/weekend-canyon-running-training)
- [Recurring event with overrides](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4196.probo.build/events/recurring-event-overrides)
- [Individual occurrence with a repeating occurrence](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4196.probo.build/events/individual-occurrence-repeating-occurrence)
- [Multiple individual occurrences](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4196.probo.build/events/multiple-individual-occurrences)
- All future instances: [Skeptical Astronomy Literature Survey](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4196.probo.build/events/skeptical-astronomy-literature-survey)
- All past instances: [Planetary Engineering II (advanced topics)](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4196.probo.build/events/planetary-engineering-ii-advanced-topics)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [x] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
