### PR TITLE
[Branch of issue/4190] Change event occurrences accordion to a modal

### DIFF
--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -34,6 +34,14 @@ function az_event_theme($existing, $type, $theme, $path) {
       ],
       'render element' => 'children',
     ],
+    'az_event_view_occurrences_button' => [
+      'variables' => [
+        'title' => NULL,
+        'items' => NULL,
+        'modal' => NULL,
+        'attributes' => NULL,
+      ],
+    ],
     'field__node__az_event' => [
       'template' => 'field--node--az-event',
       'base hook' => 'field',
@@ -150,17 +158,7 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
         $recurrence_text = ucfirst($recurr_text_transformer->transform($recurr_rule));
 
         // Initialize the accordion body render array.
-        $accordion_body = [
-          '#theme' => 'field',
-          '#title' => 'Event Occurrences',
-          '#label_display' => 'hidden',
-          '#field_name' => 'field_az_event_date_accordion',
-          '#field_type' => 'text',
-          "#entity_type" => 'node',
-          "#bundle" => 'az_event',
-          '#is_multiple' => 'true',
-          '#cache' => $build['field_az_event_date']['#cache'],
-        ];
+        $occurrences_modal = [];
         $item_index = 0;
 
         // Add any upcoming occurrences to the accordion body.
@@ -172,7 +170,7 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
             if (!isset($next_occurrence)) {
               $next_occurrence = $item->getName();
               $upcoming_events_heading = t("Upcoming Events");
-              $accordion_body[$item_index++] = [
+              $occurrences_modal[$item_index++] = [
                 '#markup' => "<h3 class='h5 mt-0'>{$upcoming_events_heading}</h3>",
               ];
               // Add to Calendar button for an event with multiple occurrences.
@@ -184,21 +182,21 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
                 '#description' => $entity->field_az_body->value ?? '',
                 '#location' => $entity->field_az_location->title ?? '',
                 '#modal' => Html::getUniqueId('calendar-link-modal'),
-                '#attributes' => ['class' => 'mb-card'],
+                '#attributes' => ['class' => 'mb-2'],
               ];
             }
-            $accordion_body[$item_index++] = $build['field_az_event_date'][$item->getName()];
+            $occurrences_modal[$item_index++] = $build['field_az_event_date'][$item->getName()];
           }
         }
 
         // Add any past occurrences to the accordion body.
         if (!isset($next_occurrence) || $next_occurrence !== 0) {
           $past_events_heading = t("Past Events");
-          $accordion_body[$item_index++] = [
+          $occurrences_modal[$item_index++] = [
             '#markup' => "<h3 class='h5" . (isset($next_occurrence) ? '' : ' mt-0') . "'>{$past_events_heading}</h3>",
           ];
           for ($i = 0; $i < ($next_occurrence ?? $number_of_occurrences); $i++) {
-            $accordion_body[$item_index++] = $build['field_az_event_date'][$i];
+            $occurrences_modal[$item_index++] = $build['field_az_event_date'][$i];
           }
         }
 
@@ -209,23 +207,21 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
           $next_event_text = t("Next event");
           $build['field_az_event_date'][$item_index]['#prefix'] = "<div class='mb-2'><strong>{$next_event_text}:</strong> ";
           $build['field_az_event_date'][$item_index++]['#suffix'] = '</div>';
-          if (isset($add_to_calendar_button)) {
-            $build['field_az_event_date'][$item_index++] = $add_to_calendar_button;
-          }
         }
         if (!empty($recurrence_text)) {
           $build['field_az_event_date'][$item_index++] = [
-            '#markup' => "<p class='mb-4'>{$recurrence_text}</p>",
+            '#markup' => "<p class='mb-3'>{$recurrence_text}</p>",
           ];
         }
+        if (isset($next_occurrence) && isset($add_to_calendar_button)) {
+          $build['field_az_event_date'][$item_index++] = $add_to_calendar_button;
+        }
         $build['field_az_event_date'][$item_index++] = [
-          '#theme' => 'az_accordion',
-          '#title' => t("View all occurrences"),
-          '#body' => $accordion_body,
-          '#attributes' => ['class' => 'accordion'],
-          '#accordion_item_id' => "event-" . $entity->id(),
-          '#collapsed' => 'collapse',
-          '#aria_expanded' => 'false',
+          '#theme' => 'az_event_view_occurrences_button',
+          '#title' => $entity->getTitle(),
+          '#items' => $occurrences_modal,
+          '#modal' => Html::getUniqueId('occurrences-modal'),
+          '#attributes' => ['class' => 'mb-2'],
         ];
         for ($i = $item_index; $i < $number_of_occurrences; $i++) {
           unset($build['field_az_event_date'][$i]);

--- a/modules/custom/az_event/templates/az-event-calendar-add-button.html.twig
+++ b/modules/custom/az_event/templates/az-event-calendar-add-button.html.twig
@@ -6,13 +6,13 @@
 * @ingroup themeable
 */
 #}
-{% set attributes = attributes.addClass('clear-both') %}
 {% set links = calendar_links(title, date(start_date), date(end_date), FALSE, description, location) %}
 
 <div{{ attributes }}>
   <!-- Button trigger modal -->
-  <button type="button" class="btn btn-hollow-primary btn-sm text-capitalize" data-toggle="modal" data-target="#{{ modal }}">
-    <span class="material-icons-sharp mr-2 align-bottom">calendar_month</span>{{ 'Add to Calendar'|t }}
+  <button type="button" class="btn btn-hollow-primary btn-sm text-capitalize d-flex mr-2" data-toggle="modal" data-target="#{{ modal }}">
+    <span class="material-icons-sharp mr-2">event</span>
+    <span class="my-auto">{{ 'Add to Calendar'|t }}</span>
   </button>
 
   <!-- Modal -->

--- a/modules/custom/az_event/templates/az-event-calendar-add-button.html.twig
+++ b/modules/custom/az_event/templates/az-event-calendar-add-button.html.twig
@@ -9,19 +9,19 @@
 {% set links = calendar_links(title, date(start_date), date(end_date), FALSE, description, location) %}
 
 <div{{ attributes }}>
-  <!-- Button trigger modal -->
+  {# Button trigger modal #}
   <button type="button" class="btn btn-hollow-primary btn-sm text-capitalize d-flex mr-2" data-toggle="modal" data-target="#{{ modal }}">
     <span class="material-icons-sharp mr-2">event</span>
     <span class="my-auto">{{ 'Add to Calendar'|t }}</span>
   </button>
 
-  <!-- Modal -->
+  {# Modal #}
   <div id="{{ modal }}" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="{{ modal }}-label" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
       <div class="modal-content">
         <div class="modal-header px-0 mx-3">
           <div>
-            <h5 class="modal-title mt-1 mb-2" id="{{ modal }}-label">{{ 'Add Event to Calendar'|t }}</h5>
+            <h2 class="h5 modal-title mt-1 mb-2" id="{{ modal }}-label">{{ 'Add Event to Calendar'|t }}</h2>
             <p class="mb-0">{{ title }}</p>
             <p class="mb-0">{{ start_date|date('g:i a, F j, Y') }}</p>
           </div>

--- a/modules/custom/az_event/templates/az-event-view-occurrences-button.html.twig
+++ b/modules/custom/az_event/templates/az-event-view-occurrences-button.html.twig
@@ -6,21 +6,20 @@
 * @ingroup themeable
 */
 #}
-
 <div{{ attributes }}>
-  <!-- Button trigger modal -->
+  {# Button trigger modal #}
   <button type="button" class="btn btn-hollow-primary btn-sm text-capitalize d-flex" data-toggle="modal" data-target="#{{ modal }}">
     <span class="material-icons-sharp mr-2">event_repeat</span>
     <span class="my-auto">{{ 'View All Occurrences'|t }}</span>
   </button>
 
-  <!-- Modal -->
+  {# Modal #}
   <div id="{{ modal }}" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="{{ modal }}-label" aria-hidden="true">
     <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered" role="document">
       <div class="modal-content">
         <div class="modal-header px-0 mx-3 pb-2">
           <div>
-            <h5 class="modal-title mt-1 mb-2" id="{{ modal }}-label">{{ title }}</h5>
+            <h2 class="h5 modal-title mt-1 mb-2" id="{{ modal }}-label">{{ title }}</h2>
           </div>
           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">&times;</span>

--- a/modules/custom/az_event/templates/az-event-view-occurrences-button.html.twig
+++ b/modules/custom/az_event/templates/az-event-view-occurrences-button.html.twig
@@ -1,0 +1,37 @@
+{#
+/**
+* @file
+* Default theme implementation to display a View All Occurrences button.
+*
+* @ingroup themeable
+*/
+#}
+
+<div{{ attributes }}>
+  <!-- Button trigger modal -->
+  <button type="button" class="btn btn-hollow-primary btn-sm text-capitalize d-flex" data-toggle="modal" data-target="#{{ modal }}">
+    <span class="material-icons-sharp mr-2">event_repeat</span>
+    <span class="my-auto">{{ 'View All Occurrences'|t }}</span>
+  </button>
+
+  <!-- Modal -->
+  <div id="{{ modal }}" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="{{ modal }}-label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered" role="document">
+      <div class="modal-content">
+        <div class="modal-header px-0 mx-3 pb-2">
+          <div>
+            <h5 class="modal-title mt-1 mb-2" id="{{ modal }}-label">{{ title }}</h5>
+          </div>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body mb-1">
+          {% for item in items %}
+            <div>{{ item }}</div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/modules/custom/az_event/templates/field--node--az-event.html.twig
+++ b/modules/custom/az_event/templates/field--node--az-event.html.twig
@@ -41,7 +41,11 @@
   {% if multiple %}
     <div{{ attributes.addClass(classes, 'field__items') }}>
       {% for item in items %}
-        <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+        {% if item.content['#modal'] %}
+          <div{{ item.attributes.addClass('d-inline-block') }}>{{ item.content }}</div>
+        {% else %}
+          <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+        {% endif %}
       {% endfor %}
     </div>
   {% else %}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

This PR is a branch of the issue/4190 branch as tracked in this PR:
 - #4190 

This PR demonstrates an alternate option for displaying the list of event occurrences on an event page. Instead of displaying them in an accordion, this PR places them in a modal in the same way as the Add to Calendar functionality.

This PR also makes some updates to the existing Add to Calendar button styling, mainly to allow the two buttons to appear next to each other. Another improvement is added to make the buttons display with flex for better vertical centering of their contained elements.

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Probo review site: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4208.probo.build

Example events:

- Some future instances, some past, many occurrences: [Weekend Canyon Running Training](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4208.probo.build/events/weekend-canyon-running-training)
- All future instances: [Skeptical Astronomy Literature Survey](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4208.probo.build/events/skeptical-astronomy-literature-survey)
- All past instances: [Planetary Engineering II (advanced topics)](https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4208.probo.build/events/planetary-engineering-ii-advanced-topics)