### PR TITLE
[Branch for PR 4195] Styling fixes for left-aligned content

### DIFF
--- a/modules/custom/az_core/css/claro-node-form-overrides.css
+++ b/modules/custom/az_core/css/claro-node-form-overrides.css
@@ -44,5 +44,5 @@ tr.odd {
 .align-left ~ ol {
   overflow: auto;
   overflow-wrap: anywhere;
-  padding-inline-start: 40px;
+  padding-inline-start: revert;
 }

--- a/modules/custom/az_core/css/claro-node-form-overrides.css
+++ b/modules/custom/az_core/css/claro-node-form-overrides.css
@@ -24,3 +24,25 @@
 tr.odd {
   background-color: #eee;
 }
+
+/** 
+ * Match styling of node form with that of style.css.
+ * See https://github.com/az-digital/az_quickstart/pull/4195.
+ */
+@media screen and (min-width: 576px) {
+  .align-left {
+    margin-right: 1em;
+    margin-bottom: 0.7em;
+  }
+  .align-right {
+    margin-left: 1em;
+    margin-bottom: 0.7em;
+  }
+}
+
+.align-left ~ ul,
+.align-left ~ ol {
+  overflow: auto;
+  overflow-wrap: anywhere;
+  padding-inline-start: 40px;
+}

--- a/themes/custom/az_barrio/css/ckeditor5.css
+++ b/themes/custom/az_barrio/css/ckeditor5.css
@@ -74,5 +74,5 @@
 .ck-widget.drupal-media-style-align-left ~ ol {
   overflow: auto;
   overflow-wrap: anywhere;
-  padding-inline-start: 40px;
+  padding-inline-start: revert;
 }

--- a/themes/custom/az_barrio/css/ckeditor5.css
+++ b/themes/custom/az_barrio/css/ckeditor5.css
@@ -62,3 +62,17 @@
 .ck-dropdown__panel .ck.ck-style-panel .ck-style-grid .ck-disabled {
   display: none;
 }
+
+/** 
+ * Match editor styling with that of style.css.
+ * See https://github.com/az-digital/az_quickstart/pull/4195.
+ */
+.ck .ck-content .drupal-media-style-align-left {
+  margin-right: 0;
+}
+.ck-widget.drupal-media-style-align-left ~ ul,
+.ck-widget.drupal-media-style-align-left ~ ol {
+  overflow: auto;
+  overflow-wrap: anywhere;
+  padding-inline-start: 40px;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR is a branch of the `4047-when-using-inline-image-text-wrap-bulleted-text-needs-more-left-padding` branch as tracked in this PR:
 - #4195

This PR adds some styling to two CSS files:

- claro-node-form-overrides.css: Copies some styling from style.css so the node edit form can match the published page. Also includes styling fixes for sibling list elements, including a `padding-inline-start` value to revert from 0px (the override from the Claro theme) to 40px (from the browser user agent stylesheet).
- ckeditor5.css: Includes the same styling fixes for sibling list elements. Also removes the `margin-right` since that is being added with our Claro overrides now.

This solution seems to work but it would be good to do more testing with varied content to ensure it doesn't cause any unwanted side effects.

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

https://37d4d6cf-4042-4492-9ac4-523fd71b504f.probo.build