### PR TITLE
Closes #4253: Invalid ARIA attribute on Person tab

### DIFF
--- a/modules/custom/az_person/templates/horizontal-tabs--node--az-person--group-tabs.html.twig
+++ b/modules/custom/az_person/templates/horizontal-tabs--node--az-person--group-tabs.html.twig
@@ -26,7 +26,7 @@
       {% set isFirstTab = true %}
       {% for key, value in tabElements %}
         <li class="nav-item ml-nmin mt-nmin border-right" role="presentation">
-          <a class="nav-link{{ isFirstTab ? ' active' }}" id="{{ (key) }}_tab" data-toggle="tab" href="#{{ (value['#id']) }}" role="tab" aria-controls="{{ (value['#id']) }}" aria-selected="{{ isFirstTab }}">{{ (value['#title']) }}</a>
+          <a class="nav-link{{ isFirstTab ? ' active' }}" id="{{ (key) }}_tab" data-toggle="tab" href="#{{ (value['#id']) }}" role="tab" aria-controls="{{ (value['#id']) }}" aria-selected="{{ isFirstTab ? 'true' : 'false' }}">{{ (value['#title']) }}</a>
         </li>
         {% set isFirstTab = false %}
       {% endfor %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
This PR corrects the value used for the aria-selected attribute on horizontal tabs on AZ Person pages.


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 - #4253 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4254.probo.build

Visit person pages and confirm that the Experience tab has an `aria-selected` attribute value of "true". If the page includes an Interests tab as well, confirm that the value is "false".

#### Example pages:
 - https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4254.probo.build/person/wilbur-wildcat
 - https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4254.probo.build/person/wilma-wildcat

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
