### PR TITLE
Closes #2403: Save UUIDs when importing Quickstart config overrides to prevent deprecation warnings.

### DIFF
--- a/modules/custom/az_core/az_core.post_update.php
+++ b/modules/custom/az_core/az_core.post_update.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Post-update functions for AZ Core module.
+ */
+
+use Drupal\az_core\Plugin\ConfigProvider\QuickstartConfigProvider;
+
+/**
+ * Add missing UUIDs to existing Quickstart override config entities.
+ */
+function az_core_post_update_add_missing_config_uuids() {
+  // Get all QuicsktartConfigProvider config data.
+  $override_config_data = [];
+  $providers = \Drupal::service('config_provider.collector')->getConfigProviders();
+  foreach ($providers as $provider) {
+    if ($provider instanceof QuickstartConfigProvider) {
+      $extension_lister = \Drupal::service('extension.list.module');
+      $installed = array_intersect_key($extension_lister->getList(), $extension_lister->getAllInstalledInfo());
+      $override_config_data = $provider->getOnlyOverrideConfig($installed);
+    }
+  }
+
+  // Generate UUID if one doesn't exist (for config entities only).
+  foreach (array_keys($override_config_data) as $name) {
+    if (\Drupal::service('config.manager')->getEntityTypeIdByName($name)) {
+      $config = \Drupal::service('config.factory')->getEditable($name);
+      if ($config->get('uuid') === NULL) {
+        $config->set('uuid', \Drupal::service('uuid')->generate());
+        $config->save();
+        // \Drupal::service('config.storage')->write($name, $config->getRawData());
+        \Drupal::logger('az_core')->notice("Added missing UUID to @config_id.", [
+          '@config_id' => $name,
+        ]);
+      }
+    }
+  }
+}

--- a/modules/custom/az_core/az_core.post_update.php
+++ b/modules/custom/az_core/az_core.post_update.php
@@ -29,7 +29,6 @@ function az_core_post_update_add_missing_config_uuids() {
       if ($config->get('uuid') === NULL) {
         $config->set('uuid', \Drupal::service('uuid')->generate());
         $config->save();
-        // \Drupal::service('config.storage')->write($name, $config->getRawData());
         \Drupal::logger('az_core')->notice("Added missing UUID to @config_id.", [
           '@config_id' => $name,
         ]);

--- a/modules/custom/az_core/az_core.post_update.php
+++ b/modules/custom/az_core/az_core.post_update.php
@@ -11,7 +11,7 @@ use Drupal\az_core\Plugin\ConfigProvider\QuickstartConfigProvider;
  * Add missing UUIDs to existing Quickstart override config entities.
  */
 function az_core_post_update_add_missing_config_uuids() {
-  // Get all QuicsktartConfigProvider config data.
+  // Get all QuickstartConfigProvider config data.
   $override_config_data = [];
   $providers = \Drupal::service('config_provider.collector')->getConfigProviders();
   foreach ($providers as $provider) {

--- a/modules/custom/az_core/az_core.services.yml
+++ b/modules/custom/az_core/az_core.services.yml
@@ -24,6 +24,8 @@ services:
       - '@config_sync.snapshotter'
       - '@config_update.config_list'
       - '@module_handler'
+      - '@config.manager'
+      - '@uuid'
   # Decorates the normal user module links.
   az_core.toolbar_link_builder:
     class: Drupal\az_core\AZUserToolbarLinkBuilder

--- a/modules/custom/az_core/src/AZConfigOverride.php
+++ b/modules/custom/az_core/src/AZConfigOverride.php
@@ -124,7 +124,7 @@ class AZConfigOverride implements LoggerAwareInterface {
           ]);
           $config = $this->configFactory->getEditable($name);
           // Generate a UUID for the configuration if one doesn't exist.
-          $data['uuid'] = $config->get('uuid') ?? $data['uuid'] ?? \Drupal::service('uuid')->generate();  
+          $data['uuid'] = $config->get('uuid') ?? $data['uuid'] ?? \Drupal::service('uuid')->generate();
           $config->setData($data);
           $config->Save();
 

--- a/modules/custom/az_core/src/AZConfigOverride.php
+++ b/modules/custom/az_core/src/AZConfigOverride.php
@@ -124,9 +124,7 @@ class AZConfigOverride implements LoggerAwareInterface {
           ]);
           $config = $this->configFactory->getEditable($name);
           // Generate a UUID for the configuration if one doesn't exist.
-          if (!isset($data['uuid']) || empty($data['uuid'])) {
-            $data['uuid'] = \Drupal::service('uuid')->generate();
-          }
+          $data['uuid'] = $config->get('uuid') ?? $data['uuid'] ?? \Drupal::service('uuid')->generate();  
           $config->setData($data);
           $config->Save();
 

--- a/modules/custom/az_core/src/AZConfigOverride.php
+++ b/modules/custom/az_core/src/AZConfigOverride.php
@@ -75,14 +75,14 @@ class AZConfigOverride implements LoggerAwareInterface {
 
   /**
    * Drupal\Core\Config\ConfigManager definition.
-   * 
+   *
    * @var \Drupal\Core\Config\ConfigManager
    */
   protected $configManager;
 
   /**
    * Drupal\Component\Uuid\UuidInterface definition.
-   * 
+   *
    * @var \Drupal\Component\Uuid\UuidInterface
    */
   protected $uuidService;

--- a/modules/custom/az_core/src/AZConfigOverride.php
+++ b/modules/custom/az_core/src/AZConfigOverride.php
@@ -123,6 +123,10 @@ class AZConfigOverride implements LoggerAwareInterface {
             '@config_id' => $name,
           ]);
           $config = $this->configFactory->getEditable($name);
+          // Generate a UUID for the configuration if one doesn't exist.
+          if (!isset($data['uuid']) || empty($data['uuid'])) {
+            $data['uuid'] = \Drupal::service('uuid')->generate();
+          }
           $config->setData($data);
           $config->Save();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Updates `AZConfigOverride::importOverrides()` to include step to ensure UUIDs exist on imported config entities.

This should resolve issues we've seen with the following deprecation error showing up in various contexts for override configs:
```
Deprecated function: mb_strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in Drupal\Core\Config\Entity\Query\Condition->compile() (line 39 of core/lib/Drupal/Core/Config/Entity/Query/Condition.php).
```

### Release notes
<!--- Delete this line (and the closing comment line) to enable release notes.

If this change requires release notes: provide a summary of changes, how to use this change, and any related links. This content will be pasted in the [release notes](https://github.com/az-digital/az_quickstart/releases). Use markdown format to ensure proper pasting of information. [Release notes example](https://github.com/az-digital/az_quickstart/releases/tag/2.11.0)

Make sure to add the `release notes` label to this PR.

```
Add markdown of release notes here.
```

Delete this line to enable release notes.  -->


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #2403

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [x] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
