### PR TITLE
Closes #4266: Revert removal of jquery_ui_slider and jquery_ui_touch_punch

### DIFF
--- a/az_quickstart.install
+++ b/az_quickstart.install
@@ -73,6 +73,8 @@ function az_quickstart_requirements($phase) {
 
     // Gather all deprecated modules that are enabled.
     $azqs_deprecated_modules = [
+      'jquery_ui_slider',
+      'jquery_ui_touch_punch',
       'media_migration',
     ];
     $enabled_deprecated_modules = [];

--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,8 @@
         "drupal/intelligencebank": "5.1.0",
         "drupal/jquery_ui": "1.7.0",
         "drupal/jquery_ui_datepicker": "2.1.1",
+        "drupal/jquery_ui_slider": "*",
+        "drupal/jquery_ui_touch_punch": "*",
         "drupal/link_class": "2.2.0",
         "drupal/linkit": "7.0.3",
         "drupal/masquerade": "2.0.0",
@@ -128,6 +130,7 @@
         "npm-asset/blazy": "1.8.2",
         "npm-asset/bootstrap-datepicker": "1.10.0",
         "npm-asset/easepick--bundle": "1.2.1",
+        "npm-asset/jquery-ui-touch-punch": "*",
         "npm-asset/slick-carousel": "1.8.0",
         "renanbr/bibtex-parser": "2.2.0",
         "seboettg/citeproc-php": "2.6.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Reverts the removal of jquery_ui_slider and jquery_ui_touch_punch from #4239. These modules remain deprecated and will be removed with Quickstart 2.14.

### Release notes
<!--- Delete this line (and the closing comment line) to enable release notes.

If this change requires release notes: provide a summary of changes, how to use this change, and any related links. This content will be pasted in the [release notes](https://github.com/az-digital/az_quickstart/releases). Use markdown format to ensure proper pasting of information. [Release notes example](https://github.com/az-digital/az_quickstart/releases/tag/2.11.0)

Make sure to add the `release notes` label to this PR.

```
Add markdown of release notes here.
```

Delete this line to enable release notes.  -->


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #4266

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
