### PR TITLE
Close #4267 SCTASK0067034 Remove 'Annual Security Report.' link from global footer.

### DIFF
--- a/modules/custom/az_global_footer/az_global_footer.install
+++ b/modules/custom/az_global_footer/az_global_footer.install
@@ -420,3 +420,37 @@ function az_global_footer_update_1021204() {
 
   return t('Updated %count Title IX / Non-Discrimination menu link(s) in the global footer.', ['%count' => $updated_count]);
 }
+
+/**
+ * Remove "Annual Security Report" link from Global Footer (#4067)
+ */
+function az_global_footer_update_1021205() {
+  $updated_count = 0;
+  $menu_link_content_ids = \Drupal::entityQuery('menu_link_content')
+    ->accessCheck(FALSE)
+    ->condition('menu_name', 'az-footer-main')
+    ->condition('title', 'Annual Security Report')
+    ->condition('link__uri', 'https://clery.arizona.edu/asr')
+    ->execute();
+
+      foreach ($menu_link_content_ids as $id) {
+    /** @var \Drupal\menu_link_content\Entity\MenuLinkContent $menu_link_content */
+    $menu_link_content = MenuLinkContent::load($id);
+    if ($menu_link_content !== NULL) {
+      if ($menu_link_content->getTitle() === 'Annual Security Report' && $menu_link_content->getUrlObject()->toString() === 'https://clery.arizona.edu/asr') {
+        $annual_security_report_link_ids[] = $id;
+        $annual_security_report_link_weight = $menu_link_content->getWeight();
+        $menu_link_content->delete();
+      }
+    }
+    // Update the weights of links to fill the gap left by
+    // the deleted 'Annual Security Report' link.
+    if ($annual_security_report_link_weight !== NULL) {
+      $weight = $menu_link_content->getWeight();
+      if ($menu_link_content->getWeight() > $annual_security_report_link_weight) {
+        $menu_link_content->set('weight', --$weight);
+        $menu_link_content->save();
+      }
+    }
+  }
+}

--- a/modules/custom/az_global_footer/data/az_global_footer.json
+++ b/modules/custom/az_global_footer/data/az_global_footer.json
@@ -45,17 +45,6 @@
       "weight": "4"
     },
     {
-      "link_id": "5",
-      "parent_link_id": "0",
-      "menu": "az-footer-main",
-      "title": "Annual Security Report",
-      "urlpath": "https://clery.arizona.edu/asr",
-      "external": true,
-      "expanded": false,
-      "enabled": true,
-      "weight": "5"
-    },
-    {
       "link_id": "6",
       "parent_link_id": "0",
       "menu": "az-footer-main",


### PR DESCRIPTION
## Description
Remove 'Annual Security Report.' link from global footer.

## Related issues
Close #4267
Also SCTASK0067034


## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [x] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
