### PR TITLE
Fixes #4284 Check for absent config entities in az_core_post_update_add_missing_config_uuids

### DIFF
--- a/modules/custom/az_core/az_core.post_update.php
+++ b/modules/custom/az_core/az_core.post_update.php
@@ -26,7 +26,7 @@ function az_core_post_update_add_missing_config_uuids() {
   foreach (array_keys($override_config_data) as $name) {
     if (\Drupal::service('config.manager')->getEntityTypeIdByName($name)) {
       $config = \Drupal::service('config.factory')->getEditable($name);
-      if ($config->get('uuid') === NULL) {
+      if (!$config->isNew() && ($config->get('uuid') === NULL)) {
         $config->set('uuid', \Drupal::service('uuid')->generate());
         $config->save();
         \Drupal::logger('az_core')->notice("Added missing UUID to @config_id.", [


### PR DESCRIPTION
## Description
The `az_core_post_update_add_missing_config_uuids` post_update can inadvertently create an empty, plugin-less config entity in cases where one of the config override items has been deleted from the site's active configuration. This is generally uncommon, because many of those overridden entites are critical to Quickstart.

This PR makes the DB post update check to make sure entities actually existed before creating a UUID for them.

## Related issues
#4284 

## How to test
- Run DB updates on a `2.12.12` site that have had the `search.page.node_search` config forcibly deleted.
- Verify that no new `search.page.node_search` config is created by the update

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
