### PR TITLE
Fixes #4291 AZ Event View Caching

### DIFF
--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -121,6 +121,11 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
       }
     }
 
+    // Cache events per route to avoid cache issues from different views.
+    // Each page view has its own route.
+    // @todo do we need to be concerned about multiple view blocks of the same events per page?
+    $build['#cache']['contexts'][] = 'route.name';
+
     // For the full content view mode, modify the display of az_event_date.
     if (($view_mode === 'full') && ($entity instanceof NodeInterface)) {
       $now = \Drupal::time()->getCurrentTime();


### PR DESCRIPTION
Quickstart has custom functionality that causes rendered events in views to  have their date field trimmed so that only the recurrence for the delta associated with that date shows in the rendered event.

This doesn't take into account that not every view has this functionality, and so that views which render the same event in the same display mode can seed the cache with render arrays for that display mode which do not trim the recurrence information. This can currently be seen in #4278 because the finder views do not trim recurrence information.

This can lead to circumstances where the calendar view inherits rendered events that do not have trimmed date fields, leading to calendars showing all the recurrences for a given event.

This PR introduces a cache context for events which cause them to have separate caches per route.

This problem could also potentially be fixed by making sure EVERY event view trims its dates properly so that no cache issues result, but that may not be able to account for custom views.

## Related issues
#4291 
#4278 (this is a related problem but not part of this PR)

## How to test

- enable `az_demo`
- **begin with a clear cache** `drush cr`
- be logged out, anonymous user **(logged in does not sufficiently test the issue)**
- visit the event finder `/finders/events`
- search for the name of a recurring event, such as `canyon running`
- see the output showing events without recurrence-trimmed dates (this is #4278 and not solved here)
- visit the calendar page, `/calendar`
- Page through events and verify that the event you searched for does not have the events shown with each event having all occurrences

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
