### PR TITLE
Fixes #4319 Trellis Event API requests use wrong timezone

### DIFF
--- a/modules/custom/az_event/az_event_trellis/src/Plugin/views/filter/AZEventTrellisViewsDateFilter.php
+++ b/modules/custom/az_event/az_event_trellis/src/Plugin/views/filter/AZEventTrellisViewsDateFilter.php
@@ -268,8 +268,8 @@ class AZEventTrellisViewsDateFilter extends FilterPluginBase {
         $end = strtotime("tomorrow", $end);
         // Roll over to the previous night.
         $end -= 1;
-        $begin = date(self::TRELLIS_DATE_FORMAT, $begin);
-        $end = date(self::TRELLIS_DATE_FORMAT, $end);
+        $begin = gmdate(self::TRELLIS_DATE_FORMAT, $begin);
+        $end = gmdate(self::TRELLIS_DATE_FORMAT, $end);
         $this->query->addWhere(
           $this->options['group'],
           $this->options['api_param_custom_begin'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The trellis event module does not appear to use the correct timezone for its API requests. This PR adjusts the filters to instead use UTC datetimes.

This makes a difference when searching for events with a time where their UTC time rolls over to a new day (for example, 5:00pm mountain time is midnight the next day on UTC time.

This issue could result in circumstances where searching for a date range for an event could fail to find an event if the range was at the edge of the event's day.

## Related issues
#4319 

## How to test
- enable `az_event_trellis` and `az_enterprise_attributes_import`
- Identify any trellis event that begins after 5 PM AZ time. (one such event is `a3UKg000000GnHwMAK`, occurred May 6 2025.)
- visit `/admin/trellis-event-importer`
- Select a start date of custom
- Select an event range of **only** the event's day (May 6 for the event listed above)
- Click **search**
- Verify the event can be found in the output
- repeat for other dates as desired

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
