### PR TITLE
Fixes #4327 Add to Calendar link fails for Event nodes with long descriptions

### DIFF
--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -123,6 +123,24 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
 
     // For the full content view mode, modify the display of az_event_date.
     if (($view_mode === 'full') && ($entity instanceof NodeInterface)) {
+      // Compute a summary for the description.
+      // Field_az_body does not have native support for summaries.
+      // Some integrations for adding calendar events depend upon the data
+      // being able to fit into an URL. (2048 characters)
+      // Prefer field_az_summary where available.
+      $summary = '';
+      if ($entity->hasField('field_az_summary')) {
+        /** @var \Drupal\Core\Field\FieldItemList $summary_field */
+        $summary_field = $entity->get('field_az_summary');
+        $summary = $summary_field->value ?: '';
+      }
+      if (empty($summary) && $entity->hasField('field_az_body')) {
+        /** @var \Drupal\Core\Field\FieldItemList $body_field */
+        $body_field = $entity->get('field_az_body');
+        $summary = $body_field->value ?: '';
+      }
+      // By default this hinges on text.settings default_summary_length.
+      $summary = text_summary($summary, 'plain_text');
       $now = \Drupal::time()->getCurrentTime();
       /** @var \Drupal\Core\Field\FieldItemList $event_date_field */
       $event_date_field = $entity->field_az_event_date;
@@ -140,7 +158,7 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
               '#start_date' => $start,
               '#end_date' => $end,
               '#all_day' => $all_day,
-              '#description' => $entity->field_az_body->value ?? '',
+              '#description' => $summary,
               '#location' => $entity->field_az_location->title ?? '',
               '#modal' => Html::getUniqueId('calendar-link-modal'),
               '#attributes' => ['class' => 'mt-3'],
@@ -215,7 +233,7 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
                 '#title' => $entity->getTitle(),
                 '#start_date' => $item['value'] ?? '',
                 '#end_date' => $item['end_value'] ?? '',
-                '#description' => $entity->field_az_body->value ?? '',
+                '#description' => $summary,
                 '#location' => $entity->field_az_location->title ?? '',
                 '#modal' => Html::getUniqueId('calendar-link-modal'),
                 '#attributes' => ['class' => 'mb-2'],

--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -132,12 +132,12 @@ function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDi
       if ($entity->hasField('field_az_summary')) {
         /** @var \Drupal\Core\Field\FieldItemList $summary_field */
         $summary_field = $entity->get('field_az_summary');
-        $summary = $summary_field->value ?: '';
+        $summary = $summary_field->value ?? '';
       }
       if (empty($summary) && $entity->hasField('field_az_body')) {
         /** @var \Drupal\Core\Field\FieldItemList $body_field */
         $body_field = $entity->get('field_az_body');
-        $summary = $body_field->value ?: '';
+        $summary = $body_field->value ?? '';
       }
       // By default this hinges on text.settings default_summary_length.
       $summary = text_summary($summary, 'plain_text');


### PR DESCRIPTION
## Description
Some of the integrations for adding events to calendars depend upon the data being able to fit into the length of a valid url. In events where the body is very long, this can result in request errors.

This PR introduces the following conventions:

- Where available, the summary field will be used
- Where there is no summary, the body field will be used
- In either case, a truncated summary will be generated that is no longer than `text.settings` setting `default_summary_length` (typically 600)

### Release notes
```
When using the Add to Calendar button on events, the event description will now rely on the summary field where available, and be truncated if it is too long.
```

## Related issues
#4327 

## How to test

- create an event with an extremely long event description
- use the Add to Calendar link, and verify that the added event had its description truncated after a certain length.
- edit and add a summary to the event
- use the Add to Calendar link
- verify that the summary field is used instead of the body

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My change requires release notes.
