### PR TITLE
Close #1251 separate CSS from JS in Arizona Bootstrap and deprecate az_barrio/arizona-bootstrap library.

### DIFF
--- a/modules/custom/az_accordion/az_accordion.libraries.yml
+++ b/modules/custom/az_accordion/az_accordion.libraries.yml
@@ -2,3 +2,6 @@ az_accordion:
   css:
     component:
       css/az-accordion-widget.css: {}
+  dependencies:
+    - az_barrio/arizona-bootstrap-css
+    - az_barrio/arizona-bootstrap-js

--- a/modules/custom/az_alphabetical_listing/az_alphabetical_listing.libraries.yml
+++ b/modules/custom/az_alphabetical_listing/az_alphabetical_listing.libraries.yml
@@ -7,4 +7,4 @@ az_alphabetical_listing:
   dependencies:
     - core/jquery
     - core/drupal
-    - az_barrio/arizona-bootstrap
+    - az_barrio/arizona-bootstrap-css

--- a/modules/custom/az_core/az_core.install
+++ b/modules/custom/az_core/az_core.install
@@ -26,7 +26,7 @@ function az_core_requirements($phase) {
       $message = $library_info['deprecated'];
       $message = strtr($message, ['%library_id%' => $library_name]);
       $requirements['az_barrio.deprecated_library'] = [
-        'title' => t('Deprecated library usage'),
+        'title' => t('Deprecated libraries'),
         'value' => t('Deprecated: @extension/@library', ['@extension' => $extension, '@library' => $library_name]),
         'description' => $message,
         'severity' => REQUIREMENT_WARNING,

--- a/modules/custom/az_core/az_core.install
+++ b/modules/custom/az_core/az_core.install
@@ -1,9 +1,11 @@
 <?php
-
 /**
  * @file
  * Contains install and update functions for az_core.
  */
+
+use Drupal\Core\Database\Database;
+
 
 /**
  * Implements hook_update_last_removed().
@@ -11,4 +13,32 @@
 function az_core_update_last_removed() {
   // Remove updates added before 2.6.0.
   return 920501;
+}
+
+/**
+ * Implements hook_requirements().
+ */
+function az_core_requirements($phase) {
+  $requirements = [];
+  if ($phase === 'runtime') {
+    $extension = 'az_barrio';
+    $library_name = 'arizona-bootstrap';
+    $library_info = \Drupal::service('library.discovery')->getLibraryByName($extension, $library_name);
+
+    if ($library_info['deprecated']) {
+
+      $message = $library_info['deprecated'];
+      // set requirement key to the library name
+      $message = strtr($message, ['%library_id%' => $library_name]);
+
+      $requirements['az_barrio.deprecated_library'] = [
+        'title' => t('Deprecated library usage'),
+        'value' => t('Deprecated: @extension/@library', ['@extension' => $extension, '@library' => $library_name]),
+        'description' => $message,
+        'severity' => REQUIREMENT_WARNING,
+      ];
+    }
+  }
+
+  return $requirements;
 }

--- a/modules/custom/az_core/az_core.install
+++ b/modules/custom/az_core/az_core.install
@@ -1,11 +1,9 @@
 <?php
+
 /**
  * @file
  * Contains install and update functions for az_core.
  */
-
-use Drupal\Core\Database\Database;
-
 
 /**
  * Implements hook_update_last_removed().
@@ -24,13 +22,9 @@ function az_core_requirements($phase) {
     $extension = 'az_barrio';
     $library_name = 'arizona-bootstrap';
     $library_info = \Drupal::service('library.discovery')->getLibraryByName($extension, $library_name);
-
     if ($library_info['deprecated']) {
-
       $message = $library_info['deprecated'];
-      // set requirement key to the library name
       $message = strtr($message, ['%library_id%' => $library_name]);
-
       $requirements['az_barrio.deprecated_library'] = [
         'title' => t('Deprecated library usage'),
         'value' => t('Deprecated: @extension/@library', ['@extension' => $extension, '@library' => $library_name]),

--- a/modules/custom/az_core/az_core.libraries.yml
+++ b/modules/custom/az_core/az_core.libraries.yml
@@ -9,7 +9,8 @@ arizona-bootstrap-node-form-overrides:
     layout:
       css/arizona-bootstrap-node-form-overrides.css: {}
   dependencies:
-    - az_barrio/arizona-bootstrap
+    - az_barrio/arizona-bootstrap-css
+    - az_barrio/arizona-bootstrap-js
     - az_barrio/button-no-conflict
 az-enterprise-attributes:
   css:

--- a/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs.libraries.yml
@@ -3,7 +3,8 @@ az_paragraphs.az_text:
     theme:
       css/az_paragraphs_az_text.css: {}
   dependencies:
-    - az_barrio/arizona-bootstrap
+    - az_barrio/arizona-bootstrap-css
+    - az_barrio/arizona-bootstrap-js
     - az_barrio/button-no-conflict
 az_paragraphs.az_paragraphs_full_width:
   header: true
@@ -17,28 +18,32 @@ az_paragraphs.az_text_background:
     theme:
       css/az_paragraphs_az_text_background.css: {}
   dependencies:
-    - az_barrio/arizona-bootstrap
+    - az_barrio/arizona-bootstrap-css
+    - az_barrio/arizona-bootstrap-js
     - az_barrio/button-no-conflict
 az_paragraphs.az_text_media:
   css:
     theme:
       css/az_paragraphs_az_text_media.css: {}
   dependencies:
-    - az_barrio/arizona-bootstrap
+    - az_barrio/arizona-bootstrap-css
+    - az_barrio/arizona-bootstrap-js
     - az_barrio/button-no-conflict
 az_paragraphs.az_photo_gallery:
   css:
     theme:
       css/az_paragraphs_az_photo_gallery.css: {}
   dependencies:
-    - az_barrio/arizona-bootstrap
+    - az_barrio/arizona-bootstrap-css
+    - az_barrio/arizona-bootstrap-js
     - az_barrio/button-no-conflict
 az_paragraphs.az_cards:
   css:
     theme:
       css/az_paragraphs_az_cards.css: {}
   dependencies:
-    - az_barrio/arizona-bootstrap
+    - az_barrio/arizona-bootstrap-css
+    - az_barrio/arizona-bootstrap-js
     - az_barrio/button-no-conflict
 az_paragraphs.preview:
   css:
@@ -47,7 +52,8 @@ az_paragraphs.preview:
       css/az_paragraphs_widget.css: {}
   dependencies:
     - az_barrio/material-design-icons-sharp
-    - az_barrio/arizona-bootstrap
+    - az_barrio/arizona-bootstrap-css
+    - az_barrio/arizona-bootstrap-js
     - az_barrio/button-no-conflict
 az_paragraphs.az_html:
   header: true

--- a/modules/custom/az_paragraphs/az_paragraphs_splitscreen/az_paragraphs_splitscreen.libraries.yml
+++ b/modules/custom/az_paragraphs/az_paragraphs_splitscreen/az_paragraphs_splitscreen.libraries.yml
@@ -3,5 +3,5 @@ az_paragraphs_splitscreen:
     theme:
       css/az_splitscreen.css: {}
   dependencies:
-    - az_barrio/arizona-bootstrap
+    - az_barrio/arizona-bootstrap-css
     - az_paragraphs/az_paragraphs.az_paragraphs_full_width

--- a/modules/custom/az_select_menu/az_select_menu.libraries.yml
+++ b/modules/custom/az_select_menu/az_select_menu.libraries.yml
@@ -8,4 +8,4 @@ az_select_menu:
     - core/jquery
     - core/drupal
     - core/once
-    - az_barrio/arizona-bootstrap
+    - az_barrio/arizona-bootstrap-css

--- a/themes/custom/az_barrio/az_barrio.libraries.yml
+++ b/themes/custom/az_barrio/az_barrio.libraries.yml
@@ -3,7 +3,8 @@ global-styling:
     theme:
       css/style.css: {}
   dependencies:
-    - az_barrio/arizona-bootstrap
+    - az_barrio/arizona-bootstrap-css
+    - az_barrio/arizona-bootstrap-js
 az-ajax:
   js:
     js/az-ajax.js: {}
@@ -33,6 +34,14 @@ arizona-bootstrap:
   css:
     theme:
       /libraries/arizona-bootstrap/css/arizona-bootstrap.min.css: { minified: true }
+  js:
+    /libraries/arizona-bootstrap/js/arizona-bootstrap.bundle.min.js: { minified: true }
+  deprecated: The combined "%library_id%" CSS and Javascript library is deprecated in az_quickstart:2.13.x and is removed from az_quickstart:2.14.x. For CSS, use az_barrio/arizona-bootstrap-css, and for Javascript use az_barrio/arizona-bootstrap-js. See https://github.com/az-digital/az_quickstart/issues/1251
+arizona-bootstrap-css:
+  css:
+    theme:
+      /libraries/arizona-bootstrap/css/arizona-bootstrap.min.css: { minified: true }
+arizona-bootstrap-js:
   js:
     /libraries/arizona-bootstrap/js/arizona-bootstrap.bundle.min.js: { minified: true }
   dependencies:

--- a/themes/custom/az_barrio/az_barrio.post_update.php
+++ b/themes/custom/az_barrio/az_barrio.post_update.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for AZ Barrio.
+ */
+
+/**
+ * Adds the az_bootstrap_cdn_version_css and az_bootstrap_cdn_version_js
+ * settings to the az_barrio.settings configuration.
+ */
+function az_barrio_post_update_split_bootstrap_cdn_version(&$sandbox = NULL) {
+  $config_factory = \Drupal::configFactory();
+  $theme_settings = $config_factory->getEditable('az_barrio.settings');
+
+  $old_version = $theme_settings->get('az_bootstrap_cdn_version');
+
+  // Only apply migration if old value exists.
+  if ($old_version !== NULL) {
+    // Set new values if not already set.
+    if ($theme_settings->get('az_bootstrap_cdn_version_css') === NULL) {
+      $theme_settings->set('az_bootstrap_cdn_version_css', $old_version);
+    }
+    if ($theme_settings->get('az_bootstrap_cdn_version_js') === NULL) {
+      $theme_settings->set('az_bootstrap_cdn_version_js', $old_version);
+    }
+
+    // Save all changes.
+    $theme_settings->save();
+  }
+}

--- a/themes/custom/az_barrio/az_barrio.post_update.php
+++ b/themes/custom/az_barrio/az_barrio.post_update.php
@@ -6,8 +6,7 @@
  */
 
 /**
- * Adds the az_bootstrap_cdn_version_css and az_bootstrap_cdn_version_js
- * settings to the az_barrio.settings configuration.
+ * Adds az_bootstrap_cdn_version_css and az_bootstrap_cdn_version_js settings.
  */
 function az_barrio_post_update_split_bootstrap_cdn_version(&$sandbox = NULL) {
   $config_factory = \Drupal::configFactory();

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -432,7 +432,7 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
       return;
     }
 
-    $az_bootstrap_token = '';
+    $az_bootstrap_js_token = '';
     $az_bootstrap_js_info = [
       'preprocess' => FALSE,
     ];

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -453,7 +453,7 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
       $az_bootstrap_js_info['minified'] = TRUE;
     }
 
-    $az_bootstrap_js_path .= $az_bootstrap_token;
+    $az_bootstrap_js_path .= $az_bootstrap_js_token;
     $libraries['arizona-bootstrap-js']['js'] = [
       $az_bootstrap_js_path => $az_bootstrap_js_info,
     ];

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -341,6 +341,127 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
       }
     }
   }
+
+  if ($extension === 'az_barrio' && isset($libraries['arizona-bootstrap-css'])) {
+    // Add AZ Bootstrap CSS based on theme settings.
+    $az_bootstrap_css_path = az_barrio_az_bootstrap_assets_path('css');
+    if (!$az_bootstrap_css_path) {
+      return;
+    }
+
+    $az_bootstrap_token = '';
+    $az_bootstrap_css_info = [
+      'media' => 'all',
+      'preprocess' => FALSE,
+      'browsers' => [
+        'IE' => TRUE,
+        '!IE' => TRUE,
+      ],
+      'minified' => FALSE,
+    ];
+
+    // AZ Bootstrap source.
+    if (theme_get_setting('az_bootstrap_source') === 'cdn') {
+      // AZ Bootstrap CDN version.
+      if (theme_get_setting('az_bootstrap_cdn_version') !== 'stable') {
+        $az_bootstrap_token = '?=' . \Drupal::state()->get('system.css_js_query_string') ?: '0';
+      }
+      $az_bootstrap_css_info['type'] = 'external';
+    }
+    else {
+      $az_bootstrap_css_info['type'] = 'file';
+    }
+
+    if (theme_get_setting('az_bootstrap_minified')) {
+      $az_bootstrap_css_info['minified'] = TRUE;
+    }
+
+    $az_bootstrap_css_path .= $az_bootstrap_token;
+    $libraries['arizona-bootstrap']['css']['theme'] = [
+      $az_bootstrap_css_path => $az_bootstrap_css_info,
+    ];
+
+    // Populate AZ Bootstrap location variable for CKEditor.
+    \Drupal::state()->set(AZ_BOOTSTRAP_LOCATION, $az_bootstrap_css_path . $az_bootstrap_token);
+
+    $font = theme_get_setting('az_barrio_font');
+    if ($font === TRUE) {
+      // Add Proxima Nova CSS based on theme settings.
+      // Ensure Proxima Nova is loaded before Arizona Bootstrap.
+      $libraries['arizona-bootstrap-css']['dependencies'][] = 'az_barrio/az-proxima-nova';
+    }
+
+    $material_design_sharp_icons = theme_get_setting('az_barrio_material_design_sharp_icons');
+    if ($material_design_sharp_icons === TRUE) {
+      // Add Material Design Sharp Icon CSS based on theme settings.
+      // Ensure icon CSS is loaded before Arizona Bootstrap.
+      $libraries['arizona-bootstrap-css']['dependencies'][] = 'az_barrio/material-design-icons-sharp';
+    }
+
+    $az_icons = theme_get_setting('az_barrio_az_icons');
+    if ($az_icons === TRUE) {
+      if ($extension === 'az_barrio' && isset($libraries['az-icons'])) {
+        // Add Arizona Icons CSS based on theme settings.
+        $az_icons_path = az_barrio_az_icons_assets_path('css');
+        // Ensure icons are loaded before Arizona Bootstrap.
+        $libraries['arizona-bootstrap-css']['dependencies'][] = 'az_barrio/az-icons';
+        $az_barrio_az_icons_css_info = [
+          'media' => 'all',
+          'preprocess' => FALSE,
+          'browsers' => [
+            'IE' => TRUE,
+            '!IE' => TRUE,
+          ],
+          'minified' => TRUE,
+        ];
+        // AZ Brand Icons source.
+        if (theme_get_setting('az_barrio_az_icons_source') === 'cdn') {
+          $az_barrio_az_icons_css_info['type'] = 'external';
+        }
+        else {
+          $az_barrio_az_icons_css_info['type'] = 'file';
+        }
+
+        $libraries['az-icons']['css']['theme'] = [
+          $az_icons_path => $az_barrio_az_icons_css_info,
+        ];
+      }
+    }
+  }
+
+  if ($extension === 'az_barrio' && isset($libraries['arizona-bootstrap-js'])) {
+    // Add AZ Bootstrap JS based on theme settings.
+    $az_bootstrap_js_path = az_barrio_az_bootstrap_assets_path('js');
+    if (!$az_bootstrap_js_path) {
+      return;
+    }
+
+    $az_bootstrap_token = '';
+    $az_bootstrap_js_info = [
+      'preprocess' => FALSE,
+    ];
+
+    // AZ Bootstrap source.
+    if (theme_get_setting('az_bootstrap_source') === 'cdn') {
+      // AZ Bootstrap CDN version.
+      if (theme_get_setting('az_bootstrap_cdn_version') !== 'stable') {
+        $az_bootstrap_token = '?=' . \Drupal::state()->get('system.css_js_query_string') ?: '0';
+      }
+      $az_bootstrap_js_info['type'] = 'external';
+    }
+    else {
+      $az_bootstrap_js_info['type'] = 'file';
+    }
+
+    if (theme_get_setting('az_bootstrap_minified')) {
+      $az_bootstrap_js_info['minified'] = TRUE;
+    }
+
+    $az_bootstrap_js_path .= $az_bootstrap_token;
+    $libraries['arizona-bootstrap']['js'] = [
+      $az_bootstrap_js_path => $az_bootstrap_js_info,
+    ];
+  }
 }
 
 /**

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -529,7 +529,7 @@ function az_barrio_az_bootstrap_css_path() {
   return $az_bootstrap_path . '.' . $type;
 }
 /**
- * Helper function for constructing AZ Bootstrap CSS asset paths.
+ * Helper function for constructing AZ Bootstrap JS asset paths.
  */
 function az_barrio_az_bootstrap_js_path() {
   $type = 'js';

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -346,7 +346,7 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
       return;
     }
 
-    $az_bootstrap_token = '';
+    $az_bootstrap_css_token = '';
     $az_bootstrap_css_info = [
       'media' => 'all',
       'preprocess' => FALSE,

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -796,3 +796,31 @@ function az_barrio_preprocess_block(&$variables) {
   }
 
 }
+
+/**
+ * Implements hook_requirements().
+ */
+function az_barrio_requirements($phase) {
+  $requirements = [];
+dpm($phase);
+  if ($phase === 'runtime') {
+    $library_name = 'az_barrio/arizona-bootstrap';
+
+    /** @var \Drupal\Core\Asset\LibraryDiscoveryCollectorInterface $collector */
+    $collector = \Drupal::service('library.discovery.collector');
+    $libraries = $collector->getLibrariesByExtension('az_barrio');
+
+    if (isset($libraries['arizona-bootstrap']['deprecated']['message'])) {
+      $message = $libraries['arizona-bootstrap']['deprecated']['message'];
+
+      $requirements['my_module.deprecated_library'] = [
+        'title' => t('Deprecated library usage'),
+        'value' => t('Deprecated: @library', ['@library' => $library_name]),
+        'description' => Markup::create($message),
+        'severity' => REQUIREMENT_WARNING,
+      ];
+    }
+  }
+
+  return $requirements;
+}

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -341,10 +341,10 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
       }
     }
   }
-
   if ($extension === 'az_barrio' && isset($libraries['arizona-bootstrap-css'])) {
     // Add AZ Bootstrap CSS based on theme settings.
     $az_bootstrap_css_path = az_barrio_az_bootstrap_assets_path('css');
+
     if (!$az_bootstrap_css_path) {
       return;
     }
@@ -371,13 +371,12 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
     else {
       $az_bootstrap_css_info['type'] = 'file';
     }
-
     if (theme_get_setting('az_bootstrap_minified')) {
       $az_bootstrap_css_info['minified'] = TRUE;
     }
 
     $az_bootstrap_css_path .= $az_bootstrap_token;
-    $libraries['arizona-bootstrap']['css']['theme'] = [
+    $libraries['arizona-bootstrap-css']['css']['theme'] = [
       $az_bootstrap_css_path => $az_bootstrap_css_info,
     ];
 
@@ -458,7 +457,7 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
     }
 
     $az_bootstrap_js_path .= $az_bootstrap_token;
-    $libraries['arizona-bootstrap']['js'] = [
+    $libraries['arizona-bootstrap-js']['js'] = [
       $az_bootstrap_js_path => $az_bootstrap_js_info,
     ];
   }
@@ -473,7 +472,6 @@ function az_barrio_az_bootstrap_assets_path($type) {
   }
 
   $az_bootstrap_path = '';
-
   // AZ Bootstrap source.
   if (theme_get_setting('az_bootstrap_source') === 'cdn') {
     $az_bootstrap_cdn_version = theme_get_setting('az_bootstrap_cdn_version');

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -294,9 +294,6 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
       $az_bootstrap_js_path => $az_bootstrap_js_info,
     ];
 
-    // Populate AZ Bootstrap location variable for CKEditor.
-    \Drupal::state()->set(AZ_BOOTSTRAP_LOCATION, $az_bootstrap_css_path . $az_bootstrap_token);
-
     $font = theme_get_setting('az_barrio_font');
     if ($font === TRUE) {
       // Add Proxima Nova CSS based on theme settings.
@@ -343,7 +340,7 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
   }
   if ($extension === 'az_barrio' && isset($libraries['arizona-bootstrap-css'])) {
     // Add AZ Bootstrap CSS based on theme settings.
-    $az_bootstrap_css_path = az_barrio_az_bootstrap_assets_path('css');
+    $az_bootstrap_css_path = az_barrio_az_bootstrap_css_path();
 
     if (!$az_bootstrap_css_path) {
       return;
@@ -363,8 +360,8 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
     // AZ Bootstrap source.
     if (theme_get_setting('az_bootstrap_source') === 'cdn') {
       // AZ Bootstrap CDN version.
-      if (theme_get_setting('az_bootstrap_cdn_version') !== 'stable') {
-        $az_bootstrap_token = '?=' . \Drupal::state()->get('system.css_js_query_string') ?: '0';
+      if (theme_get_setting('az_bootstrap_cdn_version_css') !== 'stable') {
+        $az_bootstrap_css_token = '?=' . \Drupal::state()->get('system.css_js_query_string') ?: '0';
       }
       $az_bootstrap_css_info['type'] = 'external';
     }
@@ -375,13 +372,13 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
       $az_bootstrap_css_info['minified'] = TRUE;
     }
 
-    $az_bootstrap_css_path .= $az_bootstrap_token;
+    $az_bootstrap_css_path .= $az_bootstrap_css_token;
     $libraries['arizona-bootstrap-css']['css']['theme'] = [
       $az_bootstrap_css_path => $az_bootstrap_css_info,
     ];
 
     // Populate AZ Bootstrap location variable for CKEditor.
-    \Drupal::state()->set(AZ_BOOTSTRAP_LOCATION, $az_bootstrap_css_path . $az_bootstrap_token);
+    \Drupal::state()->set(AZ_BOOTSTRAP_LOCATION, $az_bootstrap_css_path . $az_bootstrap_css_token);
 
     $font = theme_get_setting('az_barrio_font');
     if ($font === TRUE) {
@@ -430,7 +427,7 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
 
   if ($extension === 'az_barrio' && isset($libraries['arizona-bootstrap-js'])) {
     // Add AZ Bootstrap JS based on theme settings.
-    $az_bootstrap_js_path = az_barrio_az_bootstrap_assets_path('js');
+    $az_bootstrap_js_path = az_barrio_az_bootstrap_js_path();
     if (!$az_bootstrap_js_path) {
       return;
     }
@@ -443,7 +440,7 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
     // AZ Bootstrap source.
     if (theme_get_setting('az_bootstrap_source') === 'cdn') {
       // AZ Bootstrap CDN version.
-      if (theme_get_setting('az_bootstrap_cdn_version') !== 'stable') {
+      if (theme_get_setting('az_bootstrap_cdn_version_js') !== 'stable') {
         $az_bootstrap_token = '?=' . \Drupal::state()->get('system.css_js_query_string') ?: '0';
       }
       $az_bootstrap_js_info['type'] = 'external';
@@ -475,6 +472,71 @@ function az_barrio_az_bootstrap_assets_path($type) {
   // AZ Bootstrap source.
   if (theme_get_setting('az_bootstrap_source') === 'cdn') {
     $az_bootstrap_cdn_version = theme_get_setting('az_bootstrap_cdn_version');
+    if ($az_bootstrap_cdn_version === 'stable') {
+      $az_bootstrap_cdn_version = AZ_BOOTSTRAP_STABLE_VERSION;
+    }
+    $az_bootstrap_path = 'https://cdn.digital.arizona.edu/lib/arizona-bootstrap/' . $az_bootstrap_cdn_version;
+  }
+  else {
+    $az_bootstrap_path = base_path() . 'libraries/arizona-bootstrap';
+  }
+
+  $az_bootstrap_path .= '/' . $type . '/arizona-bootstrap';
+
+  // Use AZ Bootstrap Javascript bundle (contains Popper.js).
+  if ($type === 'js') {
+    $az_bootstrap_path .= '.bundle';
+  }
+
+  // AZ Bootstrap minified.
+  if (theme_get_setting('az_bootstrap_minified')) {
+    $az_bootstrap_path .= '.min';
+  }
+
+  return $az_bootstrap_path . '.' . $type;
+}
+
+/**
+ * Helper function for constructing AZ Bootstrap CSS asset paths.
+ */
+function az_barrio_az_bootstrap_css_path() {
+  $type = 'css';
+  $az_bootstrap_path = '';
+  // AZ Bootstrap source.
+  if (theme_get_setting('az_bootstrap_source') === 'cdn') {
+    $az_bootstrap_cdn_version = theme_get_setting('az_bootstrap_cdn_version_css');
+    if ($az_bootstrap_cdn_version === 'stable') {
+      $az_bootstrap_cdn_version = AZ_BOOTSTRAP_STABLE_VERSION;
+    }
+    $az_bootstrap_path = 'https://cdn.digital.arizona.edu/lib/arizona-bootstrap/' . $az_bootstrap_cdn_version;
+  }
+  else {
+    $az_bootstrap_path = base_path() . 'libraries/arizona-bootstrap';
+  }
+
+  $az_bootstrap_path .= '/' . $type . '/arizona-bootstrap';
+
+  // Use AZ Bootstrap Javascript bundle (contains Popper.js).
+  if ($type === 'js') {
+    $az_bootstrap_path .= '.bundle';
+  }
+
+  // AZ Bootstrap minified.
+  if (theme_get_setting('az_bootstrap_minified')) {
+    $az_bootstrap_path .= '.min';
+  }
+
+  return $az_bootstrap_path . '.' . $type;
+}
+/**
+ * Helper function for constructing AZ Bootstrap CSS asset paths.
+ */
+function az_barrio_az_bootstrap_js_path() {
+  $type = 'js';
+  $az_bootstrap_path = '';
+  // AZ Bootstrap source.
+  if (theme_get_setting('az_bootstrap_source') === 'cdn') {
+    $az_bootstrap_cdn_version = theme_get_setting('az_bootstrap_cdn_version_js');
     if ($az_bootstrap_cdn_version === 'stable') {
       $az_bootstrap_cdn_version = AZ_BOOTSTRAP_STABLE_VERSION;
     }

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -441,7 +441,7 @@ function az_barrio_library_info_alter(&$libraries, $extension) {
     if (theme_get_setting('az_bootstrap_source') === 'cdn') {
       // AZ Bootstrap CDN version.
       if (theme_get_setting('az_bootstrap_cdn_version_js') !== 'stable') {
-        $az_bootstrap_token = '?=' . \Drupal::state()->get('system.css_js_query_string') ?: '0';
+        $az_bootstrap_js_token = '?=' . \Drupal::state()->get('system.css_js_query_string') ?: '0';
       }
       $az_bootstrap_js_info['type'] = 'external';
     }

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -797,30 +797,3 @@ function az_barrio_preprocess_block(&$variables) {
 
 }
 
-/**
- * Implements hook_requirements().
- */
-function az_barrio_requirements($phase) {
-  $requirements = [];
-dpm($phase);
-  if ($phase === 'runtime') {
-    $library_name = 'az_barrio/arizona-bootstrap';
-
-    /** @var \Drupal\Core\Asset\LibraryDiscoveryCollectorInterface $collector */
-    $collector = \Drupal::service('library.discovery.collector');
-    $libraries = $collector->getLibrariesByExtension('az_barrio');
-
-    if (isset($libraries['arizona-bootstrap']['deprecated']['message'])) {
-      $message = $libraries['arizona-bootstrap']['deprecated']['message'];
-
-      $requirements['my_module.deprecated_library'] = [
-        'title' => t('Deprecated library usage'),
-        'value' => t('Deprecated: @library', ['@library' => $library_name]),
-        'description' => Markup::create($message),
-        'severity' => REQUIREMENT_WARNING,
-      ];
-    }
-  }
-
-  return $requirements;
-}

--- a/themes/custom/az_barrio/config/install/az_barrio.settings.yml
+++ b/themes/custom/az_barrio/config/install/az_barrio.settings.yml
@@ -83,6 +83,8 @@ az_barrio_navbar_offcanvas: true
 az_barrio_font: true
 az_bootstrap_source: cdn
 az_bootstrap_cdn_version: stable
+az_bootstrap_cdn_version_css: stable
+az_bootstrap_cdn_version_js: stable
 az_bootstrap_minified: true
 az_barrio_az_icons: true
 az_barrio_az_icons_source: cdn

--- a/themes/custom/az_barrio/config/schema/az_barrio.schema.yml
+++ b/themes/custom/az_barrio/config/schema/az_barrio.schema.yml
@@ -316,6 +316,12 @@ az_barrio.settings:
     az_bootstrap_cdn_version:
       type: string
       label: 'AZ Bootstrap CDN version'
+    az_bootstrap_cdn_version_css:
+      type: string
+      label: 'AZ Bootstrap CDN version CSS'
+    az_bootstrap_cdn_version_js:
+      type: string
+      label: 'AZ Bootstrap CDN version JS'
     az_bootstrap_minified:
       type: boolean
       label: 'Enable AZ Bootstrap minification'

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -252,8 +252,8 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
   $form['azbs_settings']['settings']['az_bootstrap_cdn']['az_bootstrap_cdn_version'] = [
     '#type' => 'radios',
     '#title' => t('AZ Bootstrap CDN version (DEPRECATED)'),
-    '#description' => t('This setting is deprecated in favor of allowing choosing your CSS and JS versions separately. This setting will be removed in a future version of AZ Barrio. See <a href="@azbootstrap">AZ Bootstrap</a> for more information.', [
-      '@azbootstrap' => 'https://github.com/az-digital/az_quickstart/issues/1251',
+    '#description' => t('This setting is deprecated in favor of allowing choosing your CSS and JS versions separately.  <a href="@bootstrapdeprecated">This setting will be removed in a future version of AZ Barrio</a>.', [
+      '@bootstrapdeprecated' => 'https://github.com/az-digital/az_quickstart/issues/1251',
     ]),
     '#options' => [
       'stable' => t('Stable version: This option has undergone the most testing within the az_barrio theme. Currently: %stableversion (Recommended).', ['%stableversion' => AZ_BOOTSTRAP_STABLE_VERSION]),

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -251,7 +251,10 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
   ];
   $form['azbs_settings']['settings']['az_bootstrap_cdn']['az_bootstrap_cdn_version'] = [
     '#type' => 'radios',
-    '#title' => t('AZ Bootstrap CDN version'),
+    '#title' => t('AZ Bootstrap CDN version (DEPRECATED)'),
+    '#description' => t('This setting is deprecated in favor of allowing choosing your CSS and JS versions separately. This setting will be removed in a future version of AZ Barrio. See <a href="@azbootstrap">AZ Bootstrap</a> for more information.', [
+      '@azbootstrap' => 'https://github.com/az-digital/az_quickstart/issues/1251',
+    ]),
     '#options' => [
       'stable' => t('Stable version: This option has undergone the most testing within the az_barrio theme. Currently: %stableversion (Recommended).', ['%stableversion' => AZ_BOOTSTRAP_STABLE_VERSION]),
       'latest-2.x' => t('Latest tagged version. The most recently tagged stable release of AZ Bootstrap. While this has not been explicitly tested on this version of az_barrio, it’s probably OK to use on production sites. Please report bugs to the AZ Digital team.'),
@@ -259,6 +262,29 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     ],
     '#default_value' => theme_get_setting('az_bootstrap_cdn_version'),
   ];
+  $form['azbs_settings']['settings']['az_bootstrap_cdn']['az_bootstrap_cdn_version_css'] = [
+    '#type' => 'radios',
+    '#title' => t('AZ Bootstrap CSS CDN version'),
+    '#options' => [
+      'stable' => t('Stable version: This option has undergone the most testing within the az_barrio theme. Currently: %stableversion (Recommended).', ['%stableversion' => AZ_BOOTSTRAP_STABLE_VERSION]),
+      'latest-2.x' => t('Latest tagged version. The most recently tagged stable release of AZ Bootstrap. While this has not been explicitly tested on this version of az_barrio, it’s probably OK to use on production sites. Please report bugs to the AZ Digital team.'),
+      '2.x' => t('Latest dev version of 2.x. This is the tip of the 2.x branch of AZ Bootstrap. Please do not use on production unless you are following the AZ Bootstrap project closely. Please report bugs to the AZ Digital team.'),
+      '5.x' => t('Latest dev version of <code>main</code>. This is the tip of the main branch of AZ Bootstrap. Please do not use on production unless you are following the AZ Bootstrap project closely. Please report bugs to the AZ Digital team.'),
+    ],
+    '#default_value' => theme_get_setting('az_bootstrap_cdn_version_css'),
+  ];
+  $form['azbs_settings']['settings']['az_bootstrap_cdn']['az_bootstrap_cdn_version_js'] = [
+    '#type' => 'radios',
+    '#title' => t('AZ Bootstrap JS CDN version'),
+    '#options' => [
+      'stable' => t('Stable version: This option has undergone the most testing within the az_barrio theme. Currently: %stableversion (Recommended).', ['%stableversion' => AZ_BOOTSTRAP_STABLE_VERSION]),
+      'latest-2.x' => t('Latest tagged version of 2.x. The most recently tagged stable release of AZ Bootstrap. While this has not been explicitly tested on this version of az_barrio, it’s probably OK to use on production sites. Please report bugs to the AZ Digital team.'),
+      '2.x' => t('Latest dev version of 2.x. This is the tip of the 2.x branch of AZ Bootstrap. Please do not use on production unless you are following the AZ Bootstrap project closely. Please report bugs to the AZ Digital team.'),
+      '5.x' => t('Latest dev version of <code>main</code>. This is the tip of the main branch of AZ Bootstrap. Please do not use on production unless you are following the AZ Bootstrap project closely. Please report bugs to the AZ Digital team.'),
+    ],
+    '#default_value' => theme_get_setting('az_bootstrap_cdn_version_js'),
+  ];
+
   $form['azbs_settings']['settings']['az_bootstrap_minified'] = [
     '#type'          => 'checkbox',
     '#title'         => t('Use minified version of AZ Bootstrap.'),


### PR DESCRIPTION
## Description

### Release notes

```
The `az_barrio/arizona-bootstrap` library is deprecated, if your theme or module depends on it, please update your code to depend on `az_barrio/arizona-bootstrap-css` and/or `az_barrio/arizona-bootstrap-js` instead.
```

## Related issues
Close #1251

## How to test



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
