### PR TITLE
Embed FormAssembly forms using the Embed JavaScript Publishing Option

### DIFF
--- a/modules/custom/az_demo/data/az_demo_media_trellis.json
+++ b/modules/custom/az_demo/data/az_demo_media_trellis.json
@@ -3,6 +3,10 @@
     {
       "id":1,
       "name": "Trellis Test RFI Form",
+      "campaign_name": "Unit RFI",
+      "campaign_description": "This is the description for the RFI",
+      "form_id": "185",
+      "record_id": "7018N00000071eDQAQ",
       "url": "https://forms-a.trellis.arizona.edu/185?tfa_4=7018N00000072edQAA",
       "uuid": "2d1c72cf-e90b-4457-992d-55f87bf5dc46"
     }

--- a/modules/custom/az_demo/migrations/az_demo_media_trellis.yml
+++ b/modules/custom/az_demo/migrations/az_demo_media_trellis.yml
@@ -22,17 +22,23 @@ source:
       name: name
       selector: name
     -
+      name: campaign_name
+      selector: campaign_name
+    -
+      name: campaign_description
+      selector: campaign_description
+    -
+      name: form_id
+      selector: form_id
+    -
+      name: record_id
+      selector: record_id
+    -
       name: uuid
       selector: uuid
     -
       name: url
       selector: url
-    -
-      name: form_id
-      selector: form_id
-    -
-      name: rec_id
-      selector: rec_id
 
 destination:
   plugin: 'entity:media'
@@ -42,6 +48,10 @@ process:
     plugin: default_value
     default_value: az_trellis
   name: name
+  field_campaign_name: campaign_name
+  field_campaign_description: campaign_description
+  field_form_id: form_id
+  field_record_id: record_id
   field_media_az_media_remote: url
   field_az_media_trellis_form_id: form_id
   field_az_media_trellis_rec_id: rec_id

--- a/modules/custom/az_media/az_media_trellis/config/install/core.entity_form_display.media.az_trellis.default.yml
+++ b/modules/custom/az_media/az_media_trellis/config/install/core.entity_form_display.media.az_trellis.default.yml
@@ -2,7 +2,11 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.media.az_trellis.field_campaign_description
+    - field.field.media.az_trellis.field_campaign_name
+    - field.field.media.az_trellis.field_form_id
     - field.field.media.az_trellis.field_media_az_media_remote
+    - field.field.media.az_trellis.field_record_id
     - media.type.az_trellis
   module:
     - path
@@ -16,13 +20,44 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 5
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_media_az_media_remote:
+  field_campaign_description:
+    type: string_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_campaign_name:
     type: string_textfield
     weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_form_id:
+    type: number
+    weight: 3
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_media_az_media_remote:
+    type: string_textfield
+    weight: 5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_record_id:
+    type: string_textfield
+    weight: 4
     region: content
     settings:
       size: 60
@@ -38,20 +73,20 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 7
+    weight: 9
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 4
+    weight: 6
     region: content
     settings:
       match_operator: CONTAINS

--- a/modules/custom/az_media/az_media_trellis/config/install/field.field.media.az_trellis.field_campaign_description.yml
+++ b/modules/custom/az_media/az_media_trellis/config/install/field.field.media.az_trellis.field_campaign_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_campaign_description
+    - media.type.az_trellis
+id: media.az_trellis.field_campaign_description
+field_name: field_campaign_description
+entity_type: media
+bundle: az_trellis
+label: 'Campaign Description'
+description: 'Trellis Form campaign name (tfa_9)'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/modules/custom/az_media/az_media_trellis/config/install/field.field.media.az_trellis.field_campaign_name.yml
+++ b/modules/custom/az_media/az_media_trellis/config/install/field.field.media.az_trellis.field_campaign_name.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_campaign_name
+    - media.type.az_trellis
+id: media.az_trellis.field_campaign_name
+field_name: field_campaign_name
+entity_type: media
+bundle: az_trellis
+label: 'Campaign Name'
+description: 'Trellis Form campaign name (tfa_7)'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/az_media/az_media_trellis/config/install/field.field.media.az_trellis.field_form_id.yml
+++ b/modules/custom/az_media/az_media_trellis/config/install/field.field.media.az_trellis.field_form_id.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_form_id
+    - media.type.az_trellis
+id: media.az_trellis.field_form_id
+field_name: field_form_id
+entity_type: media
+bundle: az_trellis
+label: 'Form ID'
+description: 'Trellis Form ID'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/modules/custom/az_media/az_media_trellis/config/install/field.field.media.az_trellis.field_record_id.yml
+++ b/modules/custom/az_media/az_media_trellis/config/install/field.field.media.az_trellis.field_record_id.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_record_id
+    - media.type.az_trellis
+id: media.az_trellis.field_record_id
+field_name: field_record_id
+entity_type: media
+bundle: az_trellis
+label: 'Record ID'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/az_media/az_media_trellis/config/install/field.storage.media.field_campaign_description.yml
+++ b/modules/custom/az_media/az_media_trellis/config/install/field.storage.media.field_campaign_description.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+  enforced:
+    module:
+      - az_media_trellis
+id: media.field_campaign_description
+field_name: field_campaign_description
+entity_type: media
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_media/az_media_trellis/config/install/field.storage.media.field_campaign_name.yml
+++ b/modules/custom/az_media/az_media_trellis/config/install/field.storage.media.field_campaign_name.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+  enforced:
+    module:
+      - az_media_trellis
+id: media.field_campaign_name
+field_name: field_campaign_name
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_media/az_media_trellis/config/install/field.storage.media.field_form_id.yml
+++ b/modules/custom/az_media/az_media_trellis/config/install/field.storage.media.field_form_id.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+  enforced:
+    module:
+      - az_media_trellis
+id: media.field_form_id
+field_name: field_form_id
+entity_type: media
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_media/az_media_trellis/config/install/field.storage.media.field_record_id.yml
+++ b/modules/custom/az_media/az_media_trellis/config/install/field.storage.media.field_record_id.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+  enforced:
+    module:
+      - az_media_trellis
+id: media.field_record_id
+field_name: field_record_id
+entity_type: media
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/az_media/az_media_trellis/templates/az-media-trellis.html.twig
+++ b/modules/custom/az_media/az_media_trellis/templates/az-media-trellis.html.twig
@@ -7,7 +7,7 @@
  * - url: (string) A formatted Trellis source URL
  */
 #}
-{% set debug_url = "https://forms-a.trellis.arizona.edu/publish/185?tfa_4=7018N00000071eDQAQ" %}
+{% set debug_url = "https://forms-a.trellis.arizona.edu/publish/185?tfa_4=7018N00000071eDQAQ&tfa_7=CampaignTitle&tfa_9=CampaignDesc" %}
 {% set debug_code = '<div id="fa-form"></div>\n' ~
     '<script src="' ~ debug_url ~ '" data-qp-target-id="fa-form" defer=""></script>' %}
 

--- a/modules/custom/az_media/az_media_trellis/templates/az-media-trellis.html.twig
+++ b/modules/custom/az_media/az_media_trellis/templates/az-media-trellis.html.twig
@@ -7,6 +7,11 @@
  * - url: (string) A formatted Trellis source URL
  */
 #}
-{{ attach_library('az_media_trellis/az-media-trellis') }}
-<div id="fa-form"></div>
-<script src="{{ url }}" data-qp-target-id="fa-form" defer></script>
+{% set debug_url = "https://forms-a.trellis.arizona.edu/publish/185?tfa_4=7018N00000071eDQAQ" %}
+{% set debug_code = '<div id="fa-form"></div>\n' ~
+    '<script src="' ~ debug_url ~ '" data-qp-target-id="fa-form" defer=""></script>' %}
+
+<div>debug_url = {{ debug_url }}</div>
+<code>{{ debug_code }}</code>
+
+{{ debug_code|raw }}


### PR DESCRIPTION
This PR is to help diagnose issues discovered in using the [Quick Publish / Embed JavaScript](https://help.formassembly.com/help/javascript-form-publishing) publishing option. Per SalesForce's [Compare Publishing Options](https://help.formassembly.com/help/publishing-options) page, the Quick Publish / Embed JavaScript publishing option does NOT work with the Salesforce Prefill Connector. However, it should work with Prefill though the URL. This PR is attempting to get Prefill to work through the URL.

https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4357.probo.build/pages/media-embeds

Code for embedding a Trellis SalesForce form using [SalesForce's Quick Publish / JS Embed publishing option](https://help.formassembly.com/help/javascript-form-publishing):
```
<div id="fa-form"></div>
<script src="https://forms-a.trellis.arizona.edu/publish/185?tfa_4=7018N00000071eDQAQ" data-qp-target-id="fa-form" defer></script>
```

## Issues
1. `<textarea name="tfa_7"><textarea>` has no prefill value. This should correspond to the campaign name.
2. `<textarea name="tfa_9"><textarea>` has no prefill value. This should correspond to the campaign description.
3. `<input type="hidden" name="tfa_4">` has no prefill value. This should correspond to the record ID. Is this the correct terminology?
4. `<input type="hidden" name="tfa_10">` has no prefill value. I'm unsure as to what this corresponds to.

The corresponding Salesforce hosted form: https://forms-a.trellis.arizona.edu/185?tfa_4=7018N00000071eDQAQ. Notice that tfa_7 is set to "Unit RFI", tfa_9 is set to "This is the description for the RFI", and the form submits (suggesting and verifying that tfa_4 is set "7018N00000071eDQAQ". You will need to use a browser inspector to see this hidden input value.

## Questions
1. How should I adjust the embed code above to allow for the prefill values to come through?<br>_I have adjusted the src URL above to `https://forms-a.trellis.arizona.edu/publish/185?tfa_4=7018N00000071eDQAQ&tfa_7=CampaignTitle&tfa_9=CampaignDesc` but the values still do not display when the form is loaded._
2. Does the Trellis team have any examples of other campus partners using this publishing approach in non-Drupal applications?

### Resources
- [Prefill Through the URL](https://help.formassembly.com/help/prefill-through-the-url)