### PR TITLE
Add `overflow-hidden` to nav-link `li`'s, for rounded corners

### DIFF
--- a/themes/custom/az_barrio/templates/navigation/menu--sidebar.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--sidebar.html.twig
@@ -46,6 +46,7 @@
           item.is_expanded ? 'menu-item--expanded',
           item.is_collapsed ? 'menu-item--collapsed',
           item.in_active_trail ? 'menu-item--active-trail',
+          'overflow-hidden',
         ]
       %}
       <li{{ item.attributes.addClass(classes) }}>


### PR DESCRIPTION
Along with [bootstrap PR of branch issue/4383-bootstrap](https://github.com/az-digital/arizona-bootstrap/pull/1627), this closes issue #4383 