### PR TITLE
Core fix for issue-3387

### DIFF
--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -529,3 +529,17 @@ function az_core_preprocess_container__text_format_filter_help(&$variables) {
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_entity_embed_container().
+ * 
+ * Prevents double-submit button ajax errors in edit pages
+ * by swapping embedded webforms with a custom preview when in collapsed mode.
+ */
+function az_core_preprocess_entity_embed_container(array &$variables) {
+  if(isset($variables["element"]["entity"]["webform"])) {
+    if(\Drupal::routeMatch()->getRouteName() === 'entity.node.edit_form') {
+      $variables["children"] = "Webform Content (Preview)";
+    }
+  }
+}


### PR DESCRIPTION

## Description
Fixes the issue but discussion needed on best placeholder.
-The issue was that embedded webforms, when rendered, also rendered their submit button. This caused every connected button with 'type="submit"' (includes page save, edit, and collapse buttons) to attempt to submit the webform, which caused javascript and AJAX errors. When AJAX is on in the webform, the edit page is inoperable. With AJAX off, clicking those buttons actually submits the webform.

After discussion, we decided the easiest thing to do is to prevent rendering the webform content in the editor. By accident I also found that the issue is only prevelant in the collapsed view; rendering the webform with the editor open is ok.

### Release notes
<!--- Delete this line (and the closing comment line) to enable release notes.

If this change requires release notes: provide a summary of changes, how to use this change, and any related links. This content will be pasted in the [release notes](https://github.com/az-digital/az_quickstart/releases). Use markdown format to ensure proper pasting of information. [Release notes example](https://github.com/az-digital/az_quickstart/releases/tag/2.11.0)

Make sure to add the `release notes` label to this PR.

```
Add markdown of release notes here.
```

Delete this line to enable release notes.  -->


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/az-digital/az_quickstart/issues/3387
## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Follow steps in related issue to test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [x ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
