### PR TITLE
Fixes #4542 Resolve Profiles API Importer lock for failed imports

### DIFF
--- a/modules/custom/az_person/az_person.module
+++ b/modules/custom/az_person/az_person.module
@@ -61,7 +61,8 @@ function az_person_form_node_az_person_edit_form_alter(&$form, FormStateInterfac
           // Migration did not exist, or migrate service not found.
           // We have no data on this person being imported or not.
         }
-        if (!empty($imported)) {
+        // Lock person if migrate map for this person points to them.
+        if (!empty($imported[0]['nid']) && ($imported[0]['nid'] === $node->id())) {
           $person_warning = t('This person has been imported from the Profiles API.');
           \Drupal::messenger()->addWarning($person_warning);
           $disabled_fields = [


### PR DESCRIPTION
## Description
An individual that was attempted to be imported via the profiles API (and fails) can lock a subsequently created node. This is because the functionality only checks that an import happened (potentially with a null destination in the case of a failed import). It should instead check if the mapped node is the one attempting to be edited.

## Related issues
Closes #4542 

## How to test

- drush en `az_http az_person_profiles_import`
- Login to site
- Visit `/admin/config/az-quickstart/settings/az-person-profiles-import` and add your API token
- Visit `/admin/content/profiles/import`
- Import a combination of people, some present in the API and some not
- For the people not present in the API, verify that the migration emits a warning that they were not found
- After the import, create nodes manually for the people not imported (**make sure that you list the netID you attempted to import them with**)
- Attempt to edit both the imported people, and the people that were created with the same names as the people that failed to import
- Verify that the imported people have locked fields, and that the manually-created people do not

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
