### PR TITLE
Closes #4592: Update prepare-for-minor-release workflow to support dynamic source branch.

### DIFF
--- a/.github/workflows/prepare-for-minor-release.yml
+++ b/.github/workflows/prepare-for-minor-release.yml
@@ -117,7 +117,7 @@ jobs:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: ${{ matrix.repo }}
           event-type: az_quickstart_prep_for_minor_release
-          client-payload: '{"release_branch_name": "${{ inputs.release_branch_name }}" , "this_release_branch_alias_constraint": "${{needs.branch_name_prep.outputs.this_release_branch_alias_constraint}}", "dev_branch_source": "${{needs.branch_name_prep.outputs.dev_branch_source}}", "dev_branch_alias": "${{needs.branch_name_prep.outputs.dev_branch_alias}}", "next_release_branch_alias_constraint": "${{needs.branch_name_prep.outputs.next_release_branch_alias_constraint}}"}'
+          client-payload: '{"source_branch_name": "${{ github.ref_name }}", "release_branch_name": "${{ inputs.release_branch_name }}", "this_release_branch_alias_constraint": "${{needs.branch_name_prep.outputs.this_release_branch_alias_constraint}}", "dev_branch_source": "${{needs.branch_name_prep.outputs.dev_branch_source}}", "dev_branch_alias": "${{needs.branch_name_prep.outputs.dev_branch_alias}}", "next_release_branch_alias_constraint": "${{needs.branch_name_prep.outputs.next_release_branch_alias_constraint}}"}'
 
   prepare_for_new_minor_release:
     name: Prepare for a new minor release


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
We need to be able to trigger the `prepare-for-minor-release` GitHub Actions workflow from either `main` branch (for `3.x` minor releases) or from the `2.x` branch (for `2.x` minor releases).

This updates that workflow to support this.

Changes made:
- Updated workflow to use the branch that the workflow was triggered from as the source of the  new release branch (i.e. either `main` or `2.x`)
- Added validation that cancels workflows triggered from other branches
- Added validation that cancels workflows triggered from the incorrect branch for the requested new minor release branch name (i.e. only allow creating `2.x.x` branches from `2.x` and creating `3.x.x` branches from `main`)
- Added validation that cancels the workflow if the requested minor release branch already exist
- Added validation that cancels the workflow if the previous minor release does not already exist
- Updated workflow to Include source/trigger branch name in workflow `run-name`
- Various other changes

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4592

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Hard to test without running workflow to see if anything breaks...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [x] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
