### PR TITLE
Fixes #4621 Event views without delta generate warnings

### DIFF
--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -349,7 +349,7 @@ function az_event_preprocess_node(&$variables) {
 
       // Get row and delta for transformations.
       $row_index = $variables['elements']['#az_view_row_index'];
-      $delta = (int) $node->view->result[$row_index]->node__field_az_event_date_delta;
+      $delta = (int) ($node->view->result[$row_index]->node__field_az_event_date_delta ?? 0);
 
       // There is a field value at our computed delta.
       if (!empty($variables['content']['field_az_event_date'][$delta])) {


### PR DESCRIPTION
`az_event_preprocess_node` currently assumes an event view will have a delta value for event date. This isn't always the case, as is the case in the `az_finder` content view. This PR adds an additional check to make sure the value exists.

## Related issues
#4621 

## How to test

- enable `az_demo`
- login to site
- visit `/finders/content`
- visit `/admin/reports/dblog`
- Verify no warnings appear regarding `Warning: Undefined property: Drupal\views\ResultRow::$node__field_az_event_date_delta`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
