### PR TITLE
Closes #4591 - Update cases of card-clickable to stretched link

### DIFF
--- a/modules/custom/az_event/az_event.module
+++ b/modules/custom/az_event/az_event.module
@@ -74,6 +74,14 @@ function az_event_entity_extra_field_info() {
       'weight' => 50,
       'visible' => FALSE,
     ];
+
+    // View event pseudo field.
+    $extra['node'][$bundle->id()]['display']['az_event_view_event'] = [
+      'label' => t('View event pseudo field'),
+      'description' => "This is a pseudo field from az_event",
+      'weight' => 50,
+      'visible' => FALSE,
+    ];
   }
 
   return $extra;
@@ -95,6 +103,14 @@ function az_event_preprocess_field(&$variables, $hook) {
  * Implements hook_ENTITY_TYPE_view().
  */
 function az_event_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+
+  // View event pseudo field.
+  if ($entity instanceof FieldableEntityInterface && $display->getComponent('az_event_view_event')) {
+    $build['az_event_view_event'][] = [
+      '#type' => 'markup',
+      '#markup' => Html::escape('View event'),
+    ];
+  }
 
   // We only know what to do with event pseudo fields if our date seems defined.
   if ($entity instanceof FieldableEntityInterface && $entity->hasField('field_az_event_date') && !empty($entity->field_az_event_date->value)) {

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_card.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_card.yml
@@ -28,15 +28,17 @@ third_party_settings:
   field_group:
     group_card_clickable:
       children:
-        - group_link
+        - group_card_body
       label: 'Card Clickable'
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card border-0 card-clickable text-bg-gray-100 mt-0 mb-4 p-0'
+        classes: 'card border-0 text-bg-gray-100 mt-0 mb-4 p-0'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -46,18 +48,17 @@ third_party_settings:
         speed: fast
     group_link:
       children:
-        - group_date
-        - group_heading
-        - group_summary
+        - links
       label: Link
-      parent_name: group_card_clickable
+      parent_name: group_card_body
       region: content
-      weight: 1
+      weight: 13
       format_type: link
       format_settings:
-        classes: 'card-body p-4'
+        classes: stretched-link
         show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -65,9 +66,9 @@ third_party_settings:
       children:
         - field_az_event_date
       label: Date
-      parent_name: group_link
+      parent_name: group_card_body
       region: content
-      weight: 5
+      weight: 9
       format_type: html_element
       format_settings:
         classes: 'text-body-secondary fw-bold small'
@@ -83,9 +84,9 @@ third_party_settings:
       children:
         - smart_title
       label: Heading
-      parent_name: group_link
+      parent_name: group_card_body
       region: content
-      weight: 6
+      weight: 10
       format_type: html_element
       format_settings:
         classes: 'card-title text-chili h5 mt-0 mb-2'
@@ -101,13 +102,36 @@ third_party_settings:
       children:
         - field_az_summary
       label: Summary
-      parent_name: group_link
+      parent_name: group_card_body
       region: content
-      weight: 7
+      weight: 12
       format_type: html_element
       format_settings:
         classes: 'card-text fw-normal small mb-0'
         id: ''
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+    group_card_body:
+      children:
+        - group_date
+        - group_heading
+        - group_summary
+        - group_link
+      label: 'Card Body'
+      parent_name: group_card_clickable
+      region: content
+      weight: 11
+      format_type: html_element
+      format_settings:
+        classes: 'card-body p-4'
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -145,7 +169,7 @@ content:
       hide_date: 0
       capitalize_noon_and_midnight: 1
     third_party_settings: {  }
-    weight: 1
+    weight: 5
     region: content
   field_az_summary:
     type: az_text_summary
@@ -153,6 +177,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 8
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 6
     region: content
   smart_title:
     settings: {  }
@@ -174,4 +203,3 @@ hidden:
   field_az_photos: true
   field_az_subheading: true
   field_az_trellis_id: true
-  links: true

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_card_alternate.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_card_alternate.yml
@@ -28,6 +28,7 @@ third_party_settings:
   field_group:
     group_card_clickable:
       children:
+        - group_card_body
         - group_link
       label: 'Card Clickable'
       parent_name: ''
@@ -35,8 +36,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card border-0 card-clickable text-bg-gray-100 mt-0 mb-4 p-0'
+        classes: 'card border-0 text-bg-gray-100 mt-0 mb-4 p-0'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -46,19 +49,17 @@ third_party_settings:
         speed: fast
     group_link:
       children:
-        - field_az_media_thumbnail_image
-        - group_date
-        - group_heading
-        - group_summary
+        - links
       label: Link
       parent_name: group_card_clickable
       region: content
-      weight: 1
+      weight: 10
       format_type: link
       format_settings:
-        classes: 'card-body p-4'
+        classes: stretched-link
         show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -66,7 +67,7 @@ third_party_settings:
       children:
         - field_az_event_date
       label: Date
-      parent_name: group_link
+      parent_name: group_card_body
       region: content
       weight: 7
       format_type: html_element
@@ -84,7 +85,7 @@ third_party_settings:
       children:
         - smart_title
       label: Heading
-      parent_name: group_link
+      parent_name: group_card_body
       region: content
       weight: 8
       format_type: html_element
@@ -102,13 +103,36 @@ third_party_settings:
       children:
         - field_az_summary
       label: Summary
-      parent_name: group_link
+      parent_name: group_card_body
       region: content
       weight: 9
       format_type: html_element
       format_settings:
         classes: 'card-text fw-normal small mb-0'
         id: ''
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+    group_card_body:
+      children:
+        - field_az_media_thumbnail_image
+        - group_date
+        - group_heading
+        - group_summary
+      label: 'Card Body'
+      parent_name: group_card_clickable
+      region: content
+      weight: 9
+      format_type: html_element
+      format_settings:
+        classes: 'card-body p-4'
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -164,6 +188,11 @@ content:
     third_party_settings: {  }
     weight: 8
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 11
+    region: content
   smart_title:
     settings: {  }
     third_party_settings: {  }
@@ -183,4 +212,3 @@ hidden:
   field_az_photos: true
   field_az_subheading: true
   field_az_trellis_id: true
-  links: true

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row_with_background.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row_with_background.yml
@@ -25,33 +25,19 @@ dependencies:
     - user
 third_party_settings:
   field_group:
-    group_link:
-      children:
-        - group_row
-      label: Link
-      parent_name: group_card
-      region: content
-      weight: 2
-      format_type: link
-      format_settings:
-        classes: text-decoration-none
-        show_empty_fields: false
-        id: ''
-        target: custom_uri
-        custom_uri: '[node:az-canonical-url]'
-        target_attribute: default
     group_card:
       children:
-        - group_link
+        - group_row
       label: Card
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'text-bg-gray-100 card border-0 card-clickable hover mb-4'
+        classes: 'text-bg-gray-100 card border-0 hover mb-4'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -64,7 +50,7 @@ third_party_settings:
         - group_column_date
         - group_column_text
       label: Row
-      parent_name: group_link
+      parent_name: group_card
       region: content
       weight: 3
       format_type: html_element
@@ -106,7 +92,7 @@ third_party_settings:
       label: 'Column - Text'
       parent_name: group_row
       region: content
-      weight: 10
+      weight: 9
       format_type: html_element
       format_settings:
         classes: col-9
@@ -186,9 +172,10 @@ third_party_settings:
       weight: 14
       format_type: html_element
       format_settings:
-        classes: 'text-bg-azurite py-3'
+        classes: 'text-bg-azurite py-3 rounded'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -197,23 +184,41 @@ third_party_settings:
         effect: none
         speed: fast
     group_view_event:
-      children: {  }
+      children:
+        - group_link
       label: 'View event'
       parent_name: group_column_text
       region: content
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link mt-2 pb-3'
-        show_empty_fields: true
+        classes: 'mt-2 pb-3'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
-        show_label: true
-        label_element: span
+        show_label: false
+        label_element: div
         label_element_classes: ''
         attributes: ''
         effect: none
         speed: fast
+    group_link:
+      children:
+        - az_event_view_event
+      label: Link
+      parent_name: group_view_event
+      region: content
+      weight: 4
+      format_type: link
+      format_settings:
+        classes: 'stretched-link link-underline link-underline-opacity-0 link-underline-opacity-100-hover'
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        target: custom_uri
+        custom_uri: '[node:az-canonical-url]'
+        target_attribute: default
   smart_title:
     enabled: true
     settings:
@@ -239,6 +244,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 2
+    region: content
+  az_event_view_event:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 8
     region: content
   field_az_event_date:
     type: smartdate_default

--- a/modules/custom/az_flexible_page/az_flexible_page.module
+++ b/modules/custom/az_flexible_page/az_flexible_page.module
@@ -7,6 +7,46 @@
 
 use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Implements hook_entity_extra_field_info().
+ */
+function az_flexible_page_entity_extra_field_info() {
+  $extra = [];
+
+  // Check to see if our content type exists.
+  $bundle = NodeType::load('az_flexible_page');
+  if ($bundle) {
+    // Read more/View page pseudo field.
+    $extra['node'][$bundle->id()]['display']['az_flexible_page_read_more'] = [
+      'label' => t('Read more pseudo field'),
+      'description' => "This is a pseudo field from az_flexible_page",
+      'weight' => 50,
+      'visible' => FALSE,
+    ];
+  }
+
+  return $extra;
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_view().
+ */
+function az_flexible_page_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+
+  // Read more pseudo field.
+  if ($entity instanceof FieldableEntityInterface && $display->getComponent('az_flexible_page_read_more')) {
+    $text = ($view_mode === 'az_row_with_background') ? 'View page' : 'Read more';
+    $build['az_flexible_page_read_more'][] = [
+      '#type' => 'markup',
+      '#markup' => '<span aria-hidden="true">' . $text . '</span>',
+    ];
+  }
+}
 
 /**
  * Implements hook_preprocess_node().

--- a/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_card.yml
+++ b/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_card.yml
@@ -25,14 +25,14 @@ third_party_settings:
   field_group:
     group_card_clickable:
       children:
-        - group_link
+        - group_card_body
       label: 'Card Clickable'
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card border-0 card-clickable hover text-bg-gray-100 mb-0 mt-0 mb-4 p-0 overflow-hidden'
+        classes: 'card border-0 hover text-bg-gray-100 mb-0 mt-0 mb-4 p-0 overflow-hidden'
         show_empty_fields: false
         id: ''
         label_as_html: false
@@ -45,16 +45,17 @@ third_party_settings:
         speed: fast
     group_link:
       children:
-        - group_media
-        - group_content
+        - az_flexible_page_read_more
       label: Link
-      parent_name: group_card_clickable
+      parent_name: group_content
       region: content
-      weight: 5
+      weight: 6
       format_type: link
       format_settings:
-        classes: 'card-body p-0'
+        classes: 'stretched-link link-underline link-underline-opacity-0 link-underline-opacity-100-hover'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         target: entity
         custom_uri: ''
         target_attribute: default
@@ -62,13 +63,15 @@ third_party_settings:
       children:
         - field_az_media_image
       label: Media
-      parent_name: group_link
+      parent_name: group_card_body
       region: content
       weight: 2
       format_type: html_element
       format_settings:
         classes: 'card-img-top mb-0'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -114,33 +117,13 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-    group_read_more:
-      children:
-        - links
-      label: 'Read more'
-      parent_name: group_content
-      region: content
-      weight: 6
-      format_type: html_element
-      format_settings:
-        classes: 'card-clickable-link text-chili text-start'
-        show_empty_fields: false
-        id: ''
-        label_as_html: false
-        element: div
-        show_label: true
-        label_element: div
-        label_element_classes: ''
-        attributes: 'aria-hidden="true"'
-        effect: none
-        speed: fast
     group_content:
       children:
         - group_heading
         - group_summary
-        - group_read_more
+        - group_link
       label: Content
-      parent_name: group_link
+      parent_name: group_card_body
       region: content
       weight: 3
       format_type: html_element
@@ -154,11 +137,37 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
+    group_card_body:
+      children:
+        - group_media
+        - group_content
+      label: 'Card body'
+      parent_name: group_card_clickable
+      region: content
+      weight: 6
+      format_type: html_element
+      format_settings:
+        classes: 'card-body p-0'
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
 id: node.az_flexible_page.az_card
 targetEntityType: node
 bundle: az_flexible_page
 mode: az_card
 content:
+  az_flexible_page_read_more:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
   field_az_media_image:
     type: entity_reference_entity_view
     label: hidden
@@ -175,11 +184,6 @@ content:
     third_party_settings: {  }
     weight: 5
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 2
-    region: content
   smart_title:
     settings: {  }
     third_party_settings: {  }
@@ -189,3 +193,4 @@ hidden:
   field_az_main_content: true
   field_az_marketing_page_style: true
   field_az_page_category: true
+  links: true

--- a/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_row.yml
+++ b/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_row.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.az_flexible_page.field_az_main_content
     - field.field.node.az_flexible_page.field_az_marketing_page_style
     - field.field.node.az_flexible_page.field_az_media_image
+    - field.field.node.az_flexible_page.field_az_metatag
     - field.field.node.az_flexible_page.field_az_page_category
     - field.field.node.az_flexible_page.field_az_summary
     - node.type.az_flexible_page
@@ -29,14 +30,15 @@ third_party_settings:
   field_group:
     group_card_clickable:
       children:
-        - group_link
+        - group_row
+        - group_card_body
       label: 'Card Clickable'
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card card-borderless card-clickable hover text-bg-gray-100 p-4'
+        classes: 'card card-borderless hover text-bg-gray-100 p-4'
         show_empty_fields: false
         id: ''
         label_as_html: false
@@ -49,15 +51,17 @@ third_party_settings:
         speed: fast
     group_link:
       children:
-        - group_row
+        - az_flexible_page_read_more
       label: Link
-      parent_name: group_card_clickable
+      parent_name: group_column
       region: content
-      weight: 2
+      weight: 4
       format_type: link
       format_settings:
-        classes: 'card-body p-0'
+        classes: 'stretched-link link-underline link-underline-opacity-0 link-underline-opacity-100-hover text-start'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         target: entity
         custom_uri: ''
         target_attribute: default
@@ -66,7 +70,7 @@ third_party_settings:
         - group_media
         - group_column
       label: Row
-      parent_name: group_link
+      parent_name: group_card_clickable
       region: content
       weight: 5
       format_type: html_element
@@ -102,7 +106,7 @@ third_party_settings:
       children:
         - smart_title
         - group_summary
-        - group_read_more
+        - group_link
       label: Column
       parent_name: group_row
       region: content
@@ -123,7 +127,7 @@ third_party_settings:
       label: Heading
       parent_name: ''
       region: hidden
-      weight: 3
+      weight: 7
       format_type: html_element
       format_settings:
         classes: 'card-title text-midnight h4 mt-md-2'
@@ -133,26 +137,6 @@ third_party_settings:
         label_element: h3
         label_element_classes: ''
         attributes: ''
-        effect: none
-        speed: fast
-    group_read_more:
-      children:
-        - links
-      label: 'Read more'
-      parent_name: group_column
-      region: content
-      weight: 5
-      format_type: html_element
-      format_settings:
-        classes: 'card-clickable-link text-chili text-start'
-        show_empty_fields: false
-        id: ''
-        label_as_html: false
-        element: div
-        show_label: true
-        label_element: div
-        label_element_classes: ''
-        attributes: 'aria-hidden="true"'
         effect: none
         speed: fast
     group_summary:
@@ -173,11 +157,35 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
+    group_card_body:
+      children: {  }
+      label: 'Card body'
+      parent_name: group_card_clickable
+      region: hidden
+      weight: 1
+      format_type: html_element
+      format_settings:
+        classes: 'card-body p-0'
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
 id: node.az_flexible_page.az_row
 targetEntityType: node
 bundle: az_flexible_page
 mode: az_row
 content:
+  az_flexible_page_read_more:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
   field_az_media_image:
     type: entity_reference_entity_view
     label: hidden
@@ -194,11 +202,6 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
   smart_title:
     settings: {  }
     third_party_settings: {  }
@@ -207,4 +210,6 @@ content:
 hidden:
   field_az_main_content: true
   field_az_marketing_page_style: true
+  field_az_metatag: true
   field_az_page_category: true
+  links: true

--- a/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_row.yml
+++ b/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_row.yml
@@ -6,7 +6,6 @@ dependencies:
     - field.field.node.az_flexible_page.field_az_main_content
     - field.field.node.az_flexible_page.field_az_marketing_page_style
     - field.field.node.az_flexible_page.field_az_media_image
-    - field.field.node.az_flexible_page.field_az_metatag
     - field.field.node.az_flexible_page.field_az_page_category
     - field.field.node.az_flexible_page.field_az_summary
     - node.type.az_flexible_page
@@ -210,6 +209,5 @@ content:
 hidden:
   field_az_main_content: true
   field_az_marketing_page_style: true
-  field_az_metatag: true
   field_az_page_category: true
   links: true

--- a/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_row_with_background.yml
+++ b/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_row_with_background.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.az_flexible_page.field_az_main_content
     - field.field.node.az_flexible_page.field_az_marketing_page_style
     - field.field.node.az_flexible_page.field_az_media_image
+    - field.field.node.az_flexible_page.field_az_metatag
     - field.field.node.az_flexible_page.field_az_page_category
     - field.field.node.az_flexible_page.field_az_summary
     - node.type.az_flexible_page
@@ -30,16 +31,17 @@ third_party_settings:
   field_group:
     group_card:
       children:
-        - group_link
+        - group_card_body
       label: Card
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'text-bg-gray-100 card card-borderless card-clickable hover mb-4'
+        classes: 'text-bg-gray-100 card card-borderless hover mb-4'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -47,21 +49,6 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-    group_link:
-      children:
-        - group_card_body
-      label: Link
-      parent_name: group_card
-      region: content
-      weight: 4
-      format_type: link
-      format_settings:
-        classes: text-decoration-none
-        show_empty_fields: false
-        id: ''
-        target: custom_uri
-        custom_uri: '[node:az-canonical-url]'
-        target_attribute: default
     group_row:
       children:
         - group_column_image
@@ -86,9 +73,9 @@ third_party_settings:
       children:
         - group_row
       label: 'Card Body'
-      parent_name: group_link
+      parent_name: group_card
       region: content
-      weight: 6
+      weight: 1
       format_type: html_element
       format_settings:
         classes: 'card-body pt-4 pb-2 px-4'
@@ -161,28 +148,51 @@ third_party_settings:
         effect: none
         speed: fast
     group_view_page:
-      children: {  }
+      children:
+        - group_link
       label: 'View page'
       parent_name: group_column_text
       region: content
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link mt-2 pb-3'
+        classes: 'mt-2 pb-3'
         show_empty_fields: true
         id: ''
+        label_as_html: false
         element: div
-        show_label: true
+        show_label: false
         label_element: span
         label_element_classes: ''
         attributes: ''
         effect: none
         speed: fast
+    group_link:
+      children:
+        - az_flexible_page_read_more
+      label: Link
+      parent_name: group_view_page
+      region: content
+      weight: 3
+      format_type: link
+      format_settings:
+        classes: 'stretched-link link-underline link-underline-opacity-0 link-underline-opacity-100-hover'
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        target: custom_uri
+        custom_uri: '[node:az-canonical-url]'
+        target_attribute: default
 id: node.az_flexible_page.az_row_with_background
 targetEntityType: node
 bundle: az_flexible_page
 mode: az_row_with_background
 content:
+  az_flexible_page_read_more:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
   field_az_media_image:
     type: entity_reference_entity_view
     label: hidden
@@ -207,5 +217,6 @@ content:
 hidden:
   field_az_main_content: true
   field_az_marketing_page_style: true
+  field_az_metatag: true
   field_az_page_category: true
   links: true

--- a/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_row_with_background.yml
+++ b/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_row_with_background.yml
@@ -6,7 +6,6 @@ dependencies:
     - field.field.node.az_flexible_page.field_az_main_content
     - field.field.node.az_flexible_page.field_az_marketing_page_style
     - field.field.node.az_flexible_page.field_az_media_image
-    - field.field.node.az_flexible_page.field_az_metatag
     - field.field.node.az_flexible_page.field_az_page_category
     - field.field.node.az_flexible_page.field_az_summary
     - node.type.az_flexible_page
@@ -217,6 +216,5 @@ content:
 hidden:
   field_az_main_content: true
   field_az_marketing_page_style: true
-  field_az_metatag: true
   field_az_page_category: true
   links: true

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_row_with_background.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_row_with_background.yml
@@ -157,7 +157,7 @@ third_party_settings:
       weight: 28
       format_type: link
       format_settings:
-        classes: 'text-decoration-none stretched-link'
+        classes: 'stretched-link link-underline link-underline-opacity-0 link-underline-opacity-100-hover'
         show_empty_fields: false
         id: ''
         label_as_html: false

--- a/modules/custom/az_person/az_person.module
+++ b/modules/custom/az_person/az_person.module
@@ -10,6 +10,10 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\node\Entity\NodeType;
 
 /**
  * Implements hook_preprocess_node().
@@ -18,6 +22,41 @@ function az_person_preprocess_node__az_person(&$variables) {
 
   $variables['#attached']['library'][] = 'az_person/az_person';
 
+}
+
+/**
+ * Implements hook_entity_extra_field_info().
+ */
+function az_person_entity_extra_field_info() {
+  $extra = [];
+
+  // Check to see if our content type exists.
+  $bundle = NodeType::load('az_person');
+  if ($bundle) {
+    // View profile pseudo field.
+    $extra['node'][$bundle->id()]['display']['az_person_view_profile'] = [
+      'label' => t('View profile pseudo field'),
+      'description' => "This is a pseudo field from az_person",
+      'weight' => 50,
+      'visible' => FALSE,
+    ];
+  }
+
+  return $extra;
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_view().
+ */
+function az_person_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+
+  // View profile pseudo field.
+  if ($entity instanceof FieldableEntityInterface && $display->getComponent('az_person_view_profile')) {
+    $build['az_person_view_profile'][] = [
+      '#type' => 'markup',
+      '#markup' => Html::escape('View profile'),
+    ];
+  }
 }
 
 /**

--- a/modules/custom/az_person/config/install/core.entity_view_display.node.az_person.az_row_with_background.yml
+++ b/modules/custom/az_person/config/install/core.entity_view_display.node.az_person.az_row_with_background.yml
@@ -5,21 +5,27 @@ dependencies:
     - core.entity_view_mode.node.az_row_with_background
     - field.field.node.az_person.field_az_address
     - field.field.node.az_person.field_az_attachments
+    - field.field.node.az_person.field_az_awards
     - field.field.node.az_person.field_az_body
     - field.field.node.az_person.field_az_degrees
     - field.field.node.az_person.field_az_email
     - field.field.node.az_person.field_az_fname
+    - field.field.node.az_person.field_az_licensure_certification
     - field.field.node.az_person.field_az_link
     - field.field.node.az_person.field_az_links
     - field.field.node.az_person.field_az_lname
     - field.field.node.az_person.field_az_media_image
+    - field.field.node.az_person.field_az_metatag
     - field.field.node.az_person.field_az_netid
     - field.field.node.az_person.field_az_person_category
     - field.field.node.az_person.field_az_person_category_sec
     - field.field.node.az_person.field_az_phones
     - field.field.node.az_person.field_az_pronouns
+    - field.field.node.az_person.field_az_research_interests
     - field.field.node.az_person.field_az_suffix
+    - field.field.node.az_person.field_az_teaching_interests
     - field.field.node.az_person.field_az_titles
+    - field.field.node.az_person.field_az_work_experience
     - node.type.az_person
   module:
     - field_group
@@ -29,16 +35,17 @@ third_party_settings:
   field_group:
     group_card:
       children:
-        - group_link
+        - group_card_body
       label: Card
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'text-bg-gray-100 card border-0 card-clickable hover mb-4'
+        classes: 'text-bg-gray-100 card border-0 hover mb-4'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -50,7 +57,7 @@ third_party_settings:
       children:
         - group_row
       label: 'Card Body'
-      parent_name: group_link
+      parent_name: group_card
       region: content
       weight: 2
       format_type: html_element
@@ -65,21 +72,6 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-    group_link:
-      children:
-        - group_card_body
-      label: Link
-      parent_name: group_card
-      region: content
-      weight: 1
-      format_type: link
-      format_settings:
-        classes: text-decoration-none
-        show_empty_fields: false
-        id: ''
-        target: custom_uri
-        custom_uri: '[node:az-canonical-url]'
-        target_attribute: default
     group_row:
       children:
         - group_column_image
@@ -160,18 +152,20 @@ third_party_settings:
         effect: none
         speed: fast
     group_view_person:
-      children: {  }
+      children:
+        - group_link
       label: 'View profile'
       parent_name: group_column_text
       region: content
       weight: 4
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link mt-2 pb-3'
-        show_empty_fields: true
+        classes: 'mt-2 pb-3'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
-        show_label: true
+        show_label: false
         label_element: span
         label_element_classes: ''
         attributes: ''
@@ -198,6 +192,22 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
+    group_link:
+      children:
+        - az_person_view_profile
+      label: Link
+      parent_name: group_view_person
+      region: content
+      weight: 4
+      format_type: link
+      format_settings:
+        classes: 'stretched-link link-underline link-underline-opacity-0 link-underline-opacity-100-hover'
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        target: entity
+        custom_uri: ''
+        target_attribute: default
   smart_title:
     enabled: true
     settings:
@@ -209,6 +219,11 @@ targetEntityType: node
 bundle: az_person
 mode: az_row_with_background
 content:
+  az_person_view_profile:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
+    region: content
   field_az_media_image:
     type: entity_reference_entity_view
     label: hidden
@@ -242,16 +257,22 @@ content:
 hidden:
   field_az_address: true
   field_az_attachments: true
+  field_az_awards: true
   field_az_body: true
   field_az_degrees: true
   field_az_email: true
   field_az_fname: true
+  field_az_licensure_certification: true
   field_az_link: true
   field_az_links: true
   field_az_lname: true
+  field_az_metatag: true
   field_az_netid: true
   field_az_person_category: true
   field_az_person_category_sec: true
   field_az_phones: true
   field_az_pronouns: true
+  field_az_research_interests: true
+  field_az_teaching_interests: true
+  field_az_work_experience: true
   links: true

--- a/modules/custom/az_person/config/install/core.entity_view_display.node.az_person.az_row_with_background.yml
+++ b/modules/custom/az_person/config/install/core.entity_view_display.node.az_person.az_row_with_background.yml
@@ -15,7 +15,6 @@ dependencies:
     - field.field.node.az_person.field_az_links
     - field.field.node.az_person.field_az_lname
     - field.field.node.az_person.field_az_media_image
-    - field.field.node.az_person.field_az_metatag
     - field.field.node.az_person.field_az_netid
     - field.field.node.az_person.field_az_person_category
     - field.field.node.az_person.field_az_person_category_sec
@@ -266,7 +265,6 @@ hidden:
   field_az_link: true
   field_az_links: true
   field_az_lname: true
-  field_az_metatag: true
   field_az_netid: true
   field_az_person_category: true
   field_az_person_category_sec: true

--- a/modules/custom/az_publication/config/install/core.entity_view_display.node.az_publication.az_card.yml
+++ b/modules/custom/az_publication/config/install/core.entity_view_display.node.az_publication.az_card.yml
@@ -41,9 +41,9 @@ third_party_settings:
       children:
         - az_publication_bibliography
       label: Reference
-      parent_name: group_link
+      parent_name: group_card_body
       region: content
-      weight: 7
+      weight: 4
       format_type: html_element
       format_settings:
         classes: 'text-body-secondary fw-normal small mt-2'
@@ -58,16 +58,17 @@ third_party_settings:
         speed: fast
     group_card_clickable:
       children:
-        - group_link
+        - group_card_body
       label: 'Card Clickable'
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card card-borderless card-clickable mb-4'
+        classes: 'card card-borderless mb-4'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -75,30 +76,13 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
-    group_link:
-      children:
-        - field_az_publication_image
-        - group_heading
-        - group_az_publication_reference
-      label: Link
-      parent_name: group_card_clickable
-      region: content
-      weight: 1
-      format_type: link
-      format_settings:
-        classes: 'card-body p-0 hide-contextual-links'
-        show_empty_fields: false
-        id: ''
-        target: entity
-        custom_uri: ''
-        target_attribute: default
     group_heading:
       children:
         - smart_title
       label: Heading
-      parent_name: group_link
+      parent_name: group_card_body
       region: content
-      weight: 6
+      weight: 3
       format_type: html_element
       format_settings:
         classes: 'card-title text-midnight h5 mb-0'
@@ -111,6 +95,45 @@ third_party_settings:
         attributes: ''
         effect: none
         speed: fast
+    group_card_body:
+      children:
+        - field_az_publication_image
+        - group_heading
+        - group_az_publication_reference
+        - group_link
+      label: 'Card body'
+      parent_name: group_card_clickable
+      region: content
+      weight: 5
+      format_type: html_element
+      format_settings:
+        classes: 'card-body p-0'
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+    group_link:
+      children:
+        - links
+      label: Link
+      parent_name: group_card_body
+      region: content
+      weight: 5
+      format_type: link
+      format_settings:
+        classes: stretched-link
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        target: entity
+        custom_uri: ''
+        target_attribute: default
   smart_title:
     enabled: true
     settings:
@@ -127,7 +150,7 @@ content:
   az_publication_bibliography:
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 8
     region: content
   field_az_publication_image:
     type: entity_reference_entity_view
@@ -136,7 +159,12 @@ content:
       view_mode: az_card_image
       link: false
     third_party_settings: {  }
-    weight: 5
+    weight: 2
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 10
     region: content
   smart_title:
     settings: {  }
@@ -170,4 +198,3 @@ hidden:
   field_az_publication_type: true
   field_az_publication_version: true
   field_az_publication_volume: true
-  links: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #4591 

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

https://review.digital.arizona.edu/arizona-bootstrap/main/docs/5.0/backwards-compatibility/#card-classes

'card-clickable' and 'card-clickable-link' are deprecated. This PR updates all view modes that are currently using card-clickable to use stretched-link's instead.

az_event --> az_card, az_card_alternate, az_row_with_background
az_news --> az_row_with_background
az_flexible_page --> az_card, az_row, az_row_with_background
az_person --> az_row_with_background
az_publication --> az_card

### Release notes
<!--- Delete this line (and the closing comment line) to enable release notes.

If this change requires release notes: provide a summary of changes, how to use this change, and any related links. This content will be pasted in the [release notes](https://github.com/az-digital/az_quickstart/releases). Use markdown format to ensure proper pasting of information. [Release notes example](https://github.com/az-digital/az_quickstart/releases/tag/2.11.0)

Make sure to add the `release notes` label to this PR.

```
Add markdown of release notes here.
```

Delete this line to enable release notes.  -->


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Verify all card-clickable's are replaced by stretched-link's. And all links (i.e. on "read more", "view page", "view profile") on cards are Arizona red and then upon hover change to chili and become underlined.

az_event and az_news (rows with background):
https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4660.probo.build/event-view-modes
az_flexible_page and az_person (rows with background):
https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4660.probo.build/page-view-modes
az_publication:
https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4660.probo.build/publication-view-modes


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Update to remove deprecated elements
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [x] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
