### PR TITLE
Closes #4591 - Update cases of card-clickable to stretched link

### DIFF
--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_card.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_card.yml
@@ -35,8 +35,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card border-0 card-clickable text-bg-gray-100 mt-0 mb-4 p-0'
+        classes: 'card border-0 text-bg-gray-100 mt-0 mb-4 p-0'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -55,9 +57,10 @@ third_party_settings:
       weight: 1
       format_type: link
       format_settings:
-        classes: 'card-body p-4'
+        classes: 'card-body p-4 stretched-link text-decoration-none'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_card_alternate.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_card_alternate.yml
@@ -35,8 +35,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card border-0 card-clickable text-bg-gray-100 mt-0 mb-4 p-0'
+        classes: 'card border-0 text-bg-gray-100 mt-0 mb-4 p-0'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -56,9 +58,10 @@ third_party_settings:
       weight: 1
       format_type: link
       format_settings:
-        classes: 'card-body p-4'
+        classes: 'card-body p-4 stretched-link text-decoration-none'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default

--- a/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row_with_background.yml
+++ b/modules/custom/az_event/config/install/core.entity_view_display.node.az_event.az_row_with_background.yml
@@ -34,9 +34,10 @@ third_party_settings:
       weight: 2
       format_type: link
       format_settings:
-        classes: text-decoration-none
+        classes: 'text-decoration-none stretched-link'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -49,9 +50,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'text-bg-gray-100 card border-0 card-clickable hover mb-4'
+        classes: 'text-bg-gray-100 card border-0 hover mb-4'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -186,9 +188,10 @@ third_party_settings:
       weight: 14
       format_type: html_element
       format_settings:
-        classes: 'text-bg-azurite py-3'
+        classes: 'text-bg-azurite py-3 rounded'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -204,13 +207,14 @@ third_party_settings:
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link mt-2 pb-3'
+        classes: 'mt-2 pb-3'
         show_empty_fields: true
         id: ''
+        label_as_html: false
         element: div
         show_label: true
         label_element: span
-        label_element_classes: ''
+        label_element_classes: hover-text-underline
         attributes: ''
         effect: none
         speed: fast

--- a/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_card.yml
+++ b/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_card.yml
@@ -32,7 +32,7 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card border-0 card-clickable hover text-bg-gray-100 mb-0 mt-0 mb-4 p-0 overflow-hidden'
+        classes: 'card border-0 hover text-bg-gray-100 mb-0 mt-0 mb-4 p-0 overflow-hidden'
         show_empty_fields: false
         id: ''
         label_as_html: false
@@ -53,8 +53,10 @@ third_party_settings:
       weight: 5
       format_type: link
       format_settings:
-        classes: 'card-body p-0'
+        classes: 'card-body p-0 stretched-link link-primary text-decoration-none'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         target: entity
         custom_uri: ''
         target_attribute: default
@@ -68,7 +70,9 @@ third_party_settings:
       format_type: html_element
       format_settings:
         classes: 'card-img-top mb-0'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -105,8 +109,10 @@ third_party_settings:
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'card-text fw-normal'
+        classes: 'card-text fw-normal text-black'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -123,14 +129,14 @@ third_party_settings:
       weight: 6
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link text-chili text-start'
+        classes: text-start
         show_empty_fields: false
         id: ''
         label_as_html: false
         element: div
         show_label: true
         label_element: div
-        label_element_classes: ''
+        label_element_classes: hover-text-underline
         attributes: 'aria-hidden="true"'
         effect: none
         speed: fast

--- a/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_row.yml
+++ b/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_row.yml
@@ -36,7 +36,7 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card card-borderless card-clickable hover text-bg-gray-100 p-4'
+        classes: 'card border-0 text-bg-gray-100 hover p-4'
         show_empty_fields: false
         id: ''
         label_as_html: false
@@ -56,8 +56,10 @@ third_party_settings:
       weight: 2
       format_type: link
       format_settings:
-        classes: 'card-body p-0'
+        classes: 'card-body p-0 stretched-link link-primary text-decoration-none'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         target: entity
         custom_uri: ''
         target_attribute: default
@@ -144,14 +146,14 @@ third_party_settings:
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link text-chili text-start'
+        classes: text-start
         show_empty_fields: false
         id: ''
         label_as_html: false
         element: div
         show_label: true
         label_element: div
-        label_element_classes: ''
+        label_element_classes: hover-text-underline
         attributes: 'aria-hidden="true"'
         effect: none
         speed: fast
@@ -164,8 +166,10 @@ third_party_settings:
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'card-text fw-normal'
+        classes: 'card-text fw-normal text-black'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3

--- a/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_row_with_background.yml
+++ b/modules/custom/az_flexible_page/config/install/core.entity_view_display.node.az_flexible_page.az_row_with_background.yml
@@ -37,9 +37,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'text-bg-gray-100 card card-borderless card-clickable hover mb-4'
+        classes: 'text-bg-gray-100 card border-0 hover mb-4'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -56,9 +57,10 @@ third_party_settings:
       weight: 4
       format_type: link
       format_settings:
-        classes: text-decoration-none
+        classes: 'stretched-link text-decoration-none'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -153,6 +155,7 @@ third_party_settings:
         classes: 'text-body-secondary fw-normal'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -168,13 +171,14 @@ third_party_settings:
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link mt-2 pb-3'
+        classes: 'mt-2 pb-3'
         show_empty_fields: true
         id: ''
+        label_as_html: false
         element: div
         show_label: true
         label_element: span
-        label_element_classes: ''
+        label_element_classes: hover-text-underline
         attributes: ''
         effect: none
         speed: fast

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_card.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_card.yml
@@ -36,21 +36,15 @@ third_party_settings:
   field_group:
     group_card_clickable:
       children:
-        - group_card_image
-        - group_heading
-        - group_text_muted
-        - group_summary
-        - group_read_more
+        - group_link
       label: 'Card Clickable'
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card hover border-0 mb-4 hover'
-        show_empty_fields: false
+        classes: 'card card-borderless card-clickable mb-4'
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -60,17 +54,19 @@ third_party_settings:
         speed: fast
     group_link:
       children:
-        - az_news_read_more
+        - field_az_media_thumbnail_image
+        - group_heading
+        - group_text_muted
+        - group_summary
+        - group_read_more
       label: Link
-      parent_name: group_read_more_text
+      parent_name: group_card_clickable
       region: content
-      weight: 8
+      weight: 4
       format_type: link
       format_settings:
-        classes: 'card-body p-0 stretched-link link-primary link-underline link-underline-opacity-0 link-underline-opacity-100-hover'
-        show_empty_fields: false
+        classes: 'card-body p-0'
         id: ''
-        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -78,9 +74,9 @@ third_party_settings:
       children:
         - smart_title
       label: Heading
-      parent_name: group_card_clickable
+      parent_name: group_link
       region: content
-      weight: 8
+      weight: 2
       format_type: html_element
       format_settings:
         classes: 'card-title text-midnight h5 mb-0'
@@ -95,16 +91,14 @@ third_party_settings:
     group_text_muted:
       children:
         - field_az_published
-      label: 'Text Body Secondary'
-      parent_name: group_card_clickable
+      label: 'Text Muted'
+      parent_name: group_link
       region: content
-      weight: 9
+      weight: 3
       format_type: html_element
       format_settings:
-        classes: 'text-body-secondary fw-normal small mt-2'
-        show_empty_fields: false
+        classes: 'text-muted font-weight-normal small mt-2'
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -116,15 +110,13 @@ third_party_settings:
       children:
         - field_az_summary
       label: Summary
-      parent_name: group_card_clickable
+      parent_name: group_link
       region: content
-      weight: 10
+      weight: 4
       format_type: html_element
       format_settings:
-        classes: 'card-text fw-normal mt-2'
-        show_empty_fields: false
+        classes: 'card-text font-weight-normal mt-2'
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -136,15 +128,14 @@ third_party_settings:
       children:
         - group_read_more_text
       label: 'Read more'
-      parent_name: group_card_clickable
+      parent_name: group_link
       region: content
-      weight: 11
+      weight: 5
       format_type: html_element
       format_settings:
-        classes: mt-2
+        classes: 'card-clickable-link mt-2'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: ''
@@ -154,37 +145,16 @@ third_party_settings:
         speed: fast
     group_read_more_text:
       children:
-        - group_link
+        - az_news_read_more
       label: 'Read more text'
       parent_name: group_read_more
       region: content
-      weight: 4
+      weight: 6
       format_type: html_element
       format_settings:
-        classes: text-start
+        classes: 'text-chili text-left'
         show_empty_fields: false
         id: ''
-        label_as_html: false
-        element: div
-        show_label: false
-        label_element: h3
-        label_element_classes: ''
-        attributes: ''
-        effect: none
-        speed: fast
-    group_card_image:
-      children:
-        - field_az_media_thumbnail_image
-      label: 'Card Image'
-      parent_name: group_card_clickable
-      region: content
-      weight: 7
-      format_type: html_element
-      format_settings:
-        classes: 'img-fluid card-img-top hover-img-zoom-in'
-        show_empty_fields: false
-        id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -200,7 +170,7 @@ content:
   az_news_read_more:
     settings: {  }
     third_party_settings: {  }
-    weight: 9
+    weight: 7
     region: content
   field_az_media_thumbnail_image:
     type: entity_reference_entity_view
@@ -209,7 +179,7 @@ content:
       view_mode: az_card_image
       link: false
     third_party_settings: {  }
-    weight: 4
+    weight: 0
     region: content
   field_az_published:
     type: timestamp_ap_style
@@ -225,10 +195,8 @@ content:
       time_before_date: 0
       use_all_day: 0
       capitalize_noon_and_midnight: 0
-      month_only: 0
-      hide_date: 0
     third_party_settings: {  }
-    weight: 6
+    weight: 5
     region: content
   field_az_summary:
     type: az_text_summary
@@ -240,7 +208,7 @@ content:
   smart_title:
     settings: {  }
     third_party_settings: {  }
-    weight: 4
+    weight: 3
     region: content
 hidden:
   field_az_attachments: true

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_card.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_card.yml
@@ -43,8 +43,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card card-borderless card-clickable mb-4'
+        classes: 'card border-0 mb-4 hover'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -65,8 +67,10 @@ third_party_settings:
       weight: 4
       format_type: link
       format_settings:
-        classes: 'card-body p-0'
+        classes: 'card-body p-0 stretched-link link-primary text-decoration-none'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -91,14 +95,16 @@ third_party_settings:
     group_text_muted:
       children:
         - field_az_published
-      label: 'Text Muted'
+      label: 'Text Body Secondary'
       parent_name: group_link
       region: content
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'text-muted font-weight-normal small mt-2'
+        classes: 'text-body-secondary fw-normal small mt-2'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -115,8 +121,10 @@ third_party_settings:
       weight: 4
       format_type: html_element
       format_settings:
-        classes: 'card-text font-weight-normal mt-2'
+        classes: 'card-text fw-normal mt-2 text-body'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -133,9 +141,10 @@ third_party_settings:
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link mt-2'
+        classes: mt-2
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: ''
@@ -152,9 +161,10 @@ third_party_settings:
       weight: 6
       format_type: html_element
       format_settings:
-        classes: 'text-chili text-left'
+        classes: 'text-start hover-text-underline'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -195,6 +205,8 @@ content:
       time_before_date: 0
       use_all_day: 0
       capitalize_noon_and_midnight: 0
+      month_only: 0
+      hide_date: 0
     third_party_settings: {  }
     weight: 5
     region: content

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_feature.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_feature.yml
@@ -51,9 +51,10 @@ third_party_settings:
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'card card-borderless card-clickable mb-6'
+        classes: 'card border-0 mb-6'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -84,18 +85,23 @@ third_party_settings:
     group_link:
       children:
         - group_row
-      label: Link
+      label: 'Card body'
       parent_name: group_card
       region: content
       weight: 20
-      format_type: link
+      format_type: html_element
       format_settings:
         classes: 'card-body p-0'
         show_empty_fields: false
         id: ''
-        target: entity
-        custom_uri: ''
-        target_attribute: default
+        label_as_html: false
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
     group_text_column:
       children:
         - group_date
@@ -127,9 +133,10 @@ third_party_settings:
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'text-muted font-weight-normal'
+        classes: 'text-body-secondary fw-normal'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -165,9 +172,10 @@ third_party_settings:
       weight: 9
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link mt-3'
+        classes: mt-3
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: ''
@@ -201,18 +209,15 @@ third_party_settings:
       parent_name: group_read_article
       region: content
       weight: 2
-      format_type: html_element
+      format_type: link
       format_settings:
-        classes: 'btn btn-red'
+        classes: 'btn btn-red stretched-link'
         show_empty_fields: false
         id: ''
-        element: div
-        show_label: false
-        label_element: h3
-        label_element_classes: ''
-        attributes: ''
-        effect: none
-        speed: fast
+        label_as_html: false
+        target: entity
+        custom_uri: ''
+        target_attribute: default
 id: node.az_news.az_feature
 targetEntityType: node
 bundle: az_news
@@ -249,6 +254,7 @@ content:
       use_all_day: 0
       capitalize_noon_and_midnight: 0
       hide_date: 0
+      month_only: 0
     third_party_settings: {  }
     weight: 1
     region: content

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_feature.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_feature.yml
@@ -44,17 +44,16 @@ third_party_settings:
   field_group:
     group_card:
       children:
-        - group_row
+        - group_link
       label: Card
       parent_name: ''
       region: content
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'card border-0 mb-6'
+        classes: 'card card-borderless card-clickable mb-6'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -67,7 +66,7 @@ third_party_settings:
         - group_photo_column
         - group_text_column
       label: Row
-      parent_name: group_card
+      parent_name: group_link
       region: content
       weight: 21
       format_type: html_element
@@ -84,17 +83,16 @@ third_party_settings:
         speed: fast
     group_link:
       children:
-        - az_news_read_more
+        - group_row
       label: Link
-      parent_name: group_read_more_text
+      parent_name: group_card
       region: content
-      weight: 22
+      weight: 20
       format_type: link
       format_settings:
-        classes: 'card-body p-0 stretched-link text-decoration-none'
+        classes: 'card-body p-0'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         target: entity
         custom_uri: ''
         target_attribute: default
@@ -129,10 +127,9 @@ third_party_settings:
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'text-body-secondary fw-normal'
+        classes: 'text-muted font-weight-normal'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -168,10 +165,9 @@ third_party_settings:
       weight: 9
       format_type: html_element
       format_settings:
-        classes: mt-3
+        classes: 'card-clickable-link mt-3'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: ''
@@ -200,7 +196,7 @@ third_party_settings:
         speed: fast
     group_read_more_text:
       children:
-        - group_link
+        - az_news_read_more
       label: 'Read more text'
       parent_name: group_read_article
       region: content
@@ -225,7 +221,7 @@ content:
   az_news_read_more:
     settings: {  }
     third_party_settings: {  }
-    weight: 23
+    weight: 1
     region: content
   field_az_media_image:
     type: media_thumbnail
@@ -253,7 +249,6 @@ content:
       use_all_day: 0
       capitalize_noon_and_midnight: 0
       hide_date: 0
-      month_only: 0
     third_party_settings: {  }
     weight: 1
     region: content

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_marquee.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_marquee.yml
@@ -36,8 +36,10 @@ third_party_settings:
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'card card-borderless card-clickable p-0 mb-4'
+        classes: 'card border-0 p-0 mb-4 hover'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -48,14 +50,16 @@ third_party_settings:
     group_text_muted:
       children:
         - field_az_published
-      label: 'Text Muted'
+      label: 'Text Body Secondary'
       parent_name: group_link
       region: content
       weight: 4
       format_type: html_element
       format_settings:
-        classes: 'text-muted font-weight-normal mb-0'
+        classes: 'text-body-secondary fw-normal mb-0'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -72,8 +76,10 @@ third_party_settings:
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'card-img mb-1'
+        classes: mb-1
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -93,8 +99,10 @@ third_party_settings:
       weight: 4
       format_type: link
       format_settings:
-        classes: 'card-body p-0'
+        classes: 'card-body p-0 stretched-link link-primary text-decoration-none'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -125,9 +133,10 @@ third_party_settings:
       weight: 6
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link mt-1'
+        classes: mt-1
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: ''
@@ -162,9 +171,10 @@ third_party_settings:
       weight: 1
       format_type: html_element
       format_settings:
-        classes: 'text-chili text-left'
+        classes: 'text-start hover-text-underline'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -192,7 +202,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: az_card_image
+      view_mode: az_medium
       link: false
     third_party_settings: {  }
     weight: 0

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_marquee.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_marquee.yml
@@ -29,20 +29,15 @@ third_party_settings:
   field_group:
     group_row:
       children:
-        - group_photo_container
-        - group_text_muted
-        - group_heading
-        - group_read_more
+        - group_link
       label: 'Card Clickable'
       parent_name: group_content
       region: content
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'card border-0 p-0 mb-4'
-        show_empty_fields: false
+        classes: 'card card-borderless card-clickable p-0 mb-4'
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -53,16 +48,14 @@ third_party_settings:
     group_text_muted:
       children:
         - field_az_published
-      label: 'Text Body Secondary'
-      parent_name: group_row
+      label: 'Text Muted'
+      parent_name: group_link
       region: content
       weight: 4
       format_type: html_element
       format_settings:
-        classes: 'text-body-secondary fw-normal mb-0'
-        show_empty_fields: false
+        classes: 'text-muted font-weight-normal mb-0'
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -74,12 +67,12 @@ third_party_settings:
       children:
         - field_az_media_thumbnail_image
       label: 'Card Image'
-      parent_name: group_row
+      parent_name: group_link
       region: content
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'mb-1'
+        classes: 'card-img mb-1'
         id: ''
         element: div
         show_label: false
@@ -90,17 +83,18 @@ third_party_settings:
         speed: fast
     group_link:
       children:
-        - az_news_read_more
+        - group_photo_container
+        - group_text_muted
+        - group_heading
+        - group_read_more
       label: Link
-      parent_name: group_read_more_text
+      parent_name: group_row
       region: content
-      weight: 7
+      weight: 4
       format_type: link
       format_settings:
-        classes: 'card-body p-0 stretched-link link-primary link-underline link-underline-opacity-0 link-underline-opacity-100-hover'
-        show_empty_fields: false
+        classes: 'card-body p-0'
         id: ''
-        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -108,7 +102,7 @@ third_party_settings:
       children:
         - smart_title
       label: Heading
-      parent_name: group_row
+      parent_name: group_link
       region: content
       weight: 5
       format_type: html_element
@@ -126,15 +120,14 @@ third_party_settings:
       children:
         - group_read_more_text
       label: 'Read more'
-      parent_name: group_row
+      parent_name: group_link
       region: content
       weight: 6
       format_type: html_element
       format_settings:
-        classes: mt-1
+        classes: 'card-clickable-link mt-1'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: ''
@@ -162,17 +155,16 @@ third_party_settings:
         speed: fast
     group_read_more_text:
       children:
-        - group_link
+        - az_news_read_more
       label: 'Read more text'
       parent_name: group_read_more
       region: content
       weight: 1
       format_type: html_element
       format_settings:
-        classes: text-start
+        classes: 'text-chili text-left'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -194,13 +186,13 @@ content:
   az_news_read_more:
     settings: {  }
     third_party_settings: {  }
-    weight: 8
+    weight: 1
     region: content
   field_az_media_thumbnail_image:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: az_medium
+      view_mode: az_card_image
       link: false
     third_party_settings: {  }
     weight: 0

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_media_list.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_media_list.yml
@@ -50,14 +50,16 @@ third_party_settings:
     group_text_muted:
       children:
         - field_az_published
-      label: 'Text Muted'
+      label: 'Text Body Secondary'
       parent_name: group_text_column
       region: content
       weight: 6
       format_type: html_element
       format_settings:
-        classes: 'text-muted font-weight-normal mb-4'
+        classes: 'text-body-secondary fw-normal mb-4'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -113,8 +115,10 @@ third_party_settings:
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'card-title text-midnight h4'
+        classes: 'card-title text-midnight h4 mt-2'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: h2
         show_label: false
         label_element: h3
@@ -131,9 +135,10 @@ third_party_settings:
       weight: 9
       format_type: html_element
       format_settings:
-        classes: card-clickable-link
+        classes: ''
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: ''
@@ -150,8 +155,10 @@ third_party_settings:
       weight: 1
       format_type: link
       format_settings:
-        classes: 'card-body p-0'
+        classes: 'card-body p-0 stretched-link link-primary text-decoration-none'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -182,8 +189,10 @@ third_party_settings:
       weight: 7
       format_type: html_element
       format_settings:
-        classes: 'card-text font-weight-normal'
+        classes: 'card-text fw-normal text-body'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -200,8 +209,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card card-borderless card-clickable'
+        classes: 'card border-0 hover'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -218,9 +229,10 @@ third_party_settings:
       weight: 1
       format_type: html_element
       format_settings:
-        classes: 'text-chili my-4'
+        classes: 'my-4 hover-text-underline'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -268,6 +280,7 @@ content:
       use_all_day: 0
       capitalize_noon_and_midnight: 0
       hide_date: 0
+      month_only: 0
     third_party_settings: {  }
     weight: 5
     region: content

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_media_list.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_media_list.yml
@@ -50,16 +50,14 @@ third_party_settings:
     group_text_muted:
       children:
         - field_az_published
-      label: 'Text Body Secondary'
+      label: 'Text Muted'
       parent_name: group_text_column
       region: content
       weight: 6
       format_type: html_element
       format_settings:
-        classes: 'text-body-secondary fw-normal mb-4'
-        show_empty_fields: false
+        classes: 'text-muted font-weight-normal mb-4'
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -115,10 +113,8 @@ third_party_settings:
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'card-title text-midnight h4 mt-2'
-        show_empty_fields: false
+        classes: 'card-title text-midnight h4'
         id: ''
-        label_as_html: false
         element: h2
         show_label: false
         label_element: h3
@@ -135,10 +131,9 @@ third_party_settings:
       weight: 9
       format_type: html_element
       format_settings:
-        classes: ''
+        classes: card-clickable-link
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: ''
@@ -148,17 +143,15 @@ third_party_settings:
         speed: fast
     group_link:
       children:
-        - az_news_read_more
+        - group_bottom_border
       label: Link
-      parent_name: group_read_more_text
+      parent_name: group_card_clickable
       region: content
-      weight: 7
+      weight: 1
       format_type: link
       format_settings:
-        classes: 'card-body p-0 stretched-link link-primary link-underline link-underline-opacity-0 link-underline-opacity-100-hover'
-        show_empty_fields: false
+        classes: 'card-body p-0'
         id: ''
-        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -166,7 +159,7 @@ third_party_settings:
       children:
         - group_row
       label: 'Bottom Border'
-      parent_name: group_card_clickable
+      parent_name: group_link
       region: content
       weight: 6
       format_type: html_element
@@ -189,10 +182,8 @@ third_party_settings:
       weight: 7
       format_type: html_element
       format_settings:
-        classes: 'card-text fw-normal'
-        show_empty_fields: false
+        classes: 'card-text font-weight-normal'
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -202,17 +193,15 @@ third_party_settings:
         speed: fast
     group_card_clickable:
       children:
-        - group_bottom_border
+        - group_link
       label: 'Card Clickable'
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card border-0'
-        show_empty_fields: false
+        classes: 'card card-borderless card-clickable'
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -222,17 +211,16 @@ third_party_settings:
         speed: fast
     group_read_more_text:
       children:
-        - group_link
+        - az_news_read_more
       label: 'Read more text'
       parent_name: group_read_more
       region: content
       weight: 1
       format_type: html_element
       format_settings:
-        classes: my-4
+        classes: 'text-chili my-4'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -254,7 +242,7 @@ content:
   az_news_read_more:
     settings: {  }
     third_party_settings: {  }
-    weight: 8
+    weight: 2
     region: content
   field_az_media_thumbnail_image:
     type: entity_reference_entity_view
@@ -280,7 +268,6 @@ content:
       use_all_day: 0
       capitalize_noon_and_midnight: 0
       hide_date: 0
-      month_only: 0
     third_party_settings: {  }
     weight: 5
     region: content

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_medium_media_list.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_medium_media_list.yml
@@ -49,16 +49,14 @@ third_party_settings:
     group_text_muted:
       children:
         - field_az_published
-      label: 'Text Body Secondary'
+      label: 'Text Muted'
       parent_name: group_text_column
       region: content
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'text-body-secondary fw-normal mb-0'
-        show_empty_fields: false
+        classes: 'text-muted font-weight-normal mb-0'
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -131,10 +129,9 @@ third_party_settings:
       weight: 7
       format_type: html_element
       format_settings:
-        classes: ''
+        classes: card-clickable-link
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: ''
@@ -144,17 +141,15 @@ third_party_settings:
         speed: fast
     group_link:
       children:
-        - az_news_read_more
+        - group_bottom_border
       label: Link
-      parent_name: group_read_more_text
+      parent_name: group_card_clickable
       region: content
-      weight: 7
+      weight: 1
       format_type: link
       format_settings:
-        classes: 'card-body p-0 stretched-link link-primary link-underline link-underline-opacity-0 link-underline-opacity-100-hover'
-        show_empty_fields: false
+        classes: 'card-body p-0'
         id: ''
-        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -162,7 +157,7 @@ third_party_settings:
       children:
         - group_row
       label: 'Bottom Border'
-      parent_name: group_card_clickable
+      parent_name: group_link
       region: content
       weight: 6
       format_type: html_element
@@ -178,17 +173,15 @@ third_party_settings:
         speed: fast
     group_card_clickable:
       children:
-        - group_bottom_border
+        - group_link
       label: 'Card Clickable'
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card border-0'
-        show_empty_fields: false
+        classes: 'card card-borderless card-clickable'
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -198,17 +191,16 @@ third_party_settings:
         speed: fast
     group_read_more_text:
       children:
-        - group_link
+        - az_news_read_more
       label: 'Read more text'
       parent_name: group_read_more
       region: content
       weight: 10
       format_type: html_element
       format_settings:
-        classes: 'mt-1 mb-4'
+        classes: 'text-chili mt-1 mb-4'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -230,7 +222,7 @@ content:
   az_news_read_more:
     settings: {  }
     third_party_settings: {  }
-    weight: 8
+    weight: 2
     region: content
   field_az_media_thumbnail_image:
     type: entity_reference_entity_view
@@ -256,7 +248,6 @@ content:
       use_all_day: 0
       capitalize_noon_and_midnight: 0
       hide_date: 0
-      month_only: 0
     third_party_settings: {  }
     weight: 0
     region: content

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_medium_media_list.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_medium_media_list.yml
@@ -49,14 +49,16 @@ third_party_settings:
     group_text_muted:
       children:
         - field_az_published
-      label: 'Text Muted'
+      label: 'Text Body Secondary'
       parent_name: group_text_column
       region: content
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'text-muted font-weight-normal mb-0'
+        classes: 'text-body-secondary fw-normal mb-0'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -129,9 +131,10 @@ third_party_settings:
       weight: 7
       format_type: html_element
       format_settings:
-        classes: card-clickable-link
+        classes: ''
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: ''
@@ -148,8 +151,10 @@ third_party_settings:
       weight: 1
       format_type: link
       format_settings:
-        classes: 'card-body p-0'
+        classes: 'card-body p-0 stretched-link link-primary text-decoration-none'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -180,8 +185,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card card-borderless card-clickable'
+        classes: 'card border-0 hover'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -198,9 +205,10 @@ third_party_settings:
       weight: 10
       format_type: html_element
       format_settings:
-        classes: 'text-chili mt-1 mb-4'
+        classes: 'mt-1 mb-4 hover-text-underline'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -248,6 +256,7 @@ content:
       use_all_day: 0
       capitalize_noon_and_midnight: 0
       hide_date: 0
+      month_only: 0
     third_party_settings: {  }
     weight: 0
     region: content

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_minimal_media_list.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_minimal_media_list.yml
@@ -75,9 +75,10 @@ third_party_settings:
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'pl-3 w-25'
+        classes: 'ps-3 w-25'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -112,9 +113,10 @@ third_party_settings:
       weight: 9
       format_type: html_element
       format_settings:
-        classes: card-clickable-link
+        classes: ''
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: ''
@@ -131,8 +133,10 @@ third_party_settings:
       weight: 1
       format_type: link
       format_settings:
-        classes: 'card-body p-0'
+        classes: 'card-body p-0 stretched-link link-primary text-decoration-none'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -163,8 +167,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card card-borderless card-clickable'
+        classes: 'card border-0 hover'
+        show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -181,9 +187,10 @@ third_party_settings:
       weight: 2
       format_type: html_element
       format_settings:
-        classes: 'text-chili small mt-2 mb-4 bold'
+        classes: 'small mt-2 mb-4 hover-text-underline'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_minimal_media_list.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_minimal_media_list.yml
@@ -75,10 +75,9 @@ third_party_settings:
       weight: 5
       format_type: html_element
       format_settings:
-        classes: 'ps-3 w-25'
+        classes: 'pl-3 w-25'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -113,10 +112,9 @@ third_party_settings:
       weight: 9
       format_type: html_element
       format_settings:
-        classes: ''
+        classes: card-clickable-link
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: ''
@@ -126,17 +124,15 @@ third_party_settings:
         speed: fast
     group_link:
       children:
-        - az_news_read_more
+        - group_bottom_border
       label: Link
-      parent_name: group_read_more_text
+      parent_name: group_card_clickable
       region: content
-      weight: 7
+      weight: 1
       format_type: link
       format_settings:
-        classes: 'card-body p-0 stretched-link link-primary link-underline link-underline-opacity-0 link-underline-opacity-100-hover'
-        show_empty_fields: false
+        classes: 'card-body p-0'
         id: ''
-        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -144,7 +140,7 @@ third_party_settings:
       children:
         - group_row
       label: 'Bottom Border'
-      parent_name: group_card_clickable
+      parent_name: group_link
       region: content
       weight: 6
       format_type: html_element
@@ -160,17 +156,15 @@ third_party_settings:
         speed: fast
     group_card_clickable:
       children:
-        - group_bottom_border
+        - group_link
       label: 'Card Clickable'
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card border-0'
-        show_empty_fields: false
+        classes: 'card card-borderless card-clickable'
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -180,17 +174,16 @@ third_party_settings:
         speed: fast
     group_read_more_text:
       children:
-        - group_link
+        - az_news_read_more
       label: 'Read more text'
       parent_name: group_read_more
       region: content
       weight: 2
       format_type: html_element
       format_settings:
-        classes: 'small mt-2 mb-4'
+        classes: 'text-chili small mt-2 mb-4 bold'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -212,7 +205,7 @@ content:
   az_news_read_more:
     settings: {  }
     third_party_settings: {  }
-    weight: 8
+    weight: 2
     region: content
   field_az_media_thumbnail_image:
     type: media_thumbnail

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_row.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_row.yml
@@ -33,16 +33,15 @@ third_party_settings:
     group_text_muted:
       children:
         - field_az_published
-      label: 'Text Body Secondary'
+      label: 'Text Muted'
       parent_name: group_media_body
       region: content
-      weight: 8
+      weight: 5
       format_type: html_element
       format_settings:
-        classes: text-body-secondary
+        classes: text-muted
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -56,13 +55,12 @@ third_party_settings:
       label: Link
       parent_name: group_row_wrap
       region: content
-      weight: 23
+      weight: 0
       format_type: link
       format_settings:
         classes: text-decoration-none
         show_empty_fields: false
         id: ''
-        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -73,7 +71,7 @@ third_party_settings:
       label: Row
       parent_name: group_story_link
       region: content
-      weight: 24
+      weight: 4
       format_type: html_element
       format_settings:
         classes: row
@@ -97,10 +95,9 @@ third_party_settings:
       weight: 22
       format_type: html_element
       format_settings:
-        classes: 'media-body text-decoration-none text-dark-silver fw-normal col d-flex flex-column'
+        classes: 'media-body text-decoration-none text-dark-silver font-weight-normal col d-flex flex-column'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -111,7 +108,7 @@ third_party_settings:
     group_media_right:
       children:
         - field_az_media_image
-      label: Media
+      label: 'Media'
       parent_name: group_media
       region: content
       weight: 21
@@ -133,13 +130,12 @@ third_party_settings:
       label: 'row wrap'
       parent_name: ''
       region: content
-      weight: 0
+      weight: 20
       format_type: html_element
       format_settings:
         classes: 'position-relative d-block list-group-item-action'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -155,8 +151,7 @@ third_party_settings:
       smart_title__classes:
         - text-midnight
         - my-0
-        - fw-bold
-        - mt-2
+        - font-weight-bold
 id: node.az_news.az_row
 targetEntityType: node
 bundle: az_news
@@ -171,7 +166,7 @@ content:
       image_loading:
         attribute: lazy
     third_party_settings: {  }
-    weight: 24
+    weight: 1
     region: content
   field_az_published:
     type: timestamp_ap_style
@@ -188,7 +183,6 @@ content:
       display_noon_and_midnight: 0
       capitalize_noon_and_midnight: 0
       hide_date: 0
-      month_only: 0
     third_party_settings: {  }
     weight: 0
     region: content
@@ -197,12 +191,12 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 10
+    weight: 7
     region: content
   smart_title:
     settings: {  }
     third_party_settings: {  }
-    weight: 9
+    weight: 6
     region: content
 hidden:
   az_news_read_more: true

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_row.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_row.yml
@@ -33,15 +33,16 @@ third_party_settings:
     group_text_muted:
       children:
         - field_az_published
-      label: 'Text Muted'
+      label: 'Text Body Secondary'
       parent_name: group_media_body
       region: content
       weight: 5
       format_type: html_element
       format_settings:
-        classes: text-muted
+        classes: text-body-secondary
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -61,6 +62,7 @@ third_party_settings:
         classes: text-decoration-none
         show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -95,9 +97,10 @@ third_party_settings:
       weight: 22
       format_type: html_element
       format_settings:
-        classes: 'media-body text-decoration-none text-dark-silver font-weight-normal col d-flex flex-column'
+        classes: 'media-body text-decoration-none text-dark-silver fw-normal col d-flex flex-column'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -108,7 +111,7 @@ third_party_settings:
     group_media_right:
       children:
         - field_az_media_image
-      label: 'Media'
+      label: Media
       parent_name: group_media
       region: content
       weight: 21
@@ -136,6 +139,7 @@ third_party_settings:
         classes: 'position-relative d-block list-group-item-action'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -151,7 +155,8 @@ third_party_settings:
       smart_title__classes:
         - text-midnight
         - my-0
-        - font-weight-bold
+        - fw-bold
+        - mt-2
 id: node.az_news.az_row
 targetEntityType: node
 bundle: az_news
@@ -183,6 +188,7 @@ content:
       display_noon_and_midnight: 0
       capitalize_noon_and_midnight: 0
       hide_date: 0
+      month_only: 0
     third_party_settings: {  }
     weight: 0
     region: content

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_row_with_background.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_row_with_background.yml
@@ -37,10 +37,9 @@ third_party_settings:
       weight: 28
       format_type: html_element
       format_settings:
-        classes: 'row g-0'
+        classes: 'row no-gutters'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -51,16 +50,15 @@ third_party_settings:
     group_text_muted:
       children:
         - field_az_published
-      label: 'Text Body Secondary'
+      label: 'Text Muted'
       parent_name: group_column_text
       region: content
       weight: 2
       format_type: html_element
       format_settings:
-        classes: 'text-body-secondary fw-normal'
+        classes: 'text-muted font-weight-normal'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -77,10 +75,9 @@ third_party_settings:
       weight: 25
       format_type: html_element
       format_settings:
-        classes: 'col-12 col-lg-4 pe-3'
+        classes: 'col-12 col-lg-4 pr-3'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -111,17 +108,16 @@ third_party_settings:
         speed: fast
     group_card:
       children:
-        - group_card_body
+        - group_link
       label: Card
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'text-bg-gray-100 card border-0 hover mb-4'
+        classes: 'bg-gray-100 card card-borderless card-clickable hover mb-4'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -133,7 +129,7 @@ third_party_settings:
       children:
         - group_row
       label: 'Card Body'
-      parent_name: group_card
+      parent_name: group_link
       region: content
       weight: 27
       format_type: html_element
@@ -150,33 +146,31 @@ third_party_settings:
         speed: fast
     group_link:
       children:
-        - az_news_read_more
+        - group_card_body
       label: Link
-      parent_name: group_read_more
+      parent_name: group_card
       region: content
-      weight: 28
+      weight: 1
       format_type: link
       format_settings:
-        classes: 'text-decoration-none stretched-link'
+        classes: text-decoration-none
         show_empty_fields: false
         id: ''
-        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
     group_read_more:
       children:
-        - group_link
+        - az_news_read_more
       label: 'Read more'
       parent_name: group_column_text
       region: content
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'mt-2 pb-3'
+        classes: 'card-clickable-link mt-2 pb-3'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -203,7 +197,7 @@ content:
   az_news_read_more:
     settings: {  }
     third_party_settings: {  }
-    weight: 29
+    weight: 25
     region: content
   field_az_media_thumbnail_image:
     type: entity_reference_entity_view
@@ -228,8 +222,6 @@ content:
       time_before_date: 0
       use_all_day: 0
       capitalize_noon_and_midnight: 0
-      month_only: 0
-      hide_date: 0
     third_party_settings: {  }
     weight: 3
     region: content

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_row_with_background.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_row_with_background.yml
@@ -37,9 +37,10 @@ third_party_settings:
       weight: 28
       format_type: html_element
       format_settings:
-        classes: 'row no-gutters'
+        classes: 'row g-0'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -50,15 +51,16 @@ third_party_settings:
     group_text_muted:
       children:
         - field_az_published
-      label: 'Text Muted'
+      label: 'Text Body Secondary'
       parent_name: group_column_text
       region: content
       weight: 2
       format_type: html_element
       format_settings:
-        classes: 'text-muted font-weight-normal'
+        classes: 'text-body-secondary fw-normal'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -75,9 +77,10 @@ third_party_settings:
       weight: 25
       format_type: html_element
       format_settings:
-        classes: 'col-12 col-lg-4 pr-3'
+        classes: 'col-12 col-lg-4 pe-3'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -115,9 +118,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'bg-gray-100 card card-borderless card-clickable hover mb-4'
+        classes: 'text-bg-gray-100 card border-0 hover mb-4'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -153,9 +157,10 @@ third_party_settings:
       weight: 1
       format_type: link
       format_settings:
-        classes: text-decoration-none
+        classes: 'stretched-link text-decoration-none'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -168,9 +173,10 @@ third_party_settings:
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link mt-2 pb-3'
+        classes: 'mt-2 pb-3 hover-text-underline'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -222,6 +228,8 @@ content:
       time_before_date: 0
       use_all_day: 0
       capitalize_noon_and_midnight: 0
+      month_only: 0
+      hide_date: 0
     third_party_settings: {  }
     weight: 3
     region: content

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_small_row.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_small_row.yml
@@ -31,7 +31,7 @@ third_party_settings:
         - group_media
         - group_text_column
       label: Row
-      parent_name: group_card_clickable
+      parent_name: group_link
       region: content
       weight: 0
       format_type: html_element
@@ -68,17 +68,16 @@ third_party_settings:
         speed: fast
     group_card_clickable:
       children:
-        - group_row
+        - group_link
       label: 'Card Clickable'
       parent_name: ''
       region: content
       weight: 0
       format_type: html_element
       format_settings:
-        classes: hover
+        classes: 'card-clickable hover'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -88,17 +87,16 @@ third_party_settings:
         speed: fast
     group_link:
       children:
-        - az_news_read_more
+        - group_row
       label: Link
-      parent_name: group_read_more_text
+      parent_name: group_card_clickable
       region: content
       weight: 1
       format_type: link
       format_settings:
-        classes: 'text-decoration-none stretched-link'
+        classes: text-decoration-none
         show_empty_fields: false
         id: ''
-        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -149,10 +147,9 @@ third_party_settings:
       weight: 22
       format_type: html_element
       format_settings:
-        classes: 'hover-text-underline mt-2'
+        classes: 'card-clickable-link hover-text-underline mt-2'
         show_empty_fields: false
         id: ''
-        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -162,7 +159,7 @@ third_party_settings:
         speed: fast
     group_read_more_text:
       children:
-        - group_link
+        - az_news_read_more
       label: 'Read more text'
       parent_name: group_read_more
       region: content
@@ -193,7 +190,7 @@ content:
   az_news_read_more:
     settings: {  }
     third_party_settings: {  }
-    weight: 2
+    weight: 11
     region: content
   field_az_media_thumbnail_image:
     type: entity_reference_entity_view

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_small_row.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_small_row.yml
@@ -75,9 +75,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card-clickable hover'
+        classes: hover
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -94,9 +95,10 @@ third_party_settings:
       weight: 1
       format_type: link
       format_settings:
-        classes: text-decoration-none
+        classes: 'text-decoration-none stretched-link'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -147,9 +149,10 @@ third_party_settings:
       weight: 22
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link hover-text-underline mt-2'
+        classes: mt-2
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -166,9 +169,10 @@ third_party_settings:
       weight: 20
       format_type: html_element
       format_settings:
-        classes: text-chili
+        classes: hover-text-underline
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3

--- a/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_small_row.yml
+++ b/modules/custom/az_news/config/install/core.entity_view_display.node.az_news.az_small_row.yml
@@ -75,7 +75,7 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: hover
+        classes: card border-0 hover
         show_empty_fields: false
         id: ''
         label_as_html: false

--- a/modules/custom/az_person/config/install/core.entity_view_display.node.az_person.az_row_with_background.yml
+++ b/modules/custom/az_person/config/install/core.entity_view_display.node.az_person.az_row_with_background.yml
@@ -5,10 +5,12 @@ dependencies:
     - core.entity_view_mode.node.az_row_with_background
     - field.field.node.az_person.field_az_address
     - field.field.node.az_person.field_az_attachments
+    - field.field.node.az_person.field_az_awards
     - field.field.node.az_person.field_az_body
     - field.field.node.az_person.field_az_degrees
     - field.field.node.az_person.field_az_email
     - field.field.node.az_person.field_az_fname
+    - field.field.node.az_person.field_az_licensure_certification
     - field.field.node.az_person.field_az_link
     - field.field.node.az_person.field_az_links
     - field.field.node.az_person.field_az_lname
@@ -18,8 +20,11 @@ dependencies:
     - field.field.node.az_person.field_az_person_category_sec
     - field.field.node.az_person.field_az_phones
     - field.field.node.az_person.field_az_pronouns
+    - field.field.node.az_person.field_az_research_interests
     - field.field.node.az_person.field_az_suffix
+    - field.field.node.az_person.field_az_teaching_interests
     - field.field.node.az_person.field_az_titles
+    - field.field.node.az_person.field_az_work_experience
     - node.type.az_person
   module:
     - field_group
@@ -36,9 +41,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'text-bg-gray-100 card border-0 card-clickable hover mb-4'
+        classes: 'text-bg-gray-100 card border-0 hover mb-4'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -74,9 +80,10 @@ third_party_settings:
       weight: 1
       format_type: link
       format_settings:
-        classes: text-decoration-none
+        classes: 'stretched-link text-decoration-none'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         target: custom_uri
         custom_uri: '[node:az-canonical-url]'
         target_attribute: default
@@ -90,9 +97,10 @@ third_party_settings:
       weight: 3
       format_type: html_element
       format_settings:
-        classes: 'row no-gutters'
+        classes: row
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -152,6 +160,7 @@ third_party_settings:
         classes: 'text-body-secondary fw-normal'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -167,13 +176,14 @@ third_party_settings:
       weight: 4
       format_type: html_element
       format_settings:
-        classes: 'card-clickable-link mt-2 pb-3'
+        classes: 'mt-2 pb-3'
         show_empty_fields: true
         id: ''
+        label_as_html: false
         element: div
         show_label: true
         label_element: span
-        label_element_classes: ''
+        label_element_classes: hover-text-underline
         attributes: ''
         effect: none
         speed: fast
@@ -242,10 +252,12 @@ content:
 hidden:
   field_az_address: true
   field_az_attachments: true
+  field_az_awards: true
   field_az_body: true
   field_az_degrees: true
   field_az_email: true
   field_az_fname: true
+  field_az_licensure_certification: true
   field_az_link: true
   field_az_links: true
   field_az_lname: true
@@ -254,4 +266,7 @@ hidden:
   field_az_person_category_sec: true
   field_az_phones: true
   field_az_pronouns: true
+  field_az_research_interests: true
+  field_az_teaching_interests: true
+  field_az_work_experience: true
   links: true

--- a/modules/custom/az_person/css/az_person.css
+++ b/modules/custom/az_person/css/az_person.css
@@ -10,7 +10,8 @@
 	margin-bottom: 0 !important;
 }
 
-.node--type-az-person .card .img-fluid,
+.node--type-az-person.node--view-mode-az-card .card .img-fluid,
+.node--type-az-person.node--view-mode-full .card .img-fluid,
 .az-person-modal .card .img-fluid {
 	/* Sharpen bottom corners of images in the top img card position */
 	border-radius: 0;

--- a/modules/custom/az_publication/config/install/core.entity_view_display.node.az_publication.az_card.yml
+++ b/modules/custom/az_publication/config/install/core.entity_view_display.node.az_publication.az_card.yml
@@ -49,6 +49,7 @@ third_party_settings:
         classes: 'text-body-secondary fw-normal small mt-2'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: div
@@ -65,9 +66,10 @@ third_party_settings:
       weight: 0
       format_type: html_element
       format_settings:
-        classes: 'card card-borderless card-clickable mb-4'
+        classes: 'card border-0 mb-4'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         element: div
         show_label: false
         label_element: h3
@@ -86,9 +88,10 @@ third_party_settings:
       weight: 1
       format_type: link
       format_settings:
-        classes: 'card-body p-0 hide-contextual-links'
+        classes: 'card-body p-0 hide-contextual-links text-decoration-none'
         show_empty_fields: false
         id: ''
+        label_as_html: false
         target: entity
         custom_uri: ''
         target_attribute: default


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #4591 

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

https://review.digital.arizona.edu/arizona-bootstrap/main/docs/5.0/backwards-compatibility/#card-classes

`card-clickable` and `card-clickable-link` are deprecated. This PR updates all content-type view modes that are currently using `card-clickable` to use `stretched-link`'s instead. This PR aims to accomplish this without restructuring any field groups (modifying parent-children relationships); this is to prevent issues later, especially in the case of sites that have added customizations to these card views, when we're upgrading sites from 2.x to 3.x. 

For `az_news`, the view modes were updated before in [commit bda4f36](https://github.com/az-digital/az_quickstart/commit/bda4f360d56bad25eae00e136c05207763f6eff2) to replace use of `card-clickable` with `stretched-link`'s; however, it was achieved by restructuring field groups. This PR aims to undo that restructuring while keeping the other changes to the az_news view modes from that PR 

Here are the list of view modes being updated in this PR:

- az_event --> az_card, az_card_alternate, az_row_with_background
- az_news --> az_card, az_feature, az_marquee, az_media_list, az_medium_media_list, az_minimal_media_list, az_row_with_background, az_small_row
- az_flexible_page --> az_card, az_row, az_row_with_background
- az_person --> az_row_with_background
- az_publication --> az_card

### Release notes
<!--- Delete this line (and the closing comment line) to enable release notes.

If this change requires release notes: provide a summary of changes, how to use this change, and any related links. This content will be pasted in the [release notes](https://github.com/az-digital/az_quickstart/releases). Use markdown format to ensure proper pasting of information. [Release notes example](https://github.com/az-digital/az_quickstart/releases/tag/2.11.0)

Make sure to add the `release notes` label to this PR.

```
Add markdown of release notes here.
```

Delete this line to enable release notes.  -->


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
Verify all card-clickable's are replaced by stretched-link's. And all link labels (i.e. on "read more", "view page", "view profile", "view event") on cards are Arizona red, then chili and underlined upon hover.

- Event views: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4672.probo.build/event-views
  - compare 2.x: https://azqs2-cws-kevin.pantheonsite.io/events-view-modes
- News views: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4672.probo.build/news-views
  - compare 2.x: https://azqs2-cws-kevin.pantheonsite.io/news-view-modes
- Page views: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4672.probo.build/page-views
  - compare 2.x: https://azqs2-cws-kevin.pantheonsite.io/az-flexible-page-view-displays
- Person views: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4672.probo.build/person-views
  - compare 2.x: https://azqs2-cws-kevin.pantheonsite.io/person-view-modes
- Publication card view: https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4672.probo.build/publication-card-view 
  - this one does not use stretched link because we want the bibliographical links inside the cards to still be clickable, mirroring 2.x behavior: https://azqs2-cws-kevin.pantheonsite.io/publications-view-modes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Update to remove deprecated elements
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [x] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [x] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
