### PR TITLE
Close #4682 Update ckeditor5-stylesheets to Arizona Bootstrap 5 and remove ckeditor_stylesheets from az_barrio.info.yml 

### DIFF
--- a/themes/custom/az_barrio/az_barrio.info.yml
+++ b/themes/custom/az_barrio/az_barrio.info.yml
@@ -44,14 +44,10 @@ regions:
   footer_sub_menus: 'Footer sub menus'
   az_page_bottom: 'Page bottom'
 
-ckeditor_stylesheets:
-  - https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css
-  - https://cdn.digital.arizona.edu/lib/arizona-bootstrap/latest-2.x/css/arizona-bootstrap.min.css
-
 ckeditor5-stylesheets:
   - css/ckeditor5.css
   - https://cdn.digital.arizona.edu/lib/az-icons/main/az-icons-styles.css
-  - https://cdn.digital.arizona.edu/lib/arizona-bootstrap/latest-2.x/css/arizona-bootstrap.min.css
+  - https://cdn.digital.arizona.edu/lib/arizona-bootstrap/latest-5.x/css/arizona-bootstrap.min.css
 
 libraries-extend:
   system/base:


### PR DESCRIPTION
## Description
This PR updates the `ckeditor5-stylesheets` configuration to use **Arizona Bootstrap 5** instead of the older 2.x version.  

It also removes the now-obsolete `ckeditor_stylesheets` key from `az_barrio.info.yml`, since CKEditor 5 does not use this configuration.  

## Related issues
Close #4682

## How to test
1. Pull this branch and clear caches (`drush cr`).  
2. Edit any content item that uses CKEditor 5.  
3. Inspect the CKEditor iframe styles:  
   - Confirm that Arizona Bootstrap **5.x** stylesheet is loaded.  
   - Confirm that the az-icons stylesheet is still applied.  
   - Ensure that editor styles match frontend styles.  
4. Verify that `ckeditor_stylesheets` no longer exists in `az_barrio.info.yml`.  
5. Confirm no regressions in the WYSIWYG editing experience.

## Types of changes
### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Other or unknown**
   - [x] Other or unknown

### Drupal contrib projects
- **Other or unknown**
   - [x] Other or unknown

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My change requires release notes.