### PR TITLE
[Branch of PR 4104] Remove az_barrio_navbar theme setting

### DIFF
--- a/modules/custom/az_flexible_page/az_flexible_page.module
+++ b/modules/custom/az_flexible_page/az_flexible_page.module
@@ -59,9 +59,6 @@ function az_flexible_page_preprocess_page__node__az_flexible_page(&$variables) {
     unset($variables['page']['content_top']);
   }
 
-  // Set the navbar flag to FALSE since that region is disabled.
-  $variables['az_barrio_navbar'] = FALSE;
-
   // Disable site branding region on "Standard - No Site Branding" style.
   if ($marketing_page_style === 'az_marketing_page_standard_no_branding') {
     if ($variables['page']['branding']) {

--- a/modules/custom/az_marketing_cloud/templates/page--export--marketing-cloud.html.twig
+++ b/modules/custom/az_marketing_cloud/templates/page--export--marketing-cloud.html.twig
@@ -16,7 +16,6 @@
  * - logged_in: A flag indicating if the user is registered and signed in.
  * - is_admin: A flag indicating if the user has permission to access
  *   administration pages.
- * - az_barrio_navbar: A flag indicating if the nav is enabled.
  *
  * Site identity:
  * - front_page: The URL of the front page. Use this instead of base_path when

--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -98,23 +98,16 @@ function az_barrio_preprocess_html(&$variables) {
  * Implements hook_preprocess_HOOK() for page templates.
  */
 function az_barrio_preprocess_page(&$variables, $hook) {
-  $variables['az_barrio_navbar'] = (theme_get_setting('az_barrio_navbar')) ? TRUE : FALSE;
-  if ($variables['az_barrio_navbar'] === TRUE) {
-    $variables['#attached']['library'][] = 'az_barrio/az-barrio-off-canvas-nav';
-    $variables['navbar_attributes'] = new Attribute([
-      'id' => 'navbar-top',
-      'class' => [
-        'navbar',
-        'navbar-expand',
-      ]
-    ]);
-    if ($variables['page']['navigation']) {
-      $variables['navbar_attributes']['class'][] = 'has-navigation-region';
-    }
-    else {
-      $variables['navbar_attributes']['class'][] = 'no-navigation-region';
-    }
-  }
+  $variables['#attached']['library'][] = 'az_barrio/az-barrio-off-canvas-nav';
+  $variables['navbar_attributes'] = new Attribute([
+    'id' => 'navbar-top',
+    'class' => [
+      'navbar',
+      'navbar-expand',
+    ]
+  ]);
+  $variables['navbar_attributes']['class'][] =
+    $variables['page']['navigation'] ? 'has-navigation-region' : 'no-navigation-region';
 
   // Allow hiding of title of front page node.
   if (theme_get_setting('az_hide_front_title') === 1 && \Drupal::service('path.matcher')->isFrontPage()) {

--- a/themes/custom/az_barrio/config/install/az_barrio.settings.yml
+++ b/themes/custom/az_barrio/config/install/az_barrio.settings.yml
@@ -79,7 +79,6 @@ info_security_privacy: true
 copyright_notice: 'The Arizona Board of Regents on behalf of <a href="https://www.arizona.edu" target="_blank">The University of Arizona</a>.'
 az_hide_front_title: false
 az_back_to_top: true
-az_barrio_navbar: true
 az_barrio_font: true
 az_bootstrap_source: cdn
 az_bootstrap_cdn_version: stable

--- a/themes/custom/az_barrio/templates/layout/page.html.twig
+++ b/themes/custom/az_barrio/templates/layout/page.html.twig
@@ -16,7 +16,6 @@
  * - logged_in: A flag indicating if the user is registered and signed in.
  * - is_admin: A flag indicating if the user has permission to access
  *   administration pages.
- * - az_barrio_navbar: A flag indicating if the nav is enabled.
  *
  * Site identity:
  * - front_page: The URL of the front page. Use this instead of base_path when

--- a/themes/custom/az_barrio/theme-settings.php
+++ b/themes/custom/az_barrio/theme-settings.php
@@ -349,12 +349,6 @@ function az_barrio_form_system_theme_settings_alter(&$form, FormStateInterface $
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   ];
-  $form['components']['navbar']['az_barrio_navbar'] = [
-    '#type' => 'checkbox',
-    '#title' => t('Use Arizona Bootstrap Navbar'),
-    '#description' => t('Check to use the Arizona Bootstrap Navbar instead of the Bootstrap Navbar.'),
-    '#default_value' => theme_get_setting('az_barrio_navbar'),
-  ];
   // Logos.
   $form['logo']['az_barrio_logo_svg_inline'] = [
     '#type' => 'checkbox',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR is a branch of the issue/4029 branch as tracked in this PR:

 - #4104

This PR makes minimal changes to remove the az_barrio_navbar theme setting (formerly az_barrio_navbar_offcanvas). Further improvements could be made in follow-ups to #4104. For example, we may not need to set attributes in the az_barrio_preprocess_page hook function.

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4694.probo.build/