### PR TITLE
Simpler fix for prepare-for-minor release workflow.

### DIFF
--- a/.github/workflows/prepare-for-minor-release.yml
+++ b/.github/workflows/prepare-for-minor-release.yml
@@ -36,8 +36,7 @@ jobs:
       - name: Ensure correct minor release branch sequence
         shell: bash
         run: |
-          # Check if the requested branch already exists
-          if git ls-remote --exit-code --heads https://github.com/az-digital/az_quickstart.git "$NEW_VERSION" >/dev/null 2>&1; then
+          if [ $(git ls-remote --heads https://github.com/az-digital/az_quickstart.git $NEW_VERSION | wc -l) = 1 ]; then
             echo "Requested minor release branch name already exists: $NEW_VERSION" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
@@ -51,21 +50,10 @@ jobs:
 
           # Check if this is the first minor release for this major version (e.g., 3.0.x)
           if [ "$minor_version" = "0" ]; then
-            # For x.0.x branches, ensure no other minor release branches exist for this major version
-            echo "Checking for existing minor release branches for major version $major_version..." >> $GITHUB_STEP_SUMMARY
-
-            existing_branches=$(git ls-remote --heads https://github.com/az-digital/az_quickstart.git | grep -E "refs/heads/${major_version}\.[0-9]+\.x$" | wc -l)
-            echo "Found $existing_branches existing minor release branches for major version $major_version" >> $GITHUB_STEP_SUMMARY
-
-            if [ "$existing_branches" -gt 0 ]; then
-              echo "Cannot create ${NEW_VERSION} - other minor release branches already exist for major version ${major_version}" >> $GITHUB_STEP_SUMMARY
-              echo "Existing ${major_version}.x.x branches:" >> $GITHUB_STEP_SUMMARY
-              git ls-remote --heads https://github.com/az-digital/az_quickstart.git | grep -E "refs/heads/${major_version}\.[0-9]+\.x$" | awk '{print $2}' | sed 's/refs\/heads\///' >> $GITHUB_STEP_SUMMARY
-              exit 1
-            fi
             echo "Creating first minor release branch for major version $major_version: $NEW_VERSION" >> $GITHUB_STEP_SUMMARY
           else
             # For non-zero minor versions, ensure the previous minor release exists
+
             prev_minor=($(echo $NEW_VERSION | tr $delimiter '\n'))
             prev_minor[1]=$((prev_minor[1]-1))
             prev_minor_branch=$(IFS=$delimiter ; echo "${prev_minor[*]}" | sed 's/\(.*\)/\1/')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

Another attempt to add support for creating the initial `x.0.x` minor release branch for a new major version (e.g., `3.0.x`) to our `prepare-for-minor-release` workflow.

- Reverts changes made by earlier attempts in #4734 and #4736. 
- Adds simpler fix to skip validations checks that aren't relevant when creating `x.0.x` branches.

Comparing against the last git revision before #4734 and #4726 were merged might be easier to make sense of:
https://github.com/az-digital/az_quickstart/compare/ae3346fbea3d989d36c3a592df4159e766de095d...prepare-3-pre-release-pt3

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
"Fortune favors the bold" (hopefully)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [x] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
