### PR TITLE
Close #4746 Changing all instances of btn-block to w-100

### DIFF
--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -308,7 +308,7 @@ class AZCardWidget extends WidgetBase {
     $element['link_style'] = [
       '#type' => 'select',
       '#options' => [
-        visually-hidden' => $this->t('Hidden link title'),
+        'visually-hidden' => $this->t('Hidden link title'),
         'w-100' => $this->t('Text link'),
         'btn w-100 btn-red' => $this->t('Red button'),
         'btn w-100 btn-blue' => $this->t('Blue button'),

--- a/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldWidget/AZCardWidget.php
@@ -308,16 +308,16 @@ class AZCardWidget extends WidgetBase {
     $element['link_style'] = [
       '#type' => 'select',
       '#options' => [
-        'visually-hidden' => $this->t('Hidden link title'),
-        'btn-block' => $this->t('Text link'),
-        'btn btn-block btn-red' => $this->t('Red button'),
-        'btn btn-block btn-blue' => $this->t('Blue button'),
-        'btn btn-block btn-outline-red' => $this->t('Red outline button'),
-        'btn btn-block btn-outline-blue' => $this->t('Blue outline button'),
-        'btn btn-block btn-outline-white' => $this->t('White outline button'),
+        visually-hidden' => $this->t('Hidden link title'),
+        'w-100' => $this->t('Text link'),
+        'btn w-100 btn-red' => $this->t('Red button'),
+        'btn w-100 btn-blue' => $this->t('Blue button'),
+        'btn w-100 btn-outline-red' => $this->t('Red outline button'),
+        'btn w-100 btn-outline-blue' => $this->t('Blue outline button'),
+        'btn w-100 btn-outline-white' => $this->t('White outline button'),
       ],
       '#title' => $this->t('Card Link Style'),
-      '#default_value' => (!empty($item->options['link_style'])) ? $item->options['link_style'] : 'btn-block',
+      '#default_value' => (!empty($item->options['link_style'])) ? $item->options['link_style'] : 'w-100',
     ];
 
     if (!$item->isEmpty()) {

--- a/modules/custom/az_demo/data/az_demo_card_paragraph.json
+++ b/modules/custom/az_demo/data/az_demo_card_paragraph.json
@@ -16,7 +16,7 @@
               "link_url": "#top",
               "media": "",
               "background": "text-bg-gray-100",
-              "link_style": "btn btn-block btn-blue"
+              "link_style": "btn w-100 btn-blue"
             },
             {
               "delta": 1,
@@ -26,7 +26,7 @@
               "link_url": "",
               "media": "",
               "background": "text-bg-chili",
-              "link_style": "btn-block"
+              "link_style": "w-100"
             }
           ],
           "bottom_spacing" : "mb-0"
@@ -47,7 +47,7 @@
             "link_url": "#top",
             "media": "runners_brains.jpeg",
             "background": "text-bg-blue",
-            "link_style": "btn btn-block btn-outline-white"
+            "link_style": "btn w-100 btn-outline-white"
           },
           {
             "delta": 1,
@@ -67,7 +67,7 @@
             "link_url": "",
             "media": "",
             "background": "text-bg-gray-300",
-            "link_style": "btn-block"
+            "link_style": "w-100"
           }
         ],
         "bottom_spacing" : "mb-0"
@@ -88,7 +88,7 @@
           "link_url": "#top",
           "media": "runners_brains.jpeg",
           "background": "text-bg-warm-gray",
-          "link_style": "btn btn-blue btn-block"
+          "link_style": "btn btn-blue w-100"
         },
         {
           "delta": 1,
@@ -108,7 +108,7 @@
           "link_url": "#top",
           "media": "",
           "background": "text-bg-azurite",
-          "link_style": "btn-block"
+          "link_style": "w-100"
         },
         {
           "delta": 3,
@@ -139,7 +139,7 @@
             "link_url": "",
             "media": "mans_best_friend.jpeg",
             "background": "text-bg-river",
-            "link_style": "btn-block"
+            "link_style": "w-100"
           },
           {
             "delta": 1,
@@ -149,7 +149,7 @@
             "link_url": "https://www.arizona.edu",
             "media": "",
             "background": "text-bg-cool-gray",
-            "link_style": "btn-block"
+            "link_style": "w-100"
           }
         ],
         "bottom_spacing" : "mb-5"

--- a/modules/custom/az_migration/migrations/az_paragraph_card_deck.yml
+++ b/modules/custom/az_migration/migrations/az_paragraph_card_deck.yml
@@ -73,7 +73,7 @@ process:
         default_value:
           class: 'text-bg-white'
           # Set the link style to default, since we can't migrate classes to this field.
-          link_style: 'btn-block'
+          link_style: 'w-100'
       media:
         -
           plugin: skip_on_empty

--- a/modules/custom/az_migration/migrations/az_paragraph_single_card.yml
+++ b/modules/custom/az_migration/migrations/az_paragraph_single_card.yml
@@ -75,7 +75,7 @@ process:
     default_value:
       class: 'text-bg-white'
       # Set the link style to default, since we can't migrate classes to this field.
-      link_style: 'btn-block'
+      link_style: 'w-100'
 
   bottom_spacing_processed:
     - plugin: default_value

--- a/modules/custom/az_paragraphs/az_paragraphs_cards/az_paragraphs_cards.install
+++ b/modules/custom/az_paragraphs/az_paragraphs_cards/az_paragraphs_cards.install
@@ -65,6 +65,13 @@ function az_paragraphs_cards_update_1130001(&$sandbox) {
               $item->options = $options;
             }
 
+            // Update full-width link styles.
+            if (isset($options['link_style']) && str_contains($options['link_style'], 'btn-block')) {
+              $updated = TRUE;
+              $options['link_style'] = str_replace('btn-block', 'w-100', $options['link_style']);
+              $item->options = $options;
+            }
+
             // Update cards bg color for AZ Bootstrap 5.
             if (isset($options['class']) && str_starts_with($options['class'], 'bg-') && $options['class'] !== 'bg-transparent') {
               $updated = TRUE;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #4746 

## Related issues
#4746 

## How to test
- [ ] The only reference to btn-block in our az_quickstart repo should be in our AZBootstrapMarkupConverter function (where it converts to w-100)
- [ ] Cards with the Card Link Style set to Red Button, Blue Button, Red outline button, Blue outline button, White outline button should all have full width buttons on the cards, instead of left justified buttons that are the size of their contents. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
