### PR TITLE
Fixes #4759 QueryException in az_paragraphs_update_1130001

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs.install
+++ b/modules/custom/az_paragraphs/az_paragraphs.install
@@ -8,6 +8,8 @@
  * profile.
  */
 
+use Drupal\Core\Entity\Query\QueryException;
+
 /**
  * Implements hook_update_last_removed().
  */
@@ -282,16 +284,26 @@ function az_paragraphs_update_1130001(&$sandbox) {
       foreach ($paragraphs as $paragraph) {
         $parent_type = $paragraph->get('parent_type')->value;
         $parent_field = $paragraph->get('parent_field_name')->value;
-        $query = \Drupal::service('entity_type.manager')->getStorage($parent_type)
-          ->getQuery()
-          ->condition("$parent_field.target_id", $paragraph->id())
-          ->range(0, 1)
-          ->accessCheck(FALSE);
-        if ($query->execute()) {
-          $valid_ids[] = $paragraph->id();
+        try {
+          $query = \Drupal::service('entity_type.manager')->getStorage($parent_type)
+            ->getQuery()
+            ->condition("$parent_field.target_id", $paragraph->id())
+            ->range(0, 1)
+            ->accessCheck(FALSE);
+          if ($query->execute()) {
+            $valid_ids[] = $paragraph->id();
+          }
+          else {
+            $logger->info('Skipping unused paragraph @pid', ['@pid' => $paragraph->id()]);
+          }
         }
-        else {
-          $logger->info('Skipping unused paragraph @pid', ['@pid' => $paragraph->id()]);
+        catch (QueryException $qe) {
+          $logger->warning('Failed to check for usage of paragraph @pid in @parent_field on type @parent_type @msg', [
+            '@pid' => $paragraph->id(),
+            '@parent_field' => $parent_field,
+            '@parent_type' => $parent_type,
+            '@msg' => $qe->getMessage(),
+          ]);
         }
       }
     }


### PR DESCRIPTION
## Description
`az_paragraphs_update_1130001` can throw an exception while checking for orphaned paragraphs in the specific case that the field that referenced the paragraph has been deleted, meaning it is the deletion of a field that caused them to become orphaned.

## Related issues
Closes #4759 

## How to test

- Execute `az_paragraphs_update_1130001` on an existing site where the specific circumstance arises:
  - the site has an entity reference revisions field on a content type that references quickstart full-text paragraphs (it may be easiest to test this by creating a new field that references them)
  - create content using paragraphs on the new field
  - delete the field
  - run `az_paragraphs_update_1130001`
  - verify output like the following occurs, rather than a crash: 
  ```
  [warning] Failed to check for usage of paragraph 324 in field_your_field_name on type node 'field_your_field_name' not found
  ```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
