### PR TITLE
Closes #4777 Add jquery_deprecated_functions module to fix az_carousel load issue.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
         "drupal/imagemagick": "4.0.2",
         "drupal/inline_entity_form": "3.0.0-rc21",
         "drupal/intelligencebank": "5.1.0",
+        "drupal/jquery_deprecated_functions": "1.0.2",
         "drupal/jquery_ui": "1.7.0",
         "drupal/jquery_ui_datepicker": "2.1.1",
         "drupal/key": "1.20",

--- a/modules/custom/az_carousel/az_carousel.info.yml
+++ b/modules/custom/az_carousel/az_carousel.info.yml
@@ -15,6 +15,7 @@ dependencies:
   - drupal:views
   - field_group:field_group
   - link_class:link_class
+  - jquery_deprecated_functions:jquery_deprecated_functions
   - pathauto:pathauto
   - search_exclude:search_exclude
   - slick:slick

--- a/modules/custom/az_carousel/az_carousel.install
+++ b/modules/custom/az_carousel/az_carousel.install
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Az_carousel.install.
+ *
+ * Install, update and uninstall functions for
+ * az_carousel module.
+ */
+
+/**
+ * Enable jquery_deprecated_functions module by default.
+ */
+function az_carousel_update_1130001() {
+  \Drupal::service('module_installer')->install(['jquery_deprecated_functions']);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Adds [jquery_deprecated_functions](https://www.drupal.org/project/jquery_deprecated_functions) module to re-add jQuery 3.x functions that Slick JS library relies on but were removed in Drupal 11's jQuery 4.x.

This module is a temporary solution while waiting for the Slick JS library to be updated for jQuery 4 compatibility. Watch [Slick](https://www.drupal.org/project/slick) module for updates.

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4777

## How to test
1. Enable az_carousel
2. Add a couple slides
3. See if the slides load where the carousel block is placed (e.g., homepage with az_demo)

https://7b5e2985-cedf-4a13-ab91-3a35916c835d--pr-4801.probo.build/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
