### PR TITLE
Fixes #4810 Views exposed form elements visually cramped

### DIFF
--- a/modules/custom/az_publication/az_publication.module
+++ b/modules/custom/az_publication/az_publication.module
@@ -122,10 +122,6 @@ function az_publication_theme() {
       'template' => 'block--block-content--views-reference--az-publications--az-author-person',
       'base hook' => 'block',
     ],
-    'views_exposed_form__az_publications' => [
-      'template' => 'views-exposed-form--az-publications',
-      'base hook' => 'views_exposed_form',
-    ],
     'az_publication_type_listing_table' => [
       'variables' => [
         'headers' => NULL,

--- a/themes/custom/az_barrio/templates/views/views-exposed-form.html.twig
+++ b/themes/custom/az_barrio/templates/views/views-exposed-form.html.twig
@@ -16,6 +16,6 @@
   #}
 {{ q }}
 {% endif %}
-<div class="d-flex flex-wrap gap-2">
+<div class="d-flex flex-wrap column-gap-2">
   {{ form }}
 </div>


### PR DESCRIPTION
## Description
Bootstrap 5 has retired the `form-row` class upon which our previous exposed form styles depended. The Barrio 5.5 replacement, `d-flex flex-wrap` is not quite equivalent, leading to elements that can be too close together.

A fix for this was previously put in place for publications, but it turns out that this is a general issue with all exposed forms.

This PR moves the template to be a general `az_barrio` one and swaps `gap-2` for `column-gap-2` to avoid adding an additional gap between vertically-oriented view blocks, such as Finder.

## Related issues
#4810 

## How to test

- enable `az_demo`
- visit `/publications`
- verify form elements have a slight gap between them
- visit `/finders/news`
- verify no regression in vertical spacing has taken place in finder exposed form
- if desired, create custom views with exposed form elements and verify spacing exists between each element

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
