### PR TITLE
Close #4863 Region class field: increase maxlength from 40 to 255

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -150,7 +150,8 @@
             },
             "drupal/bootstrap_barrio": {
                 "Js error if table not found (3519060)": "https://www.drupal.org/files/issues/2025-04-14/bootstrap-barrio-table-not-found-3519060-1.patch",
-                "Fix alerts (3485305)": "https://www.drupal.org/files/issues/2025-08-27/3485305-22.patch"
+                "Fix alerts (3485305)": "https://www.drupal.org/files/issues/2025-08-27/3485305-22.patch",
+                "Region class field: increase maxlength from 40 to 255 (3548552)": "https://www.drupal.org/files/issues/2025-09-24/3548552-4.patch"
             },
             "drupal/config_distro": {
                 "Storage comparer issue": "https://gist.githubusercontent.com/tadean/e2e0dd57f1a9c4eae28d8e713cb01d82/raw/e114987d4a76c183208c763de4dbfecbf41b7f35/config_distro_storage_comparer_issue.patch"


### PR DESCRIPTION
## Description
Added a patch to fix the issue where the **region class** textfield in Barrio theme settings was limited to 40 characters.  

This change increases the limit to **255**, allowing multiple Bootstrap utility classes to be added without truncation.

## Related issues
- Fixes #4863

## How to test
1. Go to **Appearance → Settings** for a Barrio subtheme.  
2. Open **Layout → Region** and select any region.  
3. In the "Classes for &lt;region&gt;" field, enter more than 40 characters.  
   Example:  
   ```
   d-flex justify-content-between align-items-center py-3 gap-2 flex-wrap
   ```
4. Save and confirm the full value is stored and displayed correctly.

## Types of changes

### Drupal contrib projects
- **Patch release changes**
  - [x] Patch or minor level update

## Checklist
- [x] My code follows the code style of this project  
- [ ] My change requires a change to the documentation  
- [ ] I have updated the documentation accordingly  
- [x] I have read the **CONTRIBUTING** document  
- [ ] I have added tests to cover my changes  
- [x] All new and existing tests passed  
- [x] My change requires release notes  