### PR TITLE
Optional: Small change to splitscreen demo content

### DIFF
--- a/modules/custom/az_demo/data/az_demo_splitscreen_paragraph.json
+++ b/modules/custom/az_demo/data/az_demo_splitscreen_paragraph.json
@@ -184,7 +184,7 @@
         },
         {
             "id":72,
-            "az_text_area" : "<blockquote class=\"border-white\">\"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\"<p class=\"blockquote-footer\"><em>First Last<\/em><\/p><\/blockquote>",
+            "az_text_area" : "<blockquote class=\"border-white\">\"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\"<\/blockquote><p class=\"blockquote-footer\"><em>First Last<\/em><\/p>",
             "filename" : "study.jpeg",
             "full_width" : false,
             "ordering" : "order_0",


### PR DESCRIPTION
In reviewing #4908, I noticed a minor visual inconsistency with the blockquote used in the split screen demo paragraph content.

Before:
<img width="1191" height="629" alt="Screenshot 2025-10-07 at 4 03 28 PM" src="https://github.com/user-attachments/assets/1d06799d-5959-405c-b13a-c6d07264c927" />

After:
<img width="1152" height="608" alt="Screenshot 2025-10-07 at 4 04 15 PM" src="https://github.com/user-attachments/assets/93e52816-ffe9-4011-9ae5-cbc409b30177" />

In BS5, I guess the blockquote-footer (citation/source) element needs to be outside the blockquote: https://digital.arizona.edu/arizona-bootstrap/v5/docs/5.0/content/typography/#naming-a-source

I think we could get closer to the intending display by wrapping the whole thing in a `<figure>` but when I tried to do that locally, Drupal purged it out. I'm guessing it's not allowed in this text format. Still, at least the text doesn't overlap anymore!