### PR TITLE
Fixes #4441 Warn about multiple media usage on remove button

### DIFF
--- a/modules/custom/az_media/az_media.module
+++ b/modules/custom/az_media/az_media.module
@@ -128,58 +128,18 @@ function template_preprocess_az_responsive_background_image(array &$variables) {
 }
 
 /**
- * Implements hook_form_FORM_ID_alter() for media_az_image_edit_form.
+ * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter() for image_widget_crop.
  *
- * Adds warning message for media entities that are used in multiple places.
+ * Modification for image_widget_crop widgets to show usage warning.
  */
-function az_media_form_media_az_image_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $count = 0;
-  // Find what entity this form applies to.
-  $form_object = $form_state->getFormObject();
-  if ($form_object instanceof EntityFormInterface) {
-    /** @var \Drupal\media\MediaInterface $media */
-    $media = $form_object->getEntity();
-    if ($media) {
-      $entityTypeManager = \Drupal::service('entity_type.manager');
-      // Get all fields that reference media entities.
-      $media_reference_fields = $entityTypeManager->getStorage('field_storage_config')
-        ->loadByProperties([
-          'type' => 'entity_reference',
-          'settings' => ['target_type' => 'media'],
-        ]);
-
-      // Iterate through each field and check for references.
-      foreach ($media_reference_fields as $field_name => $field_storage_config) {
-        $entity_type_id = $field_storage_config->getTargetEntityTypeId();
-        $storage = $entityTypeManager->getStorage($entity_type_id);
-
-        // Get only the name of the field without the entity type.
-        $keys = explode('.', $field_name);
-        $identifier = $keys[1] ?? NULL;
-        if (!$identifier) {
-          continue;
-        }
-        // Query for entities that reference the media ID in the current field.
-        $query = $storage->getQuery()
-          ->condition($identifier, $media->id())
-          ->accessCheck(FALSE);
-
-        $count += $query->count()->execute();
-      }
-      if ($count > 1) {
-        $form['az_media_count'] = [
-          '#type' => 'container',
-          '#markup' => t('This media item is used in @places places. Exercise caution before editing it.', [
-            '@places' => $count,
-          ]),
-          '#attributes' => [
-            'class' => ['messages messages--warning'],
-          ],
-          '#weight' => -10,
-        ];
-      }
-    }
-  }
+function az_media_field_widget_single_element_image_widget_crop_form_alter(array &$element, FormStateInterface $form_state, array $context) {
+  $element['#pre_render'] = [
+    ['Drupal\az_media\AZMediaMultipleUsagesHelper', 'warnMultipleUsages'],
+    // @todo determine why this needs to be added.
+    // If this is not added, the default ManagedFile callback does not run.
+    // Perhaps our pre_render needs to be added in a later hook.
+    ['Drupal\file\Element\ManagedFile', 'preRenderManagedFile'],
+  ];
 }
 
 /**

--- a/modules/custom/az_media/src/AZMediaMultipleUsagesHelper.php
+++ b/modules/custom/az_media/src/AZMediaMultipleUsagesHelper.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\az_media;
+
+use Drupal\Core\Security\TrustedCallbackInterface;
+
+/**
+ * Helper class for warning about media usage.
+ */
+class AZMediaMultipleUsagesHelper implements TrustedCallbackInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function trustedCallbacks() {
+    return ['warnMultipleUsages'];
+  }
+
+  /**
+   * Prepares a managed_file by changing the remove button.
+   *
+   * @param array $element
+   *   A structured array containing a managed_file.
+   *
+   * @return array
+   *   The passed-in element with remove button changed.
+   */
+  public static function warnMultipleUsages(array $element) {
+
+    $count = 0;
+    // See which files this element applies to.
+    if (!empty($element['#files'])) {
+      $ids = [];
+      foreach ($element['#files'] as $file) {
+        // Get usage for file.
+        $file_usage = \Drupal::service('file.usage')->listUsage($file);
+
+        // Get media IDs that use the file.
+        if (!empty($file_usage['file']['media'])) {
+          $ids = array_merge($ids, array_keys($file_usage['file']['media']));
+        }
+
+      }
+      // Query all reference fields which use this file.
+      if (!empty($ids)) {
+        $entityTypeManager = \Drupal::service('entity_type.manager');
+        // Get all fields that reference media entities.
+        $media_reference_fields = $entityTypeManager->getStorage('field_storage_config')
+          ->loadByProperties([
+            'type' => 'entity_reference',
+            'settings' => ['target_type' => 'media'],
+          ]);
+
+        // Iterate through each field and check for references.
+        foreach ($media_reference_fields as $field_name => $field_storage_config) {
+          $entity_type_id = $field_storage_config->getTargetEntityTypeId();
+          $storage = $entityTypeManager->getStorage($entity_type_id);
+
+          // Get only the name of the field without the entity type.
+          $keys = explode('.', $field_name);
+          $identifier = $keys[1] ?? NULL;
+          if (!$identifier) {
+            continue;
+          }
+          // Query for entities that reference the media ID.
+          $query = $storage->getQuery()
+            ->condition($identifier, $ids, 'IN')
+            ->accessCheck(FALSE);
+
+          $count += $query->count()->execute();
+        }
+      }
+    }
+    if (!empty($element['remove_button']) && ($count > 1)) {
+      $element['remove_button']['#value'] = t('Remove in @places places', [
+        '@places' => $count,
+      ]);
+    }
+    return $element;
+  }
+
+}


### PR DESCRIPTION
## Description
This is an alternate suggestion for #4670 that attempts to move the functionally to the submit button. This PR targets #4670 's branch rather than main.

## Related issues
#4441 

## How to test

-  Set the same image on multiple different nodes.
-  Open the Edit image modal
-  Observe 'Remove in [# of references] places'

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
