### PR TITLE
Closes #4971: Mobile nav menu links to unpublished pages show as inaccessible to all users

### DIFF
--- a/modules/custom/az_core/az_core.libraries.yml
+++ b/modules/custom/az_core/az_core.libraries.yml
@@ -28,5 +28,4 @@ az-mobile-nav:
     js/az-mobile-nav.js: {}
   dependencies:
     - core/drupal
-    - core/drupal.ajax
     - core/once

--- a/modules/custom/az_core/src/Plugin/Block/MobileNavBlock.php
+++ b/modules/custom/az_core/src/Plugin/Block/MobileNavBlock.php
@@ -177,6 +177,7 @@ class MobileNavBlock extends BlockBase implements ContainerFactoryPluginInterfac
       '#attached' => [
         'library' => [
           'az_core/az-mobile-nav',
+          'core/drupal.ajax',
         ],
       ],
       '#cache' => [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Updates the Mobile Nav Block:
- Adds a check to skip displaying any links that are not accessible to the current user (access result neutral)
- Changes the caching of the loaded menu tree: instead of caching only one version, separate cache items are created for each set of user permissions (according to the user permissions hash).
- Adds [checkNodeAccess](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Menu%21DefaultMenuLinkTreeManipulators.php/function/DefaultMenuLinkTreeManipulators%3A%3AcheckNodeAccess/11.x) to the menu tree manipulators, which [seems to be recommended](https://git.drupalcode.org/project/drupal/-/blob/11.x/core/lib/Drupal/Core/Menu/MenuLinkTreeInterface.php#L75-82) and a potential optimization.
- Adds `core/drupal` and `core/once` as dependencies for the `az-mobile-nav` library
- Adds `core/drupal.ajax` as a dependency for the MobileNavBlock render array

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 - #4971 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
https://pr4972-ccw95skeh2urxpgqfuvli1rjb5twtfd8.tugboatqa.com/

Edit some existing or new pages so that the main navigation menu includes unpublished pages. Then test the following both logged out and logged in as an administrator to confirm they are displayed or not displayed in the mobile nav as appropriate:
 - An enabled menu link to an unpublished page (e.g., [Split Screen](https://pr4972-ccw95skeh2urxpgqfuvli1rjb5twtfd8.tugboatqa.com/pages/split-screen))
 - An enabled menu link to a published page which is a child of a menu link to an unpublished page (e.g., [Split Screen No Sidebar](https://pr4972-ccw95skeh2urxpgqfuvli1rjb5twtfd8.tugboatqa.com/pages/split-screen-no-sidebar))
 - A disabled menu link (e.g., [Text](https://pr4972-ccw95skeh2urxpgqfuvli1rjb5twtfd8.tugboatqa.com/pages/text))

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.