### PR TITLE
Fixes #5031 Lando mariadb local development SSL issues

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -9,6 +9,21 @@ config:
 env_file:
   - .env
 services:
+  # Base Lando bitnami legacy images no longer receive support.
+  database:
+    type: compose
+    services:
+      image: mariadb:11.4
+      command: docker-entrypoint.sh mariadbd
+      restart: always
+      ports:
+        - '3306'
+      environment:
+        MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'true'
+        MARIADB_DATABASE: drupal11
+        MYSQL_DATABASE: drupal11
+        MARIADB_USER: drupal11
+        MARIADB_PASSWORD: drupal11
   appserver:
     config:
       php: .vscode/php.ini


### PR DESCRIPTION
in #4445 we enabled PHP 8.4 for local development. The lando container which uses PHP 8.4 appears to contain more recent versions of the libraries for mariadb connections, which default to assuming SSL is in use. This PR generates a service certificate for the database container and employs it for mariadb's usage for SSL.

This route was taken because it appears that it is more difficult to turn off Drush's assumption that SSL exists.

**Note**: upgrading to a more recent version of the mariadb image would also solve this issue, (because recent versions of mariadb generate their own certs) but the current version is kept for Pantheon parity.

## Related issues
Fixes #5031 

## How to test

- build environment locally in lando
- log into the database service container using `lando ssh --service=database`
- verify that `cat /etc/mysql/conf.d/.lando.cnf ` returns something like: (may vary based on lando version)
```
[mariadb]
ssl_cert = /lando/certs/database.azquickstart.crt
ssl_key  = /lando/certs/database.azquickstart.key
ssl_ca   = /lando/certs/LandoCA.crt
```
- exit out of database container
- connect to the database with `lando mariadb`
- Inspect the status of SSL variables with `show variables like '%ssl%';`
- verify something like the following is shown (may vary based on lando version):
```
+---------------------+----------------------------------------+
| Variable_name       | Value                                  |
+---------------------+----------------------------------------+
| have_openssl        | YES                                    |
| have_ssl            | YES                                    |
| ssl_ca              | /lando/certs/LandoCA.crt               |
| ssl_capath          |                                        |
| ssl_cert            | /lando/certs/database.azquickstart.crt |
| ssl_cipher          |                                        |
| ssl_crl             |                                        |
| ssl_crlpath         |                                        |
| ssl_key             | /lando/certs/database.azquickstart.key |
| version_ssl_library | OpenSSL 1.1.1f  31 Mar 2020            |
+---------------------+----------------------------------------+
```
- exit out of mariadb connection
- verify that `lando install` installs a drupal site successfully without displaying database connection warnings, Makre sure that the following (or similar) does not appear:
```
 [warning] Failed to drop or create the database. Do it yourself before installing. ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it
 ```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
