### PR TITLE
Close #5123 Retroactively enable environment_indicator_toolbar module if both environment_indicator and toolbar modules are enabled.

### DIFF
--- a/az_quickstart.install
+++ b/az_quickstart.install
@@ -186,3 +186,23 @@ function az_quickstart_update_1021302() {
 function az_quickstart_update_1130001() {
   \Drupal::service('module_installer')->install(['az_icons']);
 }
+
+/**
+ * Enable environment_indicator_toolbar module if applicable.
+ *
+ * This update ensures that environment_indicator_toolbar is enabled on sites
+ * that have both environment_indicator and toolbar modules enabled, regardless
+ * of configuration state. This addresses an issue where the module may not
+ * have been enabled during updates due to config changes happening before the
+ * environment_indicator module's own update hook could run.
+ */
+function az_quickstart_update_1130002() {
+  $module_handler = \Drupal::service('module_handler');
+  // Check if both environment_indicator and toolbar are enabled.
+  if ($module_handler->moduleExists('environment_indicator') && $module_handler->moduleExists('toolbar')) {
+    // Enable environment_indicator_toolbar if not already enabled.
+    if (!$module_handler->moduleExists('environment_indicator_toolbar')) {
+      \Drupal::service('module_installer')->install(['environment_indicator_toolbar']);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds an update hook to retroactively enable the `environment_indicator_toolbar` module on sites that have both `environment_indicator` and `toolbar` modules enabled.

The issue possibly occurred because commit 9102c45d changed the `environment_indicator.settings.yml` configuration from `toolbar_integration: [toolbar]` to `toolbar_integration: {}`. When sites updated, this config change was applied before the `environment_indicator` module's own update hook (`environment_indicator_update_8103()`) could run. Since that update hook checks if `toolbar_integration` contains 'toolbar' before enabling the toolbar submodule, it would find an empty array and skip enabling the module.

The new `az_quickstart_update_1130002()` hook checks module enabled state directly rather than configuration state, ensuring `environment_indicator_toolbar` gets enabled regardless of when config updates were applied.

### Release notes

Fixes an issue where the `environment_indicator_toolbar` module was not automatically enabled during updates to Quickstart 3.0.5 or 3.1.1, even though it should have been enabled on sites using the environment indicator and toolbar modules.

## Related issues

Closes #5123

## How to test

1. Start with a site that has `environment_indicator` and `toolbar` modules enabled, but `environment_indicator_toolbar` is NOT enabled
2. Apply this update and run `drush updb` (or run database updates via the UI)
3. Verify that `environment_indicator_toolbar` is now enabled
4. Visit an authenticated page (e.g., `/admin/content` or `/cas`) and confirm the environment indicator appears in the toolbar

Alternatively, to verify the update hook doesn't break existing installations:
1. Start with a fresh Quickstart install on Pantheon (where all three modules are already enabled)
2. Apply this update and run database updates
3. Verify no errors occur and the modules remain enabled

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)

- [x] Patch release changes
  - [x] Bug fix

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.