### PR TITLE
Closes #5231 Clarify release policy for multiple minor releases.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -89,7 +89,8 @@ There are three types of Quickstart patch releases:
 - Drupal contrib projects
   - Security updates
   - Patch or minor version updates
-  - Addition and removal of contrib modules or patches
+  - Removal of contrib modules that become unsupported
+  - Addition and removal of patches
 - Other PHP or Javascript packages and libraries
   - Security updates
   - Patch or minor version updates


### PR DESCRIPTION
## Description
This PR proposes an update to our release policy to clarify that we will only provide full support for one LTS version and the **current** minor release. The **previous** minor release will receive only security support.

In addition to reviewing the changes in the Files Changed tab, you can view the fully updated file here:
- https://github.com/az-digital/az_quickstart/blob/camikazegreen-patch-2/RELEASES.md

## Related issue
 - #5231 

## Questions

1. For security patch releases for the previous Quickstart minor release, a security release for Drupal core would require updating Drupal core in that previous Quickstart minor release. Would we bump the Drupal core version only at that time, or is it better to continually update Drupal core in the previous Quickstart minor release (with "security patch releases")? We may not need to specify this explicitly in the release policy.
   - Per AZ Digital discussion on 1/28/2026: We will only bump the Drupal core version as required for a Drupal core security release.