### PR TITLE
Fixes #5232: With AZ Navbar enabled, hover open does not fire until the page is visited once

### DIFF
--- a/themes/custom/az_barrio/az_barrio.libraries.yml
+++ b/themes/custom/az_barrio/az_barrio.libraries.yml
@@ -25,6 +25,13 @@ az-barrio-off-canvas-nav:
     js/az-barrio-off-canvas-nav.js: {}
   dependencies:
     - az_barrio/global-styling
+az-navbar-hover:
+  js:
+    js/az-navbar-hover.js: {}
+  dependencies:
+    - az_barrio/arizona-bootstrap-js
+    - core/drupal
+    - core/once
 az-proxima-nova:
   css:
     theme:

--- a/themes/custom/az_barrio/js/az-navbar-hover.js
+++ b/themes/custom/az_barrio/js/az-navbar-hover.js
@@ -1,0 +1,20 @@
+((Drupal, once) => {
+  Drupal.behaviors.azNavbarHoverDropdowns = {
+    attach: (context) => {
+      once('azNavbarHoverDropdowns', '.navbar-nav', context).forEach(
+        (navList) => {
+          if (!navList.closest('.navbar-az')) {
+            return;
+          }
+          const azBootstrap = window.arizonaBootstrap;
+          if (
+            azBootstrap &&
+            typeof azBootstrap.enableAzNavbarHoverDropdowns === 'function'
+          ) {
+            azBootstrap.enableAzNavbarHoverDropdowns();
+          }
+        },
+      );
+    },
+  };
+})(Drupal, once);

--- a/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
@@ -18,6 +18,7 @@
  *   - in_active_trail: TRUE if the link is in the active trail.
  */
 #}
+{{ attach_library('az_barrio/az-navbar-hover') }}
 {% import _self as menus %}
 {#
   We call a macro which calls itself to render the full tree.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a theme library with a Drupal behavior wrapper that calls arizonaBootstrap.enableAzNavbarHoverDropdowns() and attaches it directly in the AZ navbar menu template so the behavior reattaches whenever the menu markup is streamed.


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#5232 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
1. [Enable AZ Navbar](https://pr5234-ux4sx8nhdjp4oxlzb3mngdyviinfoyio.tugboatqa.com/admin/appearance/settings/az_barrio) if needed at `/admin/appearance/settings/az_barrio`. It would be best to test this in a non-Pantheon environment.
2. Verify open-on-hover functionality works when authenticated.
3. Clear Drupal caches to verify problem doesn't resurface.

Tugboat review environment: https://pr5234-ux4sx8nhdjp4oxlzb3mngdyviinfoyio.tugboatqa.com/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [X] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
