### PR TITLE
Close #5325 fix config_readonly for Quickstart 3.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -159,6 +159,9 @@
             "drupal/config_distro": {
                 "Storage comparer issue": "https://gist.githubusercontent.com/tadean/e2e0dd57f1a9c4eae28d8e713cb01d82/raw/e114987d4a76c183208c763de4dbfecbf41b7f35/config_distro_storage_comparer_issue.patch"
             },
+            "drupal/config_readonly": {
+                "Admin Page at admin/config/services/jsonapi is not loading in test environment (3469854)": "https://www.drupal.org/files/issues/2026-02-18/config_readonly-3469854-18.diff"
+            },
             "drupal/core": {
                 "Views Date Filter Datetime Granularity Option (2868014)": "https://www.drupal.org/files/issues/2025-06-25/2868014-139-11-x.patch",
                 "Layout builder revisions issue (3033516)": "https://www.drupal.org/files/issues/2019-06-17/3033516-17.patch",


### PR DESCRIPTION
## Description

Fixes a WSOD caused by `config_readonly` when accessing certain configuration forms (notably XML Sitemap bundle settings) while using a staged configuration workflow.

Quickstart sites using config staging hit an error due to `TranslatableMarkup` being treated as an array inside `ReadOnlyFormSubscriber::getConfigTargetNames()`. This PR adds the static patch from the upstream Drupal.org issue so Quickstart users are not blocked.

The patch is included as a static file rather than referencing a dynamic diff URL so the contents remain fixed and reviewable.

### Release notes
- Fix WSOD on some admin configuration forms when `config_readonly` is enabled.
- Applies upstream patch for config_readonly compatibility with newer form structures.

---

## Related issues
- Closes #5325  
- Upstream: https://www.drupal.org/project/config_readonly/issues/3469854

---

## How to test
1. Ensure `config_readonly` is enabled.
2. Use a site with config staging enabled.
3. Go to:  
   `/admin/config/search/xmlsitemap/settings/node/az_event`
4. Before this change: WSOD + log error.
5. After this change: form loads normally.

Optional regression checks:
- Visit other config forms to confirm no new readonly regressions.
- Run `drush cr` and confirm no PHP warnings.

---

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- Patch release changes
  - Bug fix

### Drupal contrib projects
- Patch release changes
  - Patch or minor level update

---

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.