### PR TITLE
Fixes #5308 Search API support for Robots Noindex

### DIFF
--- a/modules/custom/az_search_api/config/install/search_api.index.az_search_api_index.yml
+++ b/modules/custom/az_search_api/config/install/search_api.index.az_search_api_index.yml
@@ -343,6 +343,7 @@ processor_settings:
       url: 0
     image_style: az_card_image
   az_metatag: {  }
+  az_robots_noindex: {  }
   az_search_summary: {  }
   custom_value: {  }
   entity_status: {  }

--- a/modules/custom/az_search_api/src/Plugin/search_api/processor/AZRobotsNoIndex.php
+++ b/modules/custom/az_search_api/src/Plugin/search_api/processor/AZRobotsNoIndex.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\az_search_api\Plugin\search_api\processor;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\metatag\MetatagManager;
+use Drupal\search_api\Attribute\SearchApiProcessor;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Skip indexing content flagged as noindex.
+ */
+#[SearchApiProcessor(
+  id: 'az_robots_noindex',
+  label: new TranslatableMarkup('Robots noindex metatag'),
+  description: new TranslatableMarkup('Respect robots noindex metatag settings for a given entity.'),
+  stages: [
+    'alter_items' => 0,
+  ],
+)]
+class AZRobotsNoIndex extends ProcessorPluginBase {
+
+  /**
+   * The MetatagManager. MetatagManagerInterface does not have APIs we need.
+   */
+  protected ?MetatagManager $metatagManager = NULL;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var static $processor */
+    $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $processor->metatagManager = $container->get('metatag.manager');
+    return $processor;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterIndexedItems(array &$items) {
+    /** @var \Drupal\search_api\Item\ItemInterface $item */
+    foreach ($items as $item_id => $item) {
+      $entity = $item->getOriginalObject()->getValue();
+      if (!empty($entity)) {
+        // Render the metatag tokens for the provided entity.
+        $tags = $this->metatagManager->tagsFromEntityWithDefaults($entity);
+        $tokens = $this->metatagManager->generateTokenValues($tags, $entity);
+        $robots = $tokens['robots'] ?? '';
+        // Do not index the content if it contains a noindex robots tag.
+        if (is_string($robots) && str_contains($robots, 'noindex')) {
+          unset($items[$item_id]);
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This PR adds a `search_api` processor that prevents content from being indexed if it has a robots `noindex` metatag.

## Description
This processor, `az_robots_noindex` operates at the `alter_items` stage of `search_api` by evaluating metatags for an entity, and removing it if the noindex robot metatag is set.

### Release notes

```
az_search_api will no longer index content metatagged robots:noindex.
```


## Related issues
#5308 

## How to test

- See testing instructions in #5104 for instructions on how to set up credential secrets
- Create a **published page**
- Create an **unpublished page**
- Create a **published page with the robots Noindex metatag set:**
<img width="449" height="120" alt="image" src="https://github.com/user-attachments/assets/d9bb7f23-8874-47cc-8b48-6fadb7977610" />

 - Visit `/admin/config/search/search-api/index/az_search_api_index`
- Click **Queue all items for reindexing**
- Click **Index now**
- Wait several minutes. It can take time for the searchstax server to commit the transaction.
- Check for documents in the index, or look at the index in the Searchstax dashboard.
- Verify that only the published page appears, and specifically that the noindex page does not appear.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My change requires release notes.
