### PR TITLE
Convert Breadcrumb to be a SDC

### DIFF
--- a/themes/custom/az_barrio/components/breadcrumb/breadcrumb.component.yml
+++ b/themes/custom/az_barrio/components/breadcrumb/breadcrumb.component.yml
@@ -1,0 +1,8 @@
+name: Breadcrumb
+status: experimental
+props:
+  type: object
+  properties:
+    breadcrumb:
+      type: array
+      title: Breadcrumb items

--- a/themes/custom/az_barrio/components/breadcrumb/breadcrumb.twig
+++ b/themes/custom/az_barrio/components/breadcrumb/breadcrumb.twig
@@ -1,0 +1,17 @@
+{% if breadcrumb %}
+  <nav role="navigation" aria-label="breadcrumb">
+    <ol class="breadcrumb">
+    {% for item in breadcrumb %}
+      {% if item.url %}
+        <li class="{{ item.classes }}">
+          <a href="{{ item.url }}">{{ item.text }}</a>
+        </li>
+      {% else %}
+        <li class="{{ item.classes }}" aria-current="page">
+          {{ item.text }}
+        </li>
+      {% endif %}
+    {% endfor %}
+    </ol>
+  </nav>
+{% endif %}

--- a/themes/custom/az_barrio/templates/navigation/breadcrumb.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/breadcrumb.html.twig
@@ -8,20 +8,6 @@
  */
 #}
 
-{% if breadcrumb %}
-  <nav role="navigation" aria-label="breadcrumb">
-    <ol class="breadcrumb">
-    {% for item in breadcrumb %}
-      {% if item.url %}
-        <li class="{{ item.classes }}">
-          <a href="{{ item.url }}">{{ item.text }}</a>
-        </li>
-      {% else %}
-        <li class="{{ item.classes }}" aria-current="page">
-          {{ item.text }}
-        </li>
-      {% endif %}
-    {% endfor %}
-    </ol>
-  </nav>
-{% endif %}
+{{ include('az_barrio:breadcrumb', {
+  breadcrumb: breadcrumb,
+}, with_context = false) }}

--- a/themes/custom/az_barrio/tests/src/Functional/AzBarrioTest.php
+++ b/themes/custom/az_barrio/tests/src/Functional/AzBarrioTest.php
@@ -52,6 +52,16 @@ class AzBarrioTest extends QuickstartFunctionalTestBase {
     $this->assertSession()->elementExists('css', '#navbar-top.navbar.navbar-expand');
     $this->assertSession()->elementExists('css', '#block-az-barrio-offcanvas-searchform');
     $this->assertSession()->elementExists('css', '#block-az-barrio-mobilenavblock');
+
+    // Tests that breadcrumb block visibility and markup remain intact.
+    $this->drupalGet('');
+    $this->assertSession()->elementNotExists('css', 'nav[aria-label="breadcrumb"]');
+
+    $this->drupalGet('user/login');
+    $this->assertSession()->elementExists('css', 'nav[aria-label="breadcrumb"]');
+    $this->assertSession()->elementExists('css', 'nav[aria-label="breadcrumb"] ol.breadcrumb');
+    $this->assertSession()->elementExists('css', 'nav[aria-label="breadcrumb"] .breadcrumb-item-home a');
+    $this->assertSession()->elementExists('css', 'nav[aria-label="breadcrumb"] .breadcrumb-item.active[aria-current="page"]');
   }
 
 }


### PR DESCRIPTION
See #5405.

## Summary

Convert the az_barrio breadcrumb override into a Single Directory Component.

This change extracts the breadcrumb markup into a new theme component and keeps the existing breadcrumb template as a thin presenter that includes the component. The goal is to make breadcrumb the first low-risk SDC proof of concept in az_barrio without changing its rendered output or preprocess behavior.

## Changes

- Add a new breadcrumb SDC in the az_barrio theme
- Refactor the breadcrumb Twig override to include the new component
- Keep existing breadcrumb preprocess logic unchanged
- Extend the az_barrio functional test to verify breadcrumb visibility and markup behavior

## Why breadcrumb first

Breadcrumb is a good first SDC candidate because it is already isolated in a single Twig override, has a simple data contract, and does not require JS or component-specific library work. This lets us validate theme-level SDC usage with minimal behavioral risk.

## Testing

- `lando phpunit --filter AzBarrioTest`

## Notes

- This change does not alter the existing breadcrumb preprocess contract
- This change does not reorganize theme libraries
- This is intended as an initial SDC proof of concept for az_barrio