### PR TITLE
#5167: Address various issues with vanilla-calendar-pro implementations in #5399

### DIFF
--- a/modules/custom/az_core/js/az-date-picker-integration.js
+++ b/modules/custom/az_core/js/az-date-picker-integration.js
@@ -7,6 +7,8 @@
 
 ((Drupal, window) => {
   const OPEN_KEYS = new Set(['Enter', 'ArrowDown', ' ']);
+  const FOCUSABLE_SELECTOR =
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
   /**
    * Adds consistent mouse and keyboard open handlers to an input element.
@@ -23,10 +25,6 @@
 
     element.addEventListener('mousedown', (event) => {
       event.preventDefault();
-      openCalendar();
-    });
-
-    element.addEventListener('focus', () => {
       openCalendar();
     });
 
@@ -60,9 +58,218 @@
     return [...new Set(VanillaCalendarProUtils.parseDates(selectedValues))];
   };
 
+  /**
+   * Validates calendar date components and returns normalized Y-m-d.
+   *
+   * @param {number} year
+   *   Year component.
+   * @param {number} month
+   *   Month component (1-12).
+   * @param {number} day
+   *   Day component (1-31).
+   *
+   * @return {string|null}
+   *   Normalized date or NULL when invalid.
+   */
+  const toNormalizedIsoDate = (year, month, day) => {
+    if (
+      !Number.isInteger(year) ||
+      !Number.isInteger(month) ||
+      !Number.isInteger(day) ||
+      month < 1 ||
+      month > 12 ||
+      day < 1 ||
+      day > 31
+    ) {
+      return null;
+    }
+
+    const normalized = new Date(Date.UTC(year, month - 1, day));
+    if (
+      normalized.getUTCFullYear() !== year ||
+      normalized.getUTCMonth() !== month - 1 ||
+      normalized.getUTCDate() !== day
+    ) {
+      return null;
+    }
+
+    return [
+      String(year).padStart(4, '0'),
+      String(month).padStart(2, '0'),
+      String(day).padStart(2, '0'),
+    ].join('-');
+  };
+
+  /**
+   * Normalizes and validates a Y-m-d value (allows unpadded month/day).
+   *
+   * @param {string} value
+   *   Raw date value.
+   *
+   * @return {string|null}
+   *   Normalized Y-m-d date or NULL when invalid.
+   */
+  const normalizeIsoDate = (value) => {
+    const match = String(value || '')
+      .trim()
+      .match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+
+    if (!match) {
+      return null;
+    }
+
+    return toNormalizedIsoDate(
+      Number(match[1]),
+      Number(match[2]),
+      Number(match[3]),
+    );
+  };
+
+  /**
+   * Normalizes and validates a partial date value.
+   *
+   * Accepts Y, Y-m, or Y-m-d and returns Y-m-d.
+   *
+   * @param {string} value
+   *   Raw date value.
+   *
+   * @return {string|null}
+   *   Normalized Y-m-d date or NULL when invalid.
+   */
+  const normalizeToFullDate = (value) => {
+    const match = String(value || '')
+      .trim()
+      .match(/^(\d{4})(?:-(\d{1,2}))?(?:-(\d{1,2}))?$/);
+
+    if (!match) {
+      return null;
+    }
+
+    return toNormalizedIsoDate(
+      Number(match[1]),
+      match[2] ? Number(match[2]) : 1,
+      match[3] ? Number(match[3]) : 1,
+    );
+  };
+
+  /**
+   * Trims a normalized Y-m-d date to requested precision.
+   *
+   * @param {string} value
+   *   Date-like value.
+   * @param {number} partsCount
+   *   Number of parts to keep (1-3).
+   *
+   * @return {string}
+   *   Trimmed date or empty string when invalid.
+   */
+  const trimDateToPartsCount = (value, partsCount) => {
+    const normalized = normalizeToFullDate(value);
+    return normalized
+      ? normalized.split('-').slice(0, partsCount).join('-')
+      : '';
+  };
+
+  /**
+   * Returns visible/focusable elements for a scope.
+   *
+   * @param {ParentNode} scope
+   *   Scope to query for focusable elements.
+   * @param {HTMLElement} [excludeWithin]
+   *   Optional element whose descendants should be excluded.
+   *
+   * @return {HTMLElement[]}
+   *   Focusable elements in DOM order.
+   */
+  const getFocusableElements = (scope, excludeWithin) => {
+    const queryScope = scope || document;
+
+    return Array.from(queryScope.querySelectorAll(FOCUSABLE_SELECTOR)).filter(
+      (el) =>
+        (!excludeWithin || !excludeWithin.contains(el)) &&
+        el.offsetParent !== null &&
+        el.tabIndex >= 0 &&
+        !el.hasAttribute('disabled') &&
+        el.getAttribute('aria-disabled') !== 'true',
+    );
+  };
+
+  /**
+   * Returns whether a Tab key event should exit a calendar popup.
+   *
+   * Exit is triggered only at boundaries:
+   * - Shift+Tab on first focusable element
+   * - Tab on last focusable element
+   *
+   * @param {KeyboardEvent} event
+   *   Keydown event.
+   * @param {HTMLElement} calendarElement
+   *   Calendar root element.
+   *
+   * @return {boolean}
+   *   TRUE if the event is a boundary Tab that should close the popup.
+   */
+  const shouldExitCalendarOnTab = (event, calendarElement) => {
+    if (!event || event.key !== 'Tab' || !calendarElement) {
+      return false;
+    }
+
+    const focusableInCalendar = getFocusableElements(calendarElement);
+    if (!focusableInCalendar.length) {
+      return true;
+    }
+
+    const active = document.activeElement;
+    const first = focusableInCalendar[0];
+    const last = focusableInCalendar[focusableInCalendar.length - 1];
+
+    return event.shiftKey ? active === first : active === last;
+  };
+
+  /**
+   * Moves focus relative to an anchor element while excluding calendar content.
+   *
+   * @param {HTMLElement} calendarElement
+   *   Calendar root element to exclude from page focus traversal.
+   * @param {HTMLElement} anchorElement
+   *   Element used as the position reference in tab order.
+   * @param {'next'|'previous'} direction
+   *   Direction to move focus from the anchor.
+   *
+   * @return {boolean}
+   *   TRUE when focus moved successfully.
+   */
+  const focusRelativeToAnchor = (calendarElement, anchorElement, direction) => {
+    if (!calendarElement || !anchorElement) {
+      return false;
+    }
+
+    const focusable = getFocusableElements(document, calendarElement);
+
+    const idx = focusable.indexOf(anchorElement);
+
+    if (direction === 'previous' && idx > 0 && focusable[idx - 1]) {
+      focusable[idx - 1].focus();
+      return true;
+    }
+
+    if (direction === 'next' && idx >= 0 && focusable[idx + 1]) {
+      focusable[idx + 1].focus();
+      return true;
+    }
+
+    return false;
+  };
+
   Drupal.azCore = Drupal.azCore || {};
   Drupal.azCore.datePickerIntegration = {
     bindCalendarOpenHandlers,
     getNormalizedSelectedDates,
+    normalizeIsoDate,
+    normalizeToFullDate,
+    trimDateToPartsCount,
+    getFocusableElements,
+    shouldExitCalendarOnTab,
+    focusRelativeToAnchor,
   };
 })(Drupal, window);

--- a/modules/custom/az_event/az_event_trellis/js/az_event_trellis_date.js
+++ b/modules/custom/az_event/az_event_trellis/js/az_event_trellis_date.js
@@ -13,14 +13,16 @@
    *   Begin date input element.
    * @param {HTMLInputElement} end
    *   End date input element.
+   * @param {Object} datePickerIntegration
+   *   Shared date picker integration helpers.
    *
    * @return {string[]}
    *   Selected date values for Vanilla Calendar Pro.
    */
-  const getSelectedDatesFromInputs = (begin, end) => {
+  const getSelectedDatesFromInputs = (begin, end, datePickerIntegration) => {
     const selectedDates = [];
-    const beginDate = begin.value.trim();
-    const endDate = end.value.trim();
+    const beginDate = datePickerIntegration.normalizeIsoDate(begin.value);
+    const endDate = datePickerIntegration.normalizeIsoDate(end.value);
     if (beginDate && endDate) {
       selectedDates.push(`${beginDate}:${endDate}`);
     } else if (beginDate) {
@@ -43,10 +45,18 @@
           return;
         }
 
-        const selectedDates = getSelectedDatesFromInputs(begin, end);
+        const selectedDates = getSelectedDatesFromInputs(
+          begin,
+          end,
+          datePickerIntegration,
+        );
+
+        let calendarTabHandler = null;
+        let suppressOnHideFocus = false;
 
         const config = {
           inputMode: true,
+          openOnFocus: false,
           selectedTheme: 'light',
           themeAttrDetect: false,
           selectionDatesMode: 'multiple-ranged',
@@ -64,15 +74,97 @@
               self.hide();
             }
           },
+          onShow(self) {
+            const calendarEl = self.context.mainElement;
+            calendarTabHandler = (event) => {
+              if (event.key !== 'Tab') return;
+
+              if (
+                !datePickerIntegration.shouldExitCalendarOnTab(
+                  event,
+                  calendarEl,
+                )
+              ) {
+                return;
+              }
+
+              event.preventDefault();
+              suppressOnHideFocus = true;
+              // onHide fires synchronously, resets inputElement to begin and focuses it.
+              self.hide();
+              // Move focus in natural tab order around the begin/end pair.
+              datePickerIntegration.focusRelativeToAnchor(
+                calendarEl,
+                event.shiftKey ? begin : end,
+                event.shiftKey ? 'previous' : 'next',
+              );
+            };
+            calendarEl.addEventListener('keydown', calendarTabHandler);
+          },
           onHide(self) {
+            if (calendarTabHandler) {
+              self.context.mainElement.removeEventListener(
+                'keydown',
+                calendarTabHandler,
+              );
+              calendarTabHandler = null;
+            }
             // Reset to begin input after closing so default input-mode behavior
             // stays anchored to the primary field.
             self.context.inputElement = begin;
+            if (suppressOnHideFocus) {
+              suppressOnHideFocus = false;
+            } else {
+              begin.focus();
+            }
           },
         };
 
         const calendar = new VanillaCalendarPro.Calendar(begin, config);
         calendar.init();
+
+        // Enable keyboard opening for begin input (Enter/Arrow/Space).
+        datePickerIntegration.bindCalendarOpenHandlers(begin, () => {
+          calendar.context.inputElement = begin;
+          calendar.show();
+        });
+
+        const syncFromInputs = () => {
+          const beginRaw = String(begin.value || '').trim();
+          const endRaw = String(end.value || '').trim();
+          let beginValue = datePickerIntegration.normalizeIsoDate(beginRaw);
+          let endValue = datePickerIntegration.normalizeIsoDate(endRaw);
+
+          // Silently discard invalid manual values.
+          if (beginRaw && !beginValue) {
+            begin.value = '';
+          }
+          if (endRaw && !endValue) {
+            end.value = '';
+          }
+
+          beginValue = datePickerIntegration.normalizeIsoDate(begin.value);
+          endValue = datePickerIntegration.normalizeIsoDate(end.value);
+
+          const newDates = [];
+          if (beginValue && endValue) {
+            begin.value = beginValue;
+            end.value = endValue;
+            newDates.push(`${beginValue}:${endValue}`);
+          } else if (beginValue) {
+            begin.value = beginValue;
+            newDates.push(beginValue);
+          }
+
+          calendar.set(
+            { selectedDates: newDates },
+            { dates: true, year: true, month: true },
+          );
+        };
+
+        // Allow direct text editing on begin/end inputs.
+        begin.addEventListener('change', syncFromInputs);
+        end.addEventListener('change', syncFromInputs);
 
         let endOpenQueued = false;
         datePickerIntegration.bindCalendarOpenHandlers(end, () => {

--- a/modules/custom/az_publication/js/az_publication_date_picker.js
+++ b/modules/custom/az_publication/js/az_publication_date_picker.js
@@ -6,40 +6,6 @@
 /* global VanillaCalendarPro */
 
 ((Drupal, once) => {
-  /**
-   * Pads month/day values for Drupal datetime parsing.
-   *
-   * @param {string} value
-   *   Raw input value.
-   *
-   * @return {string}
-   *   A full date in Y-m-d format.
-   */
-  const normalizeToFullDate = (value) => {
-    const parts = String(value || '')
-      .split('-')
-      .filter((part) => part !== '');
-    while (parts.length < 3) {
-      parts.push('01');
-    }
-    return parts.slice(0, 3).join('-');
-  };
-
-  /**
-   * Trims a normalized Y-m-d date to requested precision.
-   *
-   * @param {string} value
-   *   Date string in Y-m-d format.
-   * @param {number} partsCount
-   *   Number of date components to keep.
-   *
-   * @return {string}
-   *   A date string formatted to the selected precision.
-   */
-  const trimDateToPartsCount = (value, partsCount) => {
-    return normalizeToFullDate(value).split('-').slice(0, partsCount).join('-');
-  };
-
   Drupal.behaviors.datetimeTweaksDefaultDate = {
     attach(context) {
       const datePickerIntegration = Drupal.azCore?.datePickerIntegration;
@@ -61,16 +27,19 @@
         const mode = element.dataset.azPublicationDateMode || 'default';
 
         // Keep user-visible values aligned to the selected granularity.
-        let value = String(element.value || '').trim();
+        const value = String(element.value || '').trim();
         let selectedDate = null;
         if (value) {
-          value = value.split('-').filter((part) => part !== '');
-          while (value.length < datePartsCount) {
-            value.push('01');
+          selectedDate = datePickerIntegration.normalizeToFullDate(value);
+          if (selectedDate) {
+            element.value = datePickerIntegration.trimDateToPartsCount(
+              selectedDate,
+              datePartsCount,
+            );
+          } else {
+            // Do not seed calendar state with invalid pre-existing text.
+            element.value = '';
           }
-          value = value.slice(0, datePartsCount).join('-');
-          element.value = value;
-          selectedDate = normalizeToFullDate(value);
         }
 
         const writeValueFromCalendar = (self) => {
@@ -92,20 +61,23 @@
               selected = `${year}-${month}-01`;
             }
           } else {
-            [selected] = datePickerIntegration
-              .getNormalizedSelectedDates(self);
+            [selected] = datePickerIntegration.getNormalizedSelectedDates(self);
           }
 
           if (selected) {
-            self.context.inputElement.value = trimDateToPartsCount(
-              selected,
-              datePartsCount,
-            );
+            self.context.inputElement.value =
+              datePickerIntegration.trimDateToPartsCount(
+                selected,
+                datePartsCount,
+              );
             self.hide();
           } else {
             self.context.inputElement.value = '';
           }
         };
+
+        let calendarTabHandler = null;
+        let suppressOnHideFocus = false;
 
         const config = {
           inputMode: true,
@@ -123,6 +95,49 @@
           onClickYear(self) {
             requestAnimationFrame(() => writeValueFromCalendar(self));
           },
+          onShow(self) {
+            const calendarEl = self.context.mainElement;
+            const focusAnchor = self.context.inputElement;
+            calendarTabHandler = (event) => {
+              if (event.key !== 'Tab') return;
+
+              if (
+                !datePickerIntegration.shouldExitCalendarOnTab(
+                  event,
+                  calendarEl,
+                )
+              ) {
+                return;
+              }
+
+              event.preventDefault();
+              suppressOnHideFocus = true;
+              // onHide fires synchronously from hide(), restoring focus to input.
+              self.hide();
+              // Move focus in natural tab order relative to the input anchor.
+              datePickerIntegration.focusRelativeToAnchor(
+                calendarEl,
+                focusAnchor,
+                event.shiftKey ? 'previous' : 'next',
+              );
+            };
+            calendarEl.addEventListener('keydown', calendarTabHandler);
+          },
+          onHide(self) {
+            if (calendarTabHandler) {
+              self.context.mainElement.removeEventListener(
+                'keydown',
+                calendarTabHandler,
+              );
+              calendarTabHandler = null;
+            }
+            // Restore focus after close unless focus was moved explicitly.
+            if (suppressOnHideFocus) {
+              suppressOnHideFocus = false;
+            } else if (self.context.inputElement) {
+              self.context.inputElement.focus();
+            }
+          },
         };
 
         if (selectedDate) {
@@ -131,6 +146,39 @@
 
         const calendar = new VanillaCalendarPro.Calendar(element, config);
         calendar.init();
+
+        // Allow direct text editing: silently discard invalid user input.
+        element.addEventListener('change', () => {
+          const userValue = String(element.value || '').trim();
+          const normalized =
+            datePickerIntegration.normalizeToFullDate(userValue);
+
+          if (!userValue) {
+            calendar.set(
+              { selectedDates: [] },
+              { dates: true, year: true, month: true },
+            );
+            return;
+          }
+
+          if (normalized) {
+            element.value = datePickerIntegration.trimDateToPartsCount(
+              normalized,
+              datePartsCount,
+            );
+            calendar.set(
+              { selectedDates: [normalized] },
+              { dates: true, year: true, month: true },
+            );
+            return;
+          }
+
+          element.value = '';
+          calendar.set(
+            { selectedDates: [] },
+            { dates: true, year: true, month: true },
+          );
+        });
 
         let firstOpen = true;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

Branch PR for #5399 to address issues identified in testing (assisted by Copilot):



- Disables default vanilla-calendar-pro (VCP) `openOnFocus` setting and adds custom tab focus handling boundary-scoped to calendar widgets to address issue found by @bberndt-uaz where keyboard focus could get "stuck" on calendar widgets which was preventing (or at least complicating) keyboard navigation to later parts of forms while preserving keyboard navigation within actual datepickers

- Enables direct keyboard manipulation of date inputs and automatic updating of datepicker selection with validation and automatic discarding of invalid date values.

- Moves more common functionality into the the shared `az-date-picker-integration` library

Full list of changes (generated by copilot):
```
### What changed

1. Expands shared integration helpers in [modules/custom/az_core/js/az-date-picker-integration.js](modules/custom/az_core/js/az-date-picker-integration.js):
    - Removes input `focus` auto-open from shared open handlers.
    - Adds normalized date parsing/validation helpers:
      - `normalizeIsoDate`
      - `normalizeToFullDate`
      - `trimDateToPartsCount`
    - Adds shared focus/Tab helpers:
      - `getFocusableElements`
      - `shouldExitCalendarOnTab`
      - `focusRelativeToAnchor`

2. Trellis date range picker updates in [modules/custom/az_event/az_event_trellis/js/az_event_trellis_date.js](modules/custom/az_event/az_event_trellis/js/az_event_trellis_date.js):
    - Uses shared normalization for begin/end values.
    - Adds `openOnFocus: false`.
    - Adds boundary-only Tab handling while calendar is open.
    - Supports both forward and backward boundary exit:
      - `Tab` at last focusable closes and advances after end input.
      - `Shift+Tab` at first focusable closes and moves before begin input.
    - Suppresses default onHide refocus when focus is explicitly moved.
    - Adds direct text editing sync for begin/end, silently discarding invalid values.

3. Publication date picker updates in [modules/custom/az_publication/js/az_publication_date_picker.js](modules/custom/az_publication/js/az_publication_date_picker.js):
    - Removes duplicated local normalization helpers and uses shared az_core utilities.
    - Normalizes/clears pre-existing input before seeding calendar state.
    - Adds boundary-only Tab handling with direction-aware exit:
      - forward exits to next focusable after input
      - backward exits to previous focusable before input
    - Suppresses default onHide refocus when focus is explicitly moved.
    - Adds direct manual-input handling, silently discarding invalid values and preventing invalid `selectedDates`.
 
### Behavior outcome

- No more input-focus reopen loop.
- Boundary-only keyboard escape from calendar popup.
- Invalid manual date text is not propagated into calendar state.
- Publication + trellis now share core normalization and focus behavior.
```



## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
