### PR TITLE
Closes #5449: Regression in scroll behavior of AJAX views with exposed filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -187,7 +187,8 @@
                 "[Regression] missing menu active trail since Drupal 9.5.9 (3359511)": "https://www.drupal.org/files/issues/2025-12-04/3359511-143.patch",
                 "Diffs with different line endings leads to Invalid $mode 3 specified (3389715)": "https://www.drupal.org/files/issues/2024-01-09/Diffs-with-different-line-endings-leads-to-Invalid-mode-3-specified.patch",
                 "Recent changes to migrate_drupal can break migrations that rely on hook_migration_plugins_alter() (3546325)": "https://www.drupal.org/files/issues/2025-11-07/3546325-15-11-3-x.patch",
-                "Display Bug when using #states (Forms API) with Ajax Request (1091852)": "https://www.drupal.org/files/issues/2023-12-18/1091852-186.patch"
+                "Display Bug when using #states (Forms API) with Ajax Request (1091852)": "https://www.drupal.org/files/issues/2023-12-18/1091852-186.patch",
+                "Views with exposed filter and ajax causes unexpected scroll position change (3564586)": "https://gist.githubusercontent.com/bberndt-uaz/7183bc9aee173b19176955ba1cb178f9/raw/c7baa3a68d0325b1f459860831b075cd0819571d/3564586-11.x.patch"
             },
             "drupal/draggableviews": {
                 "Row weights not displaying on sort view (3252365)": "https://www.drupal.org/files/issues/2023-08-25/3252365-check-remove-select-all-class.patch",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Adds a [patch](https://gist.github.com/bberndt-uaz/7183bc9aee173b19176955ba1cb178f9) to temporarily resolve this Drupal core issue:
- [Views with exposed filter and ajax causes unexpected scroll position change](https://www.drupal.org/project/drupal/issues/3564586)

Specifically, the patch reverts the changes from this Drupal core issue made to ajax.js in 10.6.x and 11.x:
- [Modernize Drupal.ajaxCommands.scrollTop()](https://www.drupal.org/node/3478087)

This pull request should also be backported to Quickstart 2.x.

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #5449

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

1. To observe the existing issue, visit the [Calendar page](https://demo.quickstart.arizona.edu/calendar) on the demo site and observe the scrolling behavior when using the filters in the right sidebar.
2. Also, visit the [News Views page](https://demo.quickstart.arizona.edu/pages/news-view-paragraphs) and observe the same behavior when using the category filter for the Grid View with Filter view.
3. Now visit the [Calendar page](https://pr5453-jyt0cttmqu8fq3zxiumk2hwybydyowpt.tugboatqa.com/calendar) on the Tugboat review site and confirm that no scrolling occurs when you use the filters.
4. Also, visit the [News Views page](https://pr5453-jyt0cttmqu8fq3zxiumk2hwybydyowpt.tugboatqa.com/pages/news-view-paragraphs) on the Tugboat site and confirm that no scrolling occurs when you use the category dropdown for the Grid View with Filter view.
5. Test other views with exposed forms as needed. The Finder views are not affected since Quickstart explicitly disables scrolling for those views.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [x] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
