### PR TITLE
Fixes #5456 Reduce az_search_api noncanonical duplicates

### DIFF
--- a/modules/custom/az_search_api/az_search_api.services.yml
+++ b/modules/custom/az_search_api/az_search_api.services.yml
@@ -1,0 +1,5 @@
+services:
+  logger.channel.az_search_api:
+    parent: logger.channel_base
+    arguments:
+      - 'az_search_api'

--- a/modules/custom/az_search_api/config/install/search_api.index.az_search_api_index.yml
+++ b/modules/custom/az_search_api/config/install/search_api.index.az_search_api_index.yml
@@ -131,6 +131,7 @@ processor_settings:
       - title
       - type
       - url
+  az_canonical: {  }
   az_metatag: {  }
   az_robots_noindex: {  }
   az_search_summary: {  }

--- a/modules/custom/az_search_api/src/Plugin/search_api/processor/AZCanonical.php
+++ b/modules/custom/az_search_api/src/Plugin/search_api/processor/AZCanonical.php
@@ -48,7 +48,7 @@ class AZCanonical extends ProcessorPluginBase {
         $tags = $this->metatagManager->tagsFromEntityWithDefaults($entity);
         $tokens = $this->metatagManager->generateTokenValues($tags, $entity);
         // Get the canonical url from the metatag.
-        $canonical_url = $tokens['og_url'] ?? '';
+        $canonical_url = $tokens['canonical_url'] ?? '';
         // Compute the entity's actual url.
         $url = $entity->toUrl();
         $uri = $url->setOption('absolute', TRUE)->toString();

--- a/modules/custom/az_search_api/src/Plugin/search_api/processor/AZCanonical.php
+++ b/modules/custom/az_search_api/src/Plugin/search_api/processor/AZCanonical.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\az_search_api\Plugin\search_api\processor;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\metatag\MetatagManager;
+use Drupal\search_api\Attribute\SearchApiProcessor;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Skip indexing content that is noncanonical.
+ */
+#[SearchApiProcessor(
+  id: 'az_canonical',
+  label: new TranslatableMarkup('Include only canonical items'),
+  description: new TranslatableMarkup('Include only items for which the content is the canonical version.'),
+  stages: [
+    'alter_items' => 0,
+  ],
+)]
+class AZCanonical extends ProcessorPluginBase {
+
+  /**
+   * The MetatagManager. MetatagManagerInterface does not have APIs we need.
+   */
+  protected ?MetatagManager $metatagManager = NULL;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var static $processor */
+    $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $processor->metatagManager = $container->get('metatag.manager');
+    return $processor;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterIndexedItems(array &$items) {
+    /** @var \Drupal\search_api\Item\ItemInterface $item */
+    foreach ($items as $item_id => $item) {
+      $entity = $item->getOriginalObject()->getValue();
+      if (!empty($entity)) {
+        // Render the metatag tokens for the provided entity.
+        $tags = $this->metatagManager->tagsFromEntityWithDefaults($entity);
+        $tokens = $this->metatagManager->generateTokenValues($tags, $entity);
+        // Get the canonical url from the metatag.
+        $canonical_url = $tokens['og_url'] ?? '';
+        // Compute the entity's actual url.
+        $url = $entity->toUrl();
+        $uri = $url->setOption('absolute', TRUE)->toString();
+        // Do not index the content if the canonical url does not match.
+        if (!empty($canonical_url) && ($uri !== $canonical_url)) {
+          // @todo this logging message is only for testing. Remove before merge.
+          \Drupal::logger('az_search_api')->notice(t("Not indexing @uri because of canonical @canonical_url", [
+            '@uri' => $uri,
+            '@canonical' => $canonical_url,
+          ]));
+          unset($items[$item_id]);
+        }
+      }
+    }
+  }
+
+}

--- a/modules/custom/az_search_api/src/Plugin/search_api/processor/AZCanonical.php
+++ b/modules/custom/az_search_api/src/Plugin/search_api/processor/AZCanonical.php
@@ -2,11 +2,14 @@
 
 namespace Drupal\az_search_api\Plugin\search_api\processor;
 
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\metatag\MetatagManager;
 use Drupal\search_api\Attribute\SearchApiProcessor;
 use Drupal\search_api\Processor\ProcessorPluginBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 
 /**
  * Skip indexing content that is noncanonical.
@@ -19,7 +22,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
     'alter_items' => 0,
   ],
 )]
-class AZCanonical extends ProcessorPluginBase {
+class AZCanonical extends ProcessorPluginBase implements LoggerAwareInterface {
+
+  use LoggerAwareTrait;
+  use StringTranslationTrait;
 
   /**
    * The MetatagManager. MetatagManagerInterface does not have APIs we need.
@@ -33,6 +39,7 @@ class AZCanonical extends ProcessorPluginBase {
     /** @var static $processor */
     $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $processor->metatagManager = $container->get('metatag.manager');
+    $processor->setLogger($container->get('logger.channel.az_search_api'));
     return $processor;
   }
 
@@ -51,13 +58,15 @@ class AZCanonical extends ProcessorPluginBase {
         $canonical_url = $tokens['canonical_url'] ?? '';
         // Compute the entity's actual url.
         $url = $entity->toUrl();
+        $label = $entity->label();
         $uri = $url->setOption('absolute', TRUE)->toString();
         // Do not index the content if the canonical url does not match.
         if (!empty($canonical_url) && ($uri !== $canonical_url)) {
-          // @todo this logging message is only for testing. Remove before merge.
-          \Drupal::logger('az_search_api')->notice(t("Not indexing @uri because of canonical @canonical_url", [
-            '@uri' => $uri,
-            '@canonical' => $canonical_url,
+          // @todo remove this message when az_search_api exits experimental status.
+          $this->logger->debug($this->t('Skipping index of <a href=":uri">@label</a> because %canonical_url is canonical', [
+            ':uri' => $uri,
+            '@label' => $label,
+            '%canonical' => $canonical_url,
           ]));
           unset($items[$item_id]);
         }


### PR DESCRIPTION
## Description
This PR adds an a new az_search_api processor called `az_canonical` that strikes content from the index if its canonical metatag does not match the content's url.

### Release notes
```
az_search_api will now skip indexing of content that is not canonical to the site, as defined by the opengraph url metatag.
```

## Related issues
#5456 

## How to test

- See testing instructions in #5104 for instructions on how to set up credential secrets
- Create content, or use demo content
- Verify that some created content uses metatag "Opengraph Page Url" that points elsewhere
  - Some demo content meets this condition
- Visit `/admin/config/search/search-api/index/az_search_api_index`
- Click **Queue all items for reindexing**
- Click **Index now**
- Visit watchdog log, verify there are log entries from **az_search_api** mentioning that certain pages were not indexed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My change requires release notes.
