### PR TITLE
Closes #5451: Replace @var annotations with assert() to appease latest PHPStan

### DIFF
--- a/modules/custom/az_accordion/src/Plugin/Field/FieldFormatter/AZAccordionDefaultFormatter.php
+++ b/modules/custom/az_accordion/src/Plugin/Field/FieldFormatter/AZAccordionDefaultFormatter.php
@@ -9,6 +9,7 @@ use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\az_accordion\Plugin\Field\FieldType\AZAccordionItem;
 use Drupal\paragraphs\ParagraphInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -94,8 +95,8 @@ class AZAccordionDefaultFormatter extends FormatterBase implements ContainerFact
     $entity = $items->getEntity();
     $accordion_container_id = HTML::getUniqueId('accordion-' . $entity->id());
 
-    /** @var \Drupal\az_accordion\Plugin\Field\FieldType\AZAccordionItem $item */
     foreach ($items as $delta => $item) {
+      assert($item instanceof AZAccordionItem);
       // Format title.
       $title = $item->title ?? '';
 

--- a/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
+++ b/modules/custom/az_card/src/Plugin/Field/FieldFormatter/AZCardDefaultFormatter.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\az_card\Plugin\Field\FieldFormatter;
 
+use Drupal\az_card\Plugin\Field\FieldType\AZCardItem;
 use Drupal\Core\Field\Attribute\FieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
@@ -106,8 +107,8 @@ class AZCardDefaultFormatter extends FormatterBase implements ContainerFactoryPl
     $settings = $this->getSettings();
     $element = [];
 
-    /** @var \Drupal\az_card\Plugin\Field\FieldType\AZCardItem $item */
     foreach ($items as $delta => $item) {
+      assert($item instanceof AZCardItem);
 
       // Format title.
       $title = $item->title ?? '';

--- a/modules/custom/az_publication/src/Plugin/Field/FieldWidget/AZEntityRoleInlineFormComplex.php
+++ b/modules/custom/az_publication/src/Plugin/Field/FieldWidget/AZEntityRoleInlineFormComplex.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\az_publication\Plugin\Field\FieldWidget;
 
+use Drupal\az_publication\Plugin\Field\FieldType\AZEntityRoleReferenceItem;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Field\FieldFilteredMarkup;
 use Drupal\Core\Field\FieldItemListInterface;
@@ -93,6 +94,7 @@ class AZEntityRoleInlineFormComplex extends InlineEntityFormComplex {
       // Store the $items entities in the widget state, for further
       // manipulation.
       foreach ($items as $delta => $item) {
+        assert($item instanceof AZEntityRoleReferenceItem);
         // Display the entity in the correct translation.
         $entity = $item->entity;
         $role = $item->role ?? 'author';

--- a/modules/custom/az_ranking/src/Plugin/Field/FieldFormatter/AZRankingDefaultFormatter.php
+++ b/modules/custom/az_ranking/src/Plugin/Field/FieldFormatter/AZRankingDefaultFormatter.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\az_ranking\Plugin\Field\FieldFormatter;
 
+use Drupal\az_ranking\Plugin\Field\FieldType\AZRankingItem;
 use Drupal\Core\Field\Attribute\FieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
@@ -106,8 +107,8 @@ class AZRankingDefaultFormatter extends FormatterBase implements ContainerFactor
     $settings = $this->getSettings();
     $element = [];
 
-    /** @var \Drupal\az_ranking\Plugin\Field\FieldType\AZRankingItem $item */
     foreach ($items as $delta => $item) {
+      assert($item instanceof AZRankingItem);
 
       // Format title.
       $ranking_heading = $item->ranking_heading ?? '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
#5451 : I can't find exactly what about PHPStan _2.1.45_ caused the errors from the issue:
```
 ------ ------------------------------------------------------------------------------------------------------------------------------- 
  Line   web/profiles/custom/az_quickstart/modules/custom/az_accordion/src/Plugin/Field/FieldFormatter/AZAccordionDefaultFormatter.php  
 ------ ------------------------------------------------------------------------------------------------------------------------------- 
  98     PHPDoc tag @var with type Drupal\az_accordion\Plugin\Field\FieldType\AZAccordionItem is not subtype of native type             
         Drupal\Core\Field\FieldItemInterface.                                                                                          
         🪪  varTag.nativeType                                                                                                          
 ------ ------------------------------------------------------------------------------------------------------------------------------- 
* same error occurs also for AZRankingItem and AZCardItem
```
Even though AZAccordionItem, AZRankingItem, and AZCardItem all correctly extend FieldItemBase, it seems PHPStan 2.x couldn't confirm the relationship at analysis time. Either that or it became stricter against inline @var's OR on usage of its lie detector. 

But in general it seems PHPStan 2.x [discourages use of inline @var's](https://phpstan.org/blog/phpstan-2-0-released-level-10-elephpants#:~:text=I%E2%80%99d%20like%20the%20PHP%20community%20to%20use%20inline%20%40var%20tags%20less%20and%20less%20over%20time.):

> PHPStan 2.0 validates the inline @var tag type against the native type of the assigned expression. It finds the lies spread around in @var tags:

> I’d like the PHP community to use inline @var tags less and less over time. There are many great alternatives that promote good practices and code deduplication...

[And here:](https://phpstan.org/writing-php-code/phpdocs-basics#:~:text=Instead%2C%20the%20type%20should%20be,Magic%20properties%20%23) 
> Casting a type using an inline @var PHPDocs should be used only as a last resort. It can be used in a variable assignment like this

It also says: 
> If you really need to use an inline @var, consider an alternative - an assert() call, which can throw an exception at runtime, so the code execution doesn’t continue if the requirements aren’t met.

Similar (though maybe not exact) issue here says they solved it using assert() statements: https://drupal.stackexchange.com/questions/321256/phpstan-2-vartag-type-phpdoc-tag-var-with-type-userbundle-is-not-subtype-of-ty#:~:text=Sorted%20by:,asserted%20or%20checked%20with%20instanceof%20.

So this PR changes them to assert() statements, but this means we need to make sure the paragraph types in question: `az_card`, `az_ranking`, `az_accordion`, and `az_publication` don't break at runtime. I've done the tests below on these paragraph types and have found no errors so far. 

For this: 
```
 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  Line   web/profiles/custom/az_quickstart/modules/custom/az_publication/src/Plugin/Field/FieldWidget/AZEntityRoleInlineFormComplex.php  
 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  97     Access to an undefined property Drupal\Core\Field\FieldItemInterface::$entity.                                                  
         🪪  property.notFound                                                                                                           
         💡  Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property                                           
 ------ -------------------------------------------------------------------------------------------------------------------------------- 
```
`assert($item instanceof AZEntityRoleReferenceItem);` resolves the undefined property error because AZEntityRoleReferenceItem [extends EntityReferenceItem](https://github.com/az-digital/az_quickstart/blob/163217e75b33f3b15cb0a292a9624f1918028128/modules/custom/az_publication/src/Plugin/Field/FieldType/AZEntityRoleReferenceItem.php#L31) and the phpstan-drupal stub for `EntityReferenceItem` declares
`@property ?T $entity`: https://github.com/mglaman/phpstan-drupal/blob/main/stubs/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.stub

### Release notes
<!--- Delete this line (and the closing comment line) to enable release notes.

If this change requires release notes: provide a summary of changes, how to use this change, and any related links. This content will be pasted in the [release notes](https://github.com/az-digital/az_quickstart/releases). Use markdown format to ensure proper pasting of information. [Release notes example](https://github.com/az-digital/az_quickstart/releases/tag/2.11.0)

Make sure to add the `release notes` label to this PR.

```
Add markdown of release notes here.
```

Delete this line to enable release notes.  -->


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
### Test by Running PHPStan
1. Clone fresh copy of az_quicsktart repo
2. Switch to this branch
3. Build locally with lando or ddev
4. Run `lando phpstan` or `ddev phpstan`
5. Confirm there are no errors

### ALSO test `az_accordion`, `az_card`, `az_ranking`, `az_publication`: 

`az_accordion`, `az_card`, `az_ranking` — all go through the same scenarios in their respective formatters:
1. View a page that renders the paragraph type - confirm it displays correctly
2. Create/edit a node with that paragraph - save and re-view it
3. If any items have optional fields (e.g. card with no image, accordion with no body) - verify empty/partial items render without errors

`az_publication` (AZEntityRolelnlineFormComplex) — the assert is in prepareFormState, which runs when the widget initializes:
1. Edit a publication that has existing contributors — confirm the inline entity form loads
2. Add a new contributor to a publication and save
3. Remove a contributor and save

How to check for failures:
If an assert () fails you'll see a PHP fatal AssertionError in the Drupal error log (/admin/reports/dblog). If pages render and forms save normally, the assertions are passing as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.