### PR TITLE
Fixes #5511: Give AZ Navbar split-toggle buttons distinct accessible names

### DIFF
--- a/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
@@ -60,7 +60,7 @@
           {% if item.below %}
             {% if not is_placeholder %}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                <span class="visually-hidden">{{ item.title }}</span>
+                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
               </button>
             {% endif %}
             {{ menus.menu_links(item.below, attributes.removeClass('nav-item'), menu_level + 1, item) }}
@@ -69,8 +69,8 @@
           {% if item.below %}
             <div class="btn-group">
               {{ link(item.title, item.url, { 'class': 'dropdown-item' }) }}
-              <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" data-bs-auto-close="outside" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
-                <span class="visually-hidden">{{ item.title }}</span>
+              <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
+                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
               </button>
             </div>
             {{ menus.menu_links(item.below, attributes, menu_level + 1, item) }}


### PR DESCRIPTION
## Description

Fixes #5511 by updating the visually-hidden text on both split-toggle buttons in the AZ Navbar template so they have accessible names that are distinct from their adjacent links, and by removing a dead Bootstrap attribute from the level-1 collapse trigger.

**Changes in `menu--main-navbar-az.html.twig`:**

1. **Level-0 split-toggle button** — visually-hidden span updated from `{{ item.title }}` to `{{ item.title }}, {{ 'expand submenu'|t }}`.
2. **Level-1 split-toggle button** — same visually-hidden span update as above.
3. **Level-1 split-toggle button** — `data-bs-auto-close="outside"` removed. This is a Bootstrap Dropdown option; the level-1 button uses `data-bs-toggle="collapse"` so the attribute had no effect.

### Release notes
<!-- Delete this line (and the closing comment line) to enable release notes.

If this change requires release notes: provide a summary of changes, how to use this change, and any related links. This content will be pasted in the release notes. Use markdown format to ensure proper pasting of information.

Make sure to add the `release notes` label to this PR.

```
Add markdown of release notes here.
```

Delete this line to enable release notes. -->

## Related issues

Fixes #5511

## How to test

1. Enable AZ Navbar in Arizona Barrio theme settings.
2. Create a primary nav item with a real URL (e.g. "About Us" at `/about`).
3. Create a secondary nav item under it with a real URL (e.g. "People" at `/about/people`) and add at least one tertiary child link under it.
4. On a desktop viewport, keyboard-navigate into the secondary dropdown.
5. Listen with NVDA + Chrome or VoiceOver + Safari.

**Before this fix:** Both the link and the split-toggle button announce identically (e.g. "People, link" and "People, button, collapsed").

**After this fix:** The link announces as "People, link" and the button announces as "People, expand submenu, button, collapsed" — clearly distinct and descriptive.

Additionally, confirm via browser DevTools that `data-bs-auto-close` no longer appears on the `data-bs-toggle="collapse"` button.

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [x] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.