### PR TITLE
a11y: video play/pause button — aria-pressed, event-driven state, fix aria-hidden (closes #5515)

### DIFF
--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.js
@@ -45,8 +45,7 @@
           const pWidth = Math.ceil(height * defaultAspectRatio); // get new player width
           const pHeight = Math.ceil(width / defaultAspectRatio); // get new player height
           let widthMinuspWidthDividedByTwo = (width - pWidth) / 2;
-          widthMinuspWidthDividedByTwo =
-            `${widthMinuspWidthDividedByTwo.toString()}px`;
+          widthMinuspWidthDividedByTwo = `${widthMinuspWidthDividedByTwo.toString()}px`;
           let pHeightRatio = (height - pHeight) / 2;
           pHeightRatio = `${pHeightRatio.toString()}px`;
           // when screen aspect ratio differs from video,
@@ -175,7 +174,6 @@
           });
         }
       }
-
       once('vimeoTextOnMedia-init', 'body').forEach(initVimeoBackgrounds);
     },
   };

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.js
@@ -99,7 +99,7 @@
             parentParagraph.classList.remove('az-video-paused');
             parentParagraph.classList.add('az-video-playing');
             playPauseButton.textContent = 'Pause Video';
-            playPauseButton.setAttribute('aria-pressed', 'false');
+            playPauseButton.setAttribute('aria-pressed', 'true');
           });
 
           // Sync button and class state when video pauses.
@@ -107,7 +107,7 @@
             parentParagraph.classList.remove('az-video-playing');
             parentParagraph.classList.add('az-video-paused');
             playPauseButton.textContent = 'Play Video';
-            playPauseButton.setAttribute('aria-pressed', 'true');
+            playPauseButton.setAttribute('aria-pressed', 'false');
           });
 
           // Set the iframe tabindex to -1 to prevent focus from reaching iframe.
@@ -122,9 +122,9 @@
           playPauseButton.addEventListener('click', (event) => {
             event.preventDefault();
             if (event.currentTarget.getAttribute('aria-pressed') === 'true') {
-              element.player.play().catch((error) => vimeoError(error));
-            } else {
               element.player.pause().catch((error) => vimeoError(error));
+            } else {
+              element.player.play().catch((error) => vimeoError(error));
             }
           });
         }

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_vimeo.js
@@ -45,7 +45,8 @@
           const pWidth = Math.ceil(height * defaultAspectRatio); // get new player width
           const pHeight = Math.ceil(width / defaultAspectRatio); // get new player height
           let widthMinuspWidthDividedByTwo = (width - pWidth) / 2;
-          widthMinuspWidthDividedByTwo = `${widthMinuspWidthDividedByTwo.toString()}px`;
+          widthMinuspWidthDividedByTwo =
+            `${widthMinuspWidthDividedByTwo.toString()}px`;
           let pHeightRatio = (height - pHeight) / 2;
           pHeightRatio = `${pHeightRatio.toString()}px`;
           // when screen aspect ratio differs from video,
@@ -85,10 +86,29 @@
             muted: defaultOptions.muted,
           });
 
-          // Event listener for starting play.
+          // Play/Pause button reference used by event handlers below.
+          const playPauseButton =
+            element.getElementsByClassName('az-video-playpause')[0];
+
+          // Update dimensions when buffering completes.
           element.player.on('bufferend', () => {
             setDimensions(element);
+          });
+
+          // Sync button and class state when video plays.
+          element.player.on('play', () => {
+            parentParagraph.classList.remove('az-video-paused');
             parentParagraph.classList.add('az-video-playing');
+            playPauseButton.textContent = 'Pause Video';
+            playPauseButton.setAttribute('aria-pressed', 'false');
+          });
+
+          // Sync button and class state when video pauses.
+          element.player.on('pause', () => {
+            parentParagraph.classList.remove('az-video-playing');
+            parentParagraph.classList.add('az-video-paused');
+            playPauseButton.textContent = 'Play Video';
+            playPauseButton.setAttribute('aria-pressed', 'true');
           });
 
           // Set the iframe tabindex to -1 to prevent focus from reaching iframe.
@@ -99,23 +119,13 @@
             }
           });
 
-          // Play/Pause button toggle.
-          const playPauseButton =
-            element.getElementsByClassName('az-video-playpause')[0];
+          // Play/Pause button: delegate state changes to player events.
           playPauseButton.addEventListener('click', (event) => {
             event.preventDefault();
-            if (event.currentTarget.textContent === 'Play Video') {
+            if (event.currentTarget.getAttribute('aria-pressed') === 'true') {
               element.player.play().catch((error) => vimeoError(error));
-              parentParagraph.classList.remove('az-video-paused');
-              parentParagraph.classList.add('az-video-playing');
-              event.currentTarget.textContent = 'Pause Video';
-              event.currentTarget.setAttribute('title', 'Pause the video');
             } else {
               element.player.pause().catch((error) => vimeoError(error));
-              parentParagraph.classList.remove('az-video-playing');
-              parentParagraph.classList.add('az-video-paused');
-              event.currentTarget.textContent = 'Play Video';
-              event.currentTarget.setAttribute('title', 'Play the video');
             }
           });
         }

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_youtube.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_youtube.js
@@ -2,8 +2,7 @@
   Drupal.behaviors.az_youtube_video_bg = {
     attach(context) {
       function initYouTubeBackgrounds() {
-        if (window.screen &&
-          window.screen.width > 768) {
+        if (window.screen && window.screen.width > 768) {
           // @see https://developers.google.com/youtube/player_parameters
           const defaultSettings = {
             loop: true,
@@ -17,8 +16,7 @@
 
           // Load YouTube IFrame player API
           const tag = document.createElement('script');
-          const firstScriptTag =
-            document.getElementsByTagName('script')[0];
+          const firstScriptTag = document.getElementsByTagName('script')[0];
           tag.src = 'https://www.youtube.com/iframe_api';
           firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 
@@ -28,9 +26,6 @@
           );
           window.onYouTubeIframeAPIReady = () => {
             Array.from(bgVideoParagraphs).forEach((element) => {
-              const parentParagraph = document.getElementById(
-                element.dataset.parentid,
-              );
               const youtubeId = element.dataset.youtubeid;
               bgVideoSettings[youtubeId] = {
                 autoplay: element.dataset.autoplay === 'true',
@@ -62,7 +57,9 @@
                 element.getElementsByClassName('az-video-playpause')[0];
               playPauseButton.addEventListener('click', (event) => {
                 event.preventDefault();
-                if (event.currentTarget.getAttribute('aria-pressed') === 'true') {
+                if (
+                  event.currentTarget.getAttribute('aria-pressed') === 'true'
+                ) {
                   element.player.playVideo();
                 } else {
                   element.player.pauseVideo();
@@ -128,6 +125,7 @@
             if (defaultSettings.mute) {
               event.target.mute();
             }
+
             event.target.seekTo(bgVideoSettings[id].start);
             event.target.playVideo();
             // Create and dispatch a new event when video starts playing.

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_youtube.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_youtube.js
@@ -2,7 +2,8 @@
   Drupal.behaviors.az_youtube_video_bg = {
     attach(context) {
       function initYouTubeBackgrounds() {
-        if (window.screen && window.screen.width > 768) {
+        if (window.screen &&
+          window.screen.width > 768) {
           // @see https://developers.google.com/youtube/player_parameters
           const defaultSettings = {
             loop: true,
@@ -16,7 +17,8 @@
 
           // Load YouTube IFrame player API
           const tag = document.createElement('script');
-          const firstScriptTag = document.getElementsByTagName('script')[0];
+          const firstScriptTag =
+            document.getElementsByTagName('script')[0];
           tag.src = 'https://www.youtube.com/iframe_api';
           firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 
@@ -55,23 +57,15 @@
                 },
               });
 
-              // Play/Pause button toggle.
+              // Play/Pause button: delegate state changes to player events.
               const playPauseButton =
                 element.getElementsByClassName('az-video-playpause')[0];
               playPauseButton.addEventListener('click', (event) => {
                 event.preventDefault();
-                if (event.currentTarget.textContent === 'Play Video') {
+                if (event.currentTarget.getAttribute('aria-pressed') === 'true') {
                   element.player.playVideo();
-                  parentParagraph.classList.remove('az-video-paused');
-                  parentParagraph.classList.add('az-video-playing');
-                  event.currentTarget.textContent = 'Pause Video';
-                  event.currentTarget.setAttribute('title', 'Pause the video');
                 } else {
                   element.player.pauseVideo();
-                  parentParagraph.classList.remove('az-video-playing');
-                  parentParagraph.classList.add('az-video-paused');
-                  event.currentTarget.textContent = 'Play Video';
-                  event.currentTarget.setAttribute('title', 'Play the video');
                 }
               });
             });
@@ -156,6 +150,22 @@
               resize();
               parentContainer.classList.add('az-video-playing');
               parentContainer.classList.remove('az-video-loading');
+              // Sync button state: video is confirmed playing.
+              const btn = parentContainer.querySelector('.az-video-playpause');
+              if (btn) {
+                btn.textContent = 'Pause Video';
+                btn.setAttribute('aria-pressed', 'false');
+              }
+            }
+            if (event.data === 2) {
+              // Video paused: sync button state.
+              parentContainer.classList.remove('az-video-playing');
+              parentContainer.classList.add('az-video-paused');
+              const btn = parentContainer.querySelector('.az-video-playpause');
+              if (btn) {
+                btn.textContent = 'Play Video';
+                btn.setAttribute('aria-pressed', 'true');
+              }
             }
           };
 

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_youtube.js
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/js/az_paragraphs_az_text_media_youtube.js
@@ -60,9 +60,9 @@
                 if (
                   event.currentTarget.getAttribute('aria-pressed') === 'true'
                 ) {
-                  element.player.playVideo();
-                } else {
                   element.player.pauseVideo();
+                } else {
+                  element.player.playVideo();
                 }
               });
             });
@@ -147,12 +147,13 @@
             if (event.data === 1) {
               resize();
               parentContainer.classList.add('az-video-playing');
+              parentContainer.classList.remove('az-video-paused');
               parentContainer.classList.remove('az-video-loading');
               // Sync button state: video is confirmed playing.
               const btn = parentContainer.querySelector('.az-video-playpause');
               if (btn) {
                 btn.textContent = 'Pause Video';
-                btn.setAttribute('aria-pressed', 'false');
+                btn.setAttribute('aria-pressed', 'true');
               }
             }
             if (event.data === 2) {
@@ -162,7 +163,7 @@
               const btn = parentContainer.querySelector('.az-video-playpause');
               if (btn) {
                 btn.textContent = 'Play Video';
-                btn.setAttribute('aria-pressed', 'true');
+                btn.setAttribute('aria-pressed', 'false');
               }
             }
           };

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/templates/media--az-remote-video--az-background.html.twig
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/templates/media--az-remote-video--az-background.html.twig
@@ -13,4 +13,4 @@
 <div class="az-video-container">
   <div class="az-video-player"></div>
 </div>
-<button type="button" class="bg-video-player-control btn btn-light az-video-playpause video-playpause" aria-pressed="true">Play Video</button>
+<button type="button" class="bg-video-player-control btn btn-light az-video-playpause video-playpause" aria-pressed="false">Play Video</button>

--- a/modules/custom/az_paragraphs/az_paragraphs_text_media/templates/media--az-remote-video--az-background.html.twig
+++ b/modules/custom/az_paragraphs/az_paragraphs_text_media/templates/media--az-remote-video--az-background.html.twig
@@ -13,4 +13,4 @@
 <div class="az-video-container">
   <div class="az-video-player"></div>
 </div>
-<button type="button" class="bg-video-player-control btn btn-light az-video-playpause video-playpause" title="Pause the Video" aria-hidden="">Pause Video</button>
+<button type="button" class="bg-video-player-control btn btn-light az-video-playpause video-playpause" aria-pressed="true">Play Video</button>


### PR DESCRIPTION
## Description

Follow-up to #5505 (closes #5515).

#5505 replaced the two-button pattern with a single `<button>` and fixed `tabindex` on iframes — all the right moves. This PR addresses two issues left open as follow-up:

### 1. Autoplay state mismatch (bug)

The original button started as "Pause Video" under the assumption that autoplay always succeeds. When autoplay is blocked — by browser policy, `az_gdpr_consent`, or user preference (as noted by @kevdevlu) — the video is not playing but the button says "Pause". A screen reader user hears "Pause Video, button" and presses it expecting to pause, but it starts playback instead.

**Fix:** The button now defaults to "Play Video" / `aria-pressed="true"` (conservative: not confirmed playing). The actual player events (`play`/`pause` for Vimeo; `onPlayerStateChange` states 1 and 2 for YouTube) drive all state updates. The button is always accurate regardless of autoplay outcome.

### 2. `aria-hidden=""` removed and `aria-pressed` added (accessibility)

- `aria-hidden=""` on the button had an ambiguous empty-string value — some AT treat it as `aria-hidden="true"`, hiding the only interactive control from the accessibility tree.
- `aria-pressed` is now used for toggle semantics. Screen readers announce: *"Play Video, toggle button, pressed"* (paused state) and *"Pause Video, toggle button, not pressed"* (playing state). State is programmatically determinable independent of the label.
- The redundant `title` attribute is removed — visible text content is sufficient for the accessible name.

## Changes

| File | Change |
|------|--------|
| `media--az-remote-video--az-background.html.twig` | Remove `aria-hidden=""`, remove `title`, add `aria-pressed="true"`, set initial label to "Play Video" |
| `az_paragraphs_az_text_media_vimeo.js` | Event-driven state: `play`/`pause` events sync button; click handler only calls play/pause |
| `az_paragraphs_az_text_media_youtube.js` | `onPlayerStateChange` states 1 and 2 sync button; click handler uses `aria-pressed` |

## How to test

- Visit a Text on Media paragraph with a YouTube or Vimeo background video
- With autoplay **enabled**: button should show "Play Video" briefly, then switch to "Pause Video" once the player fires its play event
- With autoplay **blocked** (e.g., via `az_gdpr_consent` or browser devtools throttling): button should remain "Play Video" — pressing it starts playback; button then switches to "Pause Video"
- Press the button to pause: it should show "Play Video" and `aria-pressed="true"`
- Press again to resume: it should show "Pause Video" and `aria-pressed="false"`
- Verify with a screen reader (NVDA/JAWS/VoiceOver) that the button is announced and state changes are heard

## Related

- Closes #5515
- Follow-up to #5505
- Referenced in #5490

## Types of changes

### Arizona Quickstart
- **Patch release changes**
   - [x] Bug fix
   - [x] Accessibility, performance, or security improvement