### PR TITLE
Fixes #5511: Fix WCAG 4.1.2 split-toggle accessible names in AZ Navbar

### DIFF
--- a/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
@@ -71,7 +71,7 @@
             <div class="btn-group">
               {{ link(item.title, item.url, { 'class': 'dropdown-item' }) }}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
-                <span class="visually-hidden">{{ item.in_active_trail ? 'Submenu for @title'|t({'@title': item.title}) : 'Submenu for @title'|t({'@title': item.title}) }}</span>
+                <span class="visually-hidden">{{ 'Submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             </div>
             {{ menus.menu_links(item.below, attributes, menu_level + 1, item) }}

--- a/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
@@ -61,7 +61,7 @@
           {% if item.below %}
             {% if not is_placeholder %}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
+                <span class="visually-hidden">{{ 'Expand submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             {% endif %}
             {{ menus.menu_links(item.below, attributes.removeClass('nav-item'), menu_level + 1, item) }}
@@ -71,7 +71,7 @@
             <div class="btn-group">
               {{ link(item.title, item.url, { 'class': 'dropdown-item' }) }}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
-                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
+                <span class="visually-hidden">{{ item.in_active_trail ? 'Collapse submenu for @title'|t({'@title': item.title}) : 'Expand submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             </div>
             {{ menus.menu_links(item.below, attributes, menu_level + 1, item) }}

--- a/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
@@ -61,7 +61,7 @@
           {% if item.below %}
             {% if not is_placeholder %}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                <span class="visually-hidden">{{ 'Expand submenu for @title'|t({'@title': item.title}) }}</span>
+                <span class="visually-hidden">{{ 'Submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             {% endif %}
             {{ menus.menu_links(item.below, attributes.removeClass('nav-item'), menu_level + 1, item) }}
@@ -71,7 +71,7 @@
             <div class="btn-group">
               {{ link(item.title, item.url, { 'class': 'dropdown-item' }) }}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
-                <span class="visually-hidden">{{ item.in_active_trail ? 'Collapse submenu for @title'|t({'@title': item.title}) : 'Expand submenu for @title'|t({'@title': item.title}) }}</span>
+                <span class="visually-hidden">{{ item.in_active_trail ? 'Submenu for @title'|t({'@title': item.title}) : 'Submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             </div>
             {{ menus.menu_links(item.below, attributes, menu_level + 1, item) }}
@@ -89,3 +89,4 @@
     </ul>
   {% endif %}
 {% endmacro %}
+

--- a/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
@@ -1,7 +1,8 @@
 {#
 /**
  * @file
- * Arizona Barrio override to display a menu. Used when az_navbar theme setting is enabled.
+ * Arizona Barrio override to display a menu. Used when
+ * az_navbar theme setting is enabled.
  *
  * Available variables:
  * - menu_name: The machine name of the menu.
@@ -60,7 +61,7 @@
           {% if item.below %}
             {% if not is_placeholder %}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                <span class="visually-hidden">{{ item.title }}</span>
+                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
               </button>
             {% endif %}
             {{ menus.menu_links(item.below, attributes.removeClass('nav-item'), menu_level + 1, item) }}
@@ -69,8 +70,8 @@
           {% if item.below %}
             <div class="btn-group">
               {{ link(item.title, item.url, { 'class': 'dropdown-item' }) }}
-              <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" data-bs-auto-close="outside" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
-                <span class="visually-hidden">{{ item.title }}</span>
+              <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
+                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
               </button>
             </div>
             {{ menus.menu_links(item.below, attributes, menu_level + 1, item) }}


### PR DESCRIPTION
## Description

Fixes a WCAG 4.1.2 (Name, Role, Value) violation in `menu--main-navbar-az.html.twig`.

When AZ Navbar is enabled and a nav item has children, the template renders a split control: a visible link and a collapse or dropdown toggle button. Both controls were previously given `{{ item.title }}` as their visually-hidden accessible name, so a screen reader user heard two identically named controls, for example:

- "People, link"
- "People, button, collapsed"

There was no submenu-specific name on the second control, so it sounded like a duplicate of the adjacent link.

### Changes

- **Level 0 split toggle** (`data-bs-toggle="dropdown"`): visually-hidden text changes from `{{ item.title }}` to `{{ 'Submenu for @title'|t({'@title': item.title}) }}` so the toggle has a stable, distinct accessible name separate from the adjacent link.
- **Level 1 split toggle** (`data-bs-toggle="collapse"`): same i18n-safe visually-hidden label update. Also removes the ineffective `data-bs-auto-close="outside"` attribute, since that Bootstrap option applies to dropdown triggers and had no effect on the collapse button.
- **State handling**: the label stays stable and descriptive, while expanded or collapsed state is conveyed separately through `aria-expanded`, avoiding stale or duplicated action words in the accessible name after toggling.

### Release notes

```
Screen reader users can now distinguish AZ Navbar split-toggle buttons from their adjacent links. The submenu toggle uses a stable accessible name such as "Submenu for About Us", while expanded/collapsed state is conveyed separately through aria-expanded, resolving a WCAG 4.1.2 Name, Role, Value violation.
```

## Related issues

Fixes #5511
Unblocks #5336

## How to test

1. Enable AZ Navbar in Arizona Barrio theme settings.
2. Create a primary nav item with a real URL (for example, `About Us` at `/about`).
3. Create a secondary nav item under it with a real URL (for example, `People` at `/about/people`).
4. Add at least one tertiary child link under that secondary item.
5. On a desktop viewport, keyboard-navigate into the navigation using NVDA + Chrome or VoiceOver + Safari.

**Expected (after fix):**
- Primary split-toggle announces a submenu-specific label distinct from the adjacent link.
- Secondary split-toggle announces a submenu-specific label distinct from the adjacent link.
- Expanded or collapsed state is conveyed by `aria-expanded`, rather than hard-coded into the visually-hidden label.
- No regression in split-toggle, keyboard, hover, or screen reader behaviour at any nav level.
- No regression in mobile navigation.

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [X] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] My change requires release notes.
