### PR TITLE
Closes #5507: Clear plugin definition cache on enterprise attributes settings save

### DIFF
--- a/modules/custom/az_core/az_enterprise_attributes_import/src/Form/AZEnterpriseAttributesImportForm.php
+++ b/modules/custom/az_core/az_enterprise_attributes_import/src/Form/AZEnterpriseAttributesImportForm.php
@@ -6,6 +6,7 @@ use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+use Drupal\Core\Plugin\CachedDiscoveryClearer;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\migrate\MigrateMessage;
 use Drupal\migrate\Plugin\MigrationInterface;
@@ -46,6 +47,13 @@ class AZEnterpriseAttributesImportForm extends ConfigFormBase {
   protected TranslationInterface $translation;
 
   /**
+   * The plugin cache clearer.
+   *
+   * @var \Drupal\Core\Plugin\CachedDiscoveryClearer
+   */
+  protected CachedDiscoveryClearer $pluginCacheClearer;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
@@ -54,6 +62,7 @@ class AZEnterpriseAttributesImportForm extends ConfigFormBase {
     $instance->keyValue = $container->get('keyvalue');
     $instance->time = $container->get('datetime.time');
     $instance->translation = $container->get('string_translation');
+    $instance->pluginCacheClearer = $container->get('plugin.cache_clearer');
     return $instance;
   }
 
@@ -98,7 +107,7 @@ class AZEnterpriseAttributesImportForm extends ConfigFormBase {
       ->set('endpoint', $form_state->getValue('endpoint'))
       ->save();
 
-    \Drupal::service('plugin.cache_clearer')->clearCachedDefinitions();
+    $this->pluginCacheClearer->clearCachedDefinitions();
 
     // Fetch the attribute migration.
     $migration = $this->pluginManagerMigration->createInstance('az_enterprise_attributes_import');

--- a/modules/custom/az_core/az_enterprise_attributes_import/src/Form/AZEnterpriseAttributesImportForm.php
+++ b/modules/custom/az_core/az_enterprise_attributes_import/src/Form/AZEnterpriseAttributesImportForm.php
@@ -6,7 +6,7 @@ use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
-use Drupal\Core\Plugin\CachedDiscoveryClearer;
+use Drupal\Core\Plugin\CachedDiscoveryClearerInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\migrate\MigrateMessage;
 use Drupal\migrate\Plugin\MigrationInterface;
@@ -49,9 +49,9 @@ class AZEnterpriseAttributesImportForm extends ConfigFormBase {
   /**
    * The plugin cache clearer.
    *
-   * @var \Drupal\Core\Plugin\CachedDiscoveryClearer
+   * @var \Drupal\Core\Plugin\CachedDiscoveryClearerInterface
    */
-  protected CachedDiscoveryClearer $pluginCacheClearer;
+  protected CachedDiscoveryClearerInterface $pluginCacheClearer;
 
   /**
    * {@inheritdoc}

--- a/modules/custom/az_core/az_enterprise_attributes_import/src/Form/AZEnterpriseAttributesImportForm.php
+++ b/modules/custom/az_core/az_enterprise_attributes_import/src/Form/AZEnterpriseAttributesImportForm.php
@@ -98,6 +98,8 @@ class AZEnterpriseAttributesImportForm extends ConfigFormBase {
       ->set('endpoint', $form_state->getValue('endpoint'))
       ->save();
 
+    \Drupal::service('plugin.cache_clearer')->clearCachedDefinitions();
+
     // Fetch the attribute migration.
     $migration = $this->pluginManagerMigration->createInstance('az_enterprise_attributes_import');
     // Phpstan doesn't know this can be NULL.


### PR DESCRIPTION
Closes #5507 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->

Adds clearCachedDefinitions() after config save so migration runs immediately pick up the new endpoint without requiring a manual drush cr.

### Release notes
<!--- Delete this line (and the closing comment line) to enable release notes.

If this change requires release notes: provide a summary of changes, how to use this change, and any related links. This content will be pasted in the [release notes](https://github.com/az-digital/az_quickstart/releases). Use markdown format to ensure proper pasting of information. [Release notes example](https://github.com/az-digital/az_quickstart/releases/tag/2.11.0)

Make sure to add the `release notes` label to this PR.

```
Add markdown of release notes here.
```

Delete this line to enable release notes.  -->


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
1. Enable `Quickstart Enterprise Attributes Import` module
2. Go to Arizona Quickstart Settings, then Enterprise Attributes Settings tab: `/admin/config/az-enterprise-attributes-import/settings`
3. Click on `Save Configuration`. It should say `Processed 195 items (0 created, 194 updated, 0 failed, 1 ignored) - done with 'az_enterprise_attributes_import'`
4. Now change the URL to the new dev (about to be prod) version: `https://api.qa.trellis.arizona.edu/ws/rest/events/v1/enterprise-attributes`  (note the diff: `...api.qa.trellis...`)
5. There should be 212 items processed now. 
6. Go to Structure -> Taxonomy -> Enterprise Attributes -> List Terms. at `/admin/structure/taxonomy/manage/az_enterprise_attributes/overview` and make sure `Program Type` is included (which was not there before)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [x] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.