### PR TITLE
Fix(5512): Tertiary menu list structure - avoid nested <li>

### DIFF
--- a/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
@@ -60,7 +60,7 @@
           {% if item.below %}
             {% if not is_placeholder %}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                <span class="visually-hidden">{{ item.title }}</span>
+                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
               </button>
             {% endif %}
             {{ menus.menu_links(item.below, attributes.removeClass('nav-item'), menu_level + 1, item) }}
@@ -69,8 +69,8 @@
           {% if item.below %}
             <div class="btn-group">
               {{ link(item.title, item.url, { 'class': 'dropdown-item' }) }}
-              <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" data-bs-auto-close="outside" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
-                <span class="visually-hidden">{{ item.title }}</span>
+              <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
+                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
               </button>
             </div>
             {{ menus.menu_links(item.below, attributes, menu_level + 1, item) }}

--- a/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
@@ -61,7 +61,7 @@
           {% if item.below %}
             {% if not is_placeholder %}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
+                <span class="visually-hidden">{{ 'Expand submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             {% endif %}
             {{ menus.menu_links(item.below, attributes.removeClass('nav-item'), menu_level + 1, item) }}
@@ -71,7 +71,7 @@
             <div class="btn-group">
               {{ link(item.title, item.url, { 'class': 'dropdown-item' }) }}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
-                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
+                <span class="visually-hidden">{{ item.in_active_trail ? 'Collapse submenu for @title'|t({'@title': item.title}) : 'Expand submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             </div>
             {{ menus.menu_links(item.below, attributes, menu_level + 1, item) }}

--- a/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
@@ -61,11 +61,7 @@
           {% if item.below %}
             {% if not is_placeholder %}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-<<<<<<< HEAD
-                <span class="visually-hidden">{{ 'Expand submenu for @title'|t({'@title': item.title}) }}</span>
-=======
-                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
->>>>>>> bug/5511
+                <span class="visually-hidden">{{ 'Submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             {% endif %}
             {{ menus.menu_links(item.below, attributes.removeClass('nav-item'), menu_level + 1, item) }}
@@ -75,11 +71,7 @@
             <div class="btn-group">
               {{ link(item.title, item.url, { 'class': 'dropdown-item' }) }}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
-<<<<<<< HEAD
-                <span class="visually-hidden">{{ item.in_active_trail ? 'Collapse submenu for @title'|t({'@title': item.title}) : 'Expand submenu for @title'|t({'@title': item.title}) }}</span>
-=======
-                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
->>>>>>> bug/5511
+                <span class="visually-hidden">{{ 'Submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             </div>
             {{ menus.menu_links(item.below, attributes, menu_level + 1, item) }}

--- a/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
@@ -61,7 +61,7 @@
           {% if item.below %}
             {% if not is_placeholder %}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                <span class="visually-hidden">{{ 'Submenu for @title'|t({'@title': item.title}) }}</span>
+                <span class="visually-hidden">{{ 'Expand submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             {% endif %}
             {{ menus.menu_links(item.below, attributes.removeClass('nav-item'), menu_level + 1, item) }}
@@ -71,7 +71,7 @@
             <div class="btn-group">
               {{ link(item.title, item.url, { 'class': 'dropdown-item' }) }}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
-                <span class="visually-hidden">{{ item.in_active_trail ? 'Submenu for @title'|t({'@title': item.title}) : 'Submenu for @title'|t({'@title': item.title}) }}</span>
+                <span class="visually-hidden">{{ item.in_active_trail ? 'Collapse submenu for @title'|t({'@title': item.title}) : 'Expand submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             </div>
             {{ menus.menu_links(item.below, attributes, menu_level + 1, item) }}
@@ -89,4 +89,3 @@
     </ul>
   {% endif %}
 {% endmacro %}
-

--- a/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
@@ -61,7 +61,7 @@
           {% if item.below %}
             {% if not is_placeholder %}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                <span class="visually-hidden">{{ 'Expand submenu for @title'|t({'@title': item.title}) }}</span>
+                <span class="visually-hidden">{{ 'Submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             {% endif %}
             {{ menus.menu_links(item.below, attributes.removeClass('nav-item'), menu_level + 1, item) }}
@@ -71,7 +71,7 @@
             <div class="btn-group">
               {{ link(item.title, item.url, { 'class': 'dropdown-item' }) }}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
-                <span class="visually-hidden">{{ item.in_active_trail ? 'Collapse submenu for @title'|t({'@title': item.title}) : 'Expand submenu for @title'|t({'@title': item.title}) }}</span>
+                <span class="visually-hidden">{{ item.in_active_trail ? 'Submenu for @title'|t({'@title': item.title}) : 'Submenu for @title'|t({'@title': item.title}) }}</span>
               </button>
             </div>
             {{ menus.menu_links(item.below, attributes, menu_level + 1, item) }}
@@ -89,3 +89,4 @@
     </ul>
   {% endif %}
 {% endmacro %}
+

--- a/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
+++ b/themes/custom/az_barrio/templates/navigation/menu--main-navbar-az.html.twig
@@ -1,7 +1,8 @@
 {#
 /**
  * @file
- * Arizona Barrio override to display a menu. Used when az_navbar theme setting is enabled.
+ * Arizona Barrio override to display a menu. Used when
+ * az_navbar theme setting is enabled.
  *
  * Available variables:
  * - menu_name: The machine name of the menu.
@@ -60,7 +61,7 @@
           {% if item.below %}
             {% if not is_placeholder %}
               <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                <span class="visually-hidden">{{ item.title }}</span>
+                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
               </button>
             {% endif %}
             {{ menus.menu_links(item.below, attributes.removeClass('nav-item'), menu_level + 1, item) }}
@@ -69,8 +70,8 @@
           {% if item.below %}
             <div class="btn-group">
               {{ link(item.title, item.url, { 'class': 'dropdown-item' }) }}
-              <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" data-bs-auto-close="outside" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
-                <span class="visually-hidden">{{ item.title }}</span>
+              <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="collapse" data-bs-target="#tertiary-{{ item.title|clean_class }}" aria-controls="tertiary-{{ item.title|clean_class }}" aria-expanded="{{ item.in_active_trail ? 'true' : 'false' }}">
+                <span class="visually-hidden">{{ item.title }}, {{ 'expand submenu'|t }}</span>
               </button>
             </div>
             {{ menus.menu_links(item.below, attributes, menu_level + 1, item) }}


### PR DESCRIPTION
Fixes #5512 — Why: sites running Quickstart 3.2.0 with AZ Navbar saw HTML validation errors caused by nested <li> elements at the tertiary menu level, which can confuse assistive technologies and produce invalid DOM structures.

What this change does:
- Removes the nested `<li>` pattern at the tertiary menu level so the menu renders valid HTML.
- Standardizes the split-toggle accessible name to an i18n-safe placeholder (`Submenu for @title`).

Impact:
- Resolves Nu Html Checker / DubBot `<ul>/<ol>` direct-children` validation errors attributed to the navbar.
- Improves screen reader interpretation of the menu structure.

How to test:
1. Enable AZ Navbar in Arizona Barrio theme and render a three-level menu where tertiary items are plain links.
2. Run Nu Html Checker / DubBot against the rendered page and confirm the `<ul>/<ol>` error is gone.
3. Test with a screen reader (NVDA/VoiceOver) to confirm the submenu buttons announce the submenu name.
4. Verify no visual or JS regressions in dropdown/collapse behavior.

Notes:
- This is a template-level fix; if accepted it will close #5512.
- Backporting this change to release branches is recommended for affected sites.