### PR TITLE
WIP(5514): Short-term Slick carousel accessibility patch (theme JS)

### DIFF
--- a/themes/custom/az_barrio/az_barrio.libraries.yml
+++ b/themes/custom/az_barrio/az_barrio.libraries.yml
@@ -76,3 +76,17 @@ toasts:
   dependencies:
     - core/drupal
     - az_barrio/arizona-bootstrap-js
+
+az-slick-a11y-patch:
+  js:
+    js/slick-a11y-patch.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+
+az-slick-a11y-patch:
+  js:
+    js/slick-a11y-patch.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal

--- a/themes/custom/az_barrio/js/slick-a11y-patch.js
+++ b/themes/custom/az_barrio/js/slick-a11y-patch.js
@@ -1,0 +1,37 @@
+// Accessibility runtime patch for Slick carousel (short-term fix for #5514)
+// - Adjust roles on dot navigation
+// - Add aria-label to track
+// - Prevent focusable elements inside aria-hidden slides
+(function ($, Drupal) {
+  'use strict';
+  $(document).once('slick-a11y-patch').each(function () {
+    // When slick initializes, apply corrections
+    $(document).on('init reInit', '.slick-slider', function (event, slick) {
+      var $slider = $(this);
+      // ensure track has accessible name
+      var $track = $slider.find('.slick-track');
+      if ($track.length && !$track.attr('aria-label')) {
+        $track.attr('aria-label', $slider.data('a11y-label') || 'Carousel slides');
+      }
+      // fix dots role
+      var $dots = $slider.find('.slick-dots');
+      if ($dots.length) {
+        $dots.attr('role', 'list');
+        $dots.find('li').each(function (i) {
+          $(this).removeAttr('role aria-selected aria-controls');
+          // ensure internal button has accessible label
+          var $btn = $(this).find('button');
+          if ($btn.length && !$btn.attr('aria-label')) {
+            $btn.attr('aria-label', 'Go to slide ' + (i+1));
+          }
+        });
+      }
+      // hide focusable children of aria-hidden slides
+      $slider.find('.slick-slide[aria-hidden="true"]').each(function () {
+        $(this).find('a, button, input, select, textarea').attr('tabindex', '-1');
+      });
+      // remove problematic role on slide wrapper
+      $slider.find('.slick-slide').removeAttr('role tabindex');
+    });
+  });
+})(jQuery, Drupal);


### PR DESCRIPTION
Addresses #5514 (short-term mitigation) — Why: the Slick carousel library generates runtime ARIA markup that triggers several critical axe-core violations (invalid roles/attributes, focusable elements hidden with `aria-hidden`, missing accessible names).

What this change does:
- Adds an optional theme JS runtime patch that applies pragmatic corrections when Slick initializes:
  - Adds an accessible `aria-label` to the slides track when missing.
  - Converts `.slick-dots` to `role="list"` and removes invalid ARIA attributes from dot `<li>` items.
  - Ensures dot buttons have `aria-label` text (e.g., "Go to slide N").
  - Removes problematic `role`/`tabindex` from slide wrappers and prevents focusable children inside `aria-hidden` slides.

Impact:
- Mitigates the most critical ARIA violations reported by automated scans and improves keyboard/focus behavior.
- This is an intermediate, opt-in mitigation; the recommended long-term solution is to migrate away from Slick to an accessibility-first carousel library.

How to test:
1. Enable the theme library `az-slick-a11y-patch` on a site using `az_carousel` (or ensure the theme loads the patch JS).
2. Initialize a carousel with dot navigation and run axe-core or Accessibility Insights; confirm the previously reported violations are resolved.
3. Test keyboard navigation and screen-reader announcements for the carousel and dot controls.
4. Validate there are no regressions in autoplay/slide behavior.

Notes:
- This patch aims to be a short-term mitigation and is distributed as an optional theme library; module-level or upstream fixes may be preferable.
- If accepted, this PR will be a mitigation for #5514; consider the long-term migration path as well.