### PR TITLE
Closes #3354 Change AZ finder filter reset to redirect to the current URL path.

### DIFF
--- a/modules/custom/az_finder/js/active-filter-reset.js
+++ b/modules/custom/az_finder/js/active-filter-reset.js
@@ -8,11 +8,6 @@
 ((Drupal) => {
   Drupal.behaviors.azFinderActiveFilterReset = {
     attach(context) {
-      const clickHandler = (selector, action) => {
-        const element = selector.querySelector('.js-form-submit');
-        if (element && action) action(element);
-      };
-
       const resetFilters = (container) => {
         const checkboxes = container.querySelectorAll('input[type="checkbox"]');
         const textFields = container.querySelectorAll('input[type="text"]');
@@ -23,13 +18,14 @@
         textFields.forEach((textField) => {
           textField.value = '';
         });
-        clickHandler(container, (element) => element.click());
 
         const event = new CustomEvent('az-finder-filter-reset', {
           bubbles: true,
           detail: { message: 'Filters have been reset.' },
         });
         container.dispatchEvent(event);
+
+        window.location.href = window.location.pathname;
       };
 
       context


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Changes the function of the AZ finder's reset filters button to redirect to the current URL path instead of clicking the apply button.

This possible workaround was suggested by @bberndt-uaz.

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #3354 

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

1. With AZ Demo installed, visit a demo finder page and fill in some filters.
2. When the reset button appears, click it to see the filters clear out and the page reload to the base URL path without extra URL parameters.
3. See that the displayed results are reset to the original defaults for that page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
