### PR TITLE
Closes #5590: Uncaught PHP Exception AssertionError related to lazy_builder and mobile_nav_block

### DIFF
--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -586,9 +586,9 @@ function az_core_preprocess_entity_embed_container(array &$variables) {
 /**
  * Implements hook_block_build_BASE_BLOCK_ID_alter().
  *
- * Adds a build array flag for mobile nav blocks for use in the page template.
- * This flag is checked before the block has been built by the lazy builder.
+ * Adds a cache key to identify mobile nav blocks. The az_barrio page template
+ * checks this key prior to the lazy building of the block.
  */
 function az_core_block_build_mobile_nav_block_alter(array &$build, BlockPluginInterface $block): void {
-  $build['#mobile_nav_block'] = TRUE;
+  $build['#cache']['keys'][] = 'mobile_nav_block';
 }

--- a/themes/custom/az_barrio/templates/layout/page.html.twig
+++ b/themes/custom/az_barrio/templates/layout/page.html.twig
@@ -115,7 +115,7 @@
                     </button>
                   {% endif %}
                   {% for offcanvasblock in page.navigation_offcanvas %}
-                    {% if offcanvasblock['#mobile_nav_block'] %}
+                    {% if 'mobile_nav_block' in offcanvasblock['#cache']['keys'] %}
                       <button type="button" data-bs-toggle="offcanvas" data-bs-target="#azMobileNav" aria-controls="azMobileNav" class="btn btn-arizona-header">
                         <span aria-hidden="true" class="icon material-symbols-rounded">menu</span>
                         <span class="icon-text">Menu</span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Resolves the PHP assertion error that can appear in local development:
 - Changes the flag used by the AZ Barrio page template from a custom build array element to an additional cache key. This makes the cache ID for mobile nav blocks a bit longer, but otherwise there should be no impact.

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 - #5590

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

Build this PR branch locally with DDEV and visit the home page after installing Quickstart. The home page should be displayed normally instead of causing a white screen PHP error. Also, confirm that the mobile nav menu is still accessible from the menu icon in the top right corner on mobile devices.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
