### PR TITLE
#5604: Fix external PR handling in release-plan-pick-list workflow

### DIFF
--- a/.github/workflows/release-plan-pick-list.yml
+++ b/.github/workflows/release-plan-pick-list.yml
@@ -16,7 +16,8 @@ jobs:
   generate-pick-list:
     name: Generate pick list and comment on release plan issue
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      issues: write
     steps:
       - name: Generate pick list and comment on release plan issue
         env:
@@ -59,11 +60,11 @@ jobs:
           CURSOR="null"
           HAS_NEXT_PAGE="true"
           # pr_number -> merge_commit_sha (az-digital/az_quickstart PRs only)
-          declare -A PR_COMMITS
+          declare -A PR_COMMITS=()
           # pr_number -> committed date (ISO 8601)
-          declare -A PR_COMMIT_DATE
-          # pr_number -> "repo#number" for PRs from other repositories
-          declare -A EXTERNAL_PRS
+          declare -A PR_COMMIT_DATE=()
+          # repo#number entries for PRs from other repositories
+          declare -a EXTERNAL_PRS=()
 
           GRAPHQL_QUERY='query($org: String!, $num: Int!, $after: String) {
             organization(login: $org) {
@@ -118,7 +119,7 @@ jobs:
                     PR_COMMIT_DATE["$PR_NUM"]="$COMMITTED_DATE"
                   fi
                 elif [ "$REPO" != "null" ]; then
-                  EXTERNAL_PRS["${REPO}#${PR_NUM}"]="$REPO"
+                  EXTERNAL_PRS+=("${REPO}#${PR_NUM}")
                 fi
               fi
             done < <(echo "$RESPONSE" | jq -r '
@@ -189,7 +190,7 @@ jobs:
               else
                 EXTERNAL_PR_LIST="${EXTERNAL_PR_LIST}"$'\n'"${EXTERNAL_COUNTER}. ${REPO_AND_NUM}"
               fi
-            done < <(printf '%s\n' "${!EXTERNAL_PRS[@]}" | sort)
+            done < <(printf '%s\n' "${EXTERNAL_PRS[@]}" | sort -u)
           fi
 
           # Build the comment body using printf to control newlines precisely.


### PR DESCRIPTION

## Description
Fixes the release-plan-pick-list workflow so it no longer fails when a project contains no completed PRs from other repositories.

The failure we saw during `workflow_dispatch` was:

```text
Fetching project #281 metadata from az-digital org...
Project: 3.3.5 bug-fix patch release (public)
Fetching project items from project #281 in az-digital org...
Found 28 pull request(s) in Done status.
/home/runner/work/_temp/9580f0b2-5afc-4a5b-a31c-c59b010fd042.sh: line 158: EXTERNAL_PRS: unbound variable
Error: Process completed with exit code 1.
```

This updates the workflow to:
- initialize the bash arrays used under `set -u`
- collect external PR references in an indexed array instead of an associative array
- sort and de-duplicate external PR entries safely before rendering the comment
- grant `issues: write` permission so the workflow can post the generated pick list back to the release plan issue

### Release notes
<!--- Delete this line (and the closing comment line) to enable release notes.

No release notes needed. This only fixes an internal GitHub Actions workflow used to generate release pick lists.

Delete this line to enable release notes.  -->

## Related issues
No related issue exists yet.

## How to test
1. Go to the `Create Release Plan Pick List` workflow in GitHub Actions.
2. Run the workflow with a valid public project number and release plan issue number.
3. Use a project that has completed `az-digital/az_quickstart` PRs and no completed PRs from other repositories.
4. Confirm the workflow completes successfully instead of failing with `EXTERNAL_PRS: unbound variable`.
5. Confirm the target issue receives a comment containing:
   - the ordered quickstart PR list
   - the cherry-pick command block
   - no `Pull Requests from Other Repositories` section when there are no external PRs
6. Optionally rerun against a project that does include completed PRs from other repositories and confirm that section is still rendered correctly.

## Types of changes

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
