### PR TITLE
Closes #5635: Fix Recurring Import Issue, Enterprise Attributes Issue

### DIFF
--- a/modules/custom/az_event/az_event_trellis/src/Form/AZRecurringImportRuleForm.php
+++ b/modules/custom/az_event/az_event_trellis/src/Form/AZRecurringImportRuleForm.php
@@ -134,7 +134,8 @@ final class AZRecurringImportRuleForm extends EntityForm {
       $terms = $query->execute();
       $terms = $term_storage->loadMultiple($terms);
       foreach ($terms as $term) {
-        $options[$term->field_az_attribute_key->value] = $this->entityRepository->getTranslationFromContext($term)->label();
+        $label = $this->entityRepository->getTranslationFromContext($term)->label();
+        $options[$label] = $label;
       }
 
       // Build the select element for the attribute.

--- a/modules/custom/az_event/az_event_trellis/src/Plugin/migrate/source/AZTrellisEventSource.php
+++ b/modules/custom/az_event/az_event_trellis/src/Plugin/migrate/source/AZTrellisEventSource.php
@@ -66,8 +66,10 @@ class AZTrellisEventSource extends SourcePluginBase {
     $this->trellisIds = $configuration['trellis_ids'] ?? [];
     // If no arguments are supplied, fetch the list currently on the site.
     if (empty($this->trellisIds)) {
-      $ids = $this->trellisHelper->getImportedEventIds();
-      $ids += $this->trellisHelper->getRecurringEventIds();
+      $ids = array_merge(
+        $this->trellisHelper->getImportedEventIds(),
+        $this->trellisHelper->getRecurringEventIds(),
+      );
       $this->trellisIds = array_unique($ids);
     }
   }

--- a/modules/custom/az_event/az_event_trellis/src/Plugin/views/filter/AZEventTrellisViewsAttributeFilter.php
+++ b/modules/custom/az_event/az_event_trellis/src/Plugin/views/filter/AZEventTrellisViewsAttributeFilter.php
@@ -84,7 +84,8 @@ class AZEventTrellisViewsAttributeFilter extends FilterPluginBase {
     // Build option list.
     foreach ($terms as $term) {
       if ($term->hasField('field_az_attribute_key') && !empty($term->field_az_attribute_key->value)) {
-        $options[$term->field_az_attribute_key->value] = $this->entityRepository->getTranslationFromContext($term)->label();
+        $label = $this->entityRepository->getTranslationFromContext($term)->label();
+        $options[$label] = $label;
       }
     }
     $form['value'] = [

--- a/modules/custom/az_event/az_event_trellis/src/TrellisHelper.php
+++ b/modules/custom/az_event/az_event_trellis/src/TrellisHelper.php
@@ -216,7 +216,7 @@ final class TrellisHelper {
     $event_api_ids = [];
     foreach ($imports as $import) {
       /** @var \Drupal\az_event_trellis\Entity\AZRecurringImportRule $import */
-      $event_api_ids += $import->getEventIds();
+      $event_api_ids = array_merge($event_api_ids, $import->getEventIds());
     }
     // Remove duplicates in case searches overlapped.
     $event_api_ids = array_unique($event_api_ids);


### PR DESCRIPTION
Closes #5635 

During development of Opportunity Content Type, we found that we should use `array_merge`: [Commit 069b53d](https://github.com/az-digital/az_quickstart/pull/5182/changes/069b53da627994ff920071a17da7b971dd76e452), [Commit 892fe54](https://github.com/az-digital/az_quickstart/pull/5182/changes/892fe54e8dd1220bf7e20c49c223f6fcd822275f#diff-f6f7e348fe3d0e71ecf0f8770b6f7530a1e937cf71ddeb8f874a0c54aa511d32R69-R72) . We also found that we should use enterprise attributes values instead of the keys to search for events. [Commit c03200b](https://github.com/az-digital/az_quickstart/pull/5182/changes/c03200b9ab8bd24fb7a6e3e12e388ffdb16c648c). 

This PR adds these fixes to Trellis Events.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->


### Release notes
<!--- Delete this line (and the closing comment line) to enable release notes.

If this change requires release notes: provide a summary of changes, how to use this change, and any related links. This content will be pasted in the [release notes](https://github.com/az-digital/az_quickstart/releases). Use markdown format to ensure proper pasting of information. [Release notes example](https://github.com/az-digital/az_quickstart/releases/tag/2.11.0)

Make sure to add the `release notes` label to this PR.

```
Add markdown of release notes here.
```

Delete this line to enable release notes.  -->


## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

### Verify Issue 1 Fixed: Recurring Import Event IDs get dropped when events are already imported**

1. Enable `az_event_trellis`. 
2. Go to the importer: `/admin/trellis-event-importer`. 
3. Import 3 events. For example, you can filter **Topic** for `Humanities`. From the search results import 3 events. Make a note of which 3 events you have imported
4. Create a recurring import with a different set of events. For example, filter **Topic** for  `Arts & Culture` and then **Category** for `Lectures, Workshops, & Panels`. Click search, and create a recurring import from that search. Make a note of what events are going to be imported for this recurring import. 
5. Set **Quickstart Trellis Events** in Cron migration `/admin/config/migrate_queue_importer/cron_migration` to have 0 interval. Then go to `/admin/config/system/cron` to run cron by clicking on the link in the page. 
6. If you have imported 3 events from step 3, and there are 4 events from the recurring import in step 4, verify that all 7 events are imported. Example:

- What's already imported: [A, B, C]
- Recurring Import: [D, E, F, G]

What should be imported: [A, B, C, D, E, F, G]

### Verify Issue 2 Fixed: Recurring Import Event ID's get dropped when there are multiple recurring imports 
Do the same steps as above, except this time, in Step 3, instead of importing, create a recurring import from the search results. After doing step 3 and 4 above, you should have 2 recurring imports. When you run cron, it should import the events from both the first and second recurring import minus any duplicates: 

- First Recurring Import: [A, B, C, D]
- Second Recurring Import: [D, E, F, G, H]

What should be imported: [A, B, C, D, E, F, G, H]

### Verify Issue 3 Fixed: the Trellis Events API searches using the value of Enterprise Attributes, but we're submitting the key so if the value and key differ like in the case of Science & Research, we get empty results

1. Go to trellis event importer `/admin/trellis-event-importer`
2. Search for Topic: `Science & Research`
3. Make sure that results are being returned


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
