### PR TITLE
Fixes #5634 Allow search results to use canonical URL 

### DIFF
--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -285,8 +285,11 @@ function az_core_canonical_url(array $data, bool $absolute = FALSE) {
   $url = $node->toUrl();
   $uri = $absolute ? $url->setOption('absolute', TRUE)->toString() : $url->toUriString();
 
-  if (!empty($node->field_az_link[0]->uri)) {
-    $uri = $node->field_az_link[0]->uri;
+  if ($node->hasField('field_az_link') && !$node->get('field_az_link')->isEmpty()) {
+    $canonical_link = $node->get('field_az_link')->first();
+    if (!empty($canonical_link->uri)) {
+      $uri = $canonical_link->uri;
+    }
   }
 
   return $uri;

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -601,7 +601,7 @@ function az_core_block_build_mobile_nav_block_alter(array &$build, BlockPluginIn
 function az_core_preprocess_search_result(&$variables) : void {
   // Attempt to get the current node context of the search result.
   $node = $variables['result']['node'] ?? NULL;
-  if ($node && ($node instanceof NodeInterface)) {
+  if ($node && ($node instanceof NodeInterface) && TRUE) {
     // Get the token value of the canonical url.
     $token = \Drupal::token()->replace('[node:az-canonical-url]', ['node' => $node]);
     if (!empty($token)) {

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -601,7 +601,7 @@ function az_core_block_build_mobile_nav_block_alter(array &$build, BlockPluginIn
  *
  * Make the search result use the canonical url if available.
  */
-function az_core_preprocess_search_result(&$variables) : void {
+function az_core_preprocess_search_result(&$variables): void {
   // Attempt to get the current node context of the search result.
   $node = $variables['result']['node'] ?? NULL;
   if ($node && ($node instanceof NodeInterface)) {

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -592,3 +592,27 @@ function az_core_preprocess_entity_embed_container(array &$variables) {
 function az_core_block_build_mobile_nav_block_alter(array &$build, BlockPluginInterface $block): void {
   $build['#cache']['keys'][] = 'mobile_nav_block';
 }
+
+/**
+ * Implements hook_preprocess_search_result().
+ *
+ * Make the search result use the canonical url if available.
+ */
+function az_core_preprocess_search_result(&$variables) : void {
+  // Attempt to get the current node context of the search result.
+  $node = $variables['result']['node'] ?? NULL;
+  if ($node && ($node instanceof NodeInterface)) {
+    // Get the token value of the canonical url.
+    $token = \Drupal::token()->replace('[node:az-canonical-url]', ['node' => $node]);
+    if (!empty($token)) {
+      try {
+        // Turn routes and internal URIs into urls.
+        $url = Url::fromUri($token);
+        $variables['url'] = $url->toString();
+      }
+      catch (\InvalidArgumentException $e) {
+
+      }
+    }
+  }
+}

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -614,7 +614,7 @@ function az_core_preprocess_search_result(&$variables): void {
         $variables['url'] = $url->toString();
       }
       catch (\InvalidArgumentException $e) {
-
+        // Do nothing if the token does not resolve to a valid URI.
       }
     }
   }

--- a/modules/custom/az_core/az_core.module
+++ b/modules/custom/az_core/az_core.module
@@ -601,7 +601,7 @@ function az_core_block_build_mobile_nav_block_alter(array &$build, BlockPluginIn
 function az_core_preprocess_search_result(&$variables) : void {
   // Attempt to get the current node context of the search result.
   $node = $variables['result']['node'] ?? NULL;
-  if ($node && ($node instanceof NodeInterface) && TRUE) {
+  if ($node && ($node instanceof NodeInterface)) {
     // Get the token value of the canonical url.
     $token = \Drupal::token()->replace('[node:az-canonical-url]', ['node' => $node]);
     if (!empty($token)) {


### PR DESCRIPTION
## Description
This PR allows the stock Drupal search to use the canonical URL for nodes.

It also hardens canonical URL token evaluation in `az_core_canonical_url()` by checking that `field_az_link` exists and is populated before reading it, and falling back to the node URL when it is not available.

### Release notes
```
The built-in Drupal search form will now use a node's canonical URL where available.
```

## Related issues
#5634 

## How to test

- enable az_demo
- run cron
- visit `/admin/config/search/pages`
- run cron again, until the index is 100%
- visit `/search/node`
- search for `jet stream`
- verify that the demo content with a canonical url points to the canonical location, and that others point to the node as normal
- create additional content if desired, with or without a canonical url
- run cron again
- verify that search results use the canonical url correctly
- verify results still work for node types/content without a populated `field_az_link` value (fallback URL is used)

## Types of changes


### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My change requires release notes.