### PR TITLE
Closes #5656: Only report abandoned packages in composer audit CI workflow job (don't fail). (2.x backport of #5657)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Run composer audit
         run: |
           cd az-quickstart-scaffolding
-          composer audit --no-dev --ignore-severity=low --ignore-severity=moderate
+          composer audit --no-dev --ignore-severity=low --ignore-severity=moderate --abandoned=report
 
   yarn-audit:
     name: yarn audit (security)


### PR DESCRIPTION
Backport of https://github.com/az-digital/az_quickstart/pull/5657

This PR was manually (because our automated backport workflow fails when changes to workflow files are involved) created to backport changes from https://github.com/az-digital/az_quickstart/pull/5657 to the 2.x branch.

Original PR: https://github.com/az-digital/az_quickstart/pull/5657