### PR TITLE
Fixes #5669 AZ SEO metatag defaults drush command

### DIFF
--- a/modules/custom/az_seo/drush.services:.yml
+++ b/modules/custom/az_seo/drush.services:.yml
@@ -1,0 +1,5 @@
+services:
+  az_seo.commands:
+    class: \Drupal\az_seo\Drush\Commands\AZMetatagSetCommand
+    tags:
+      - { name: drush.command }

--- a/modules/custom/az_seo/src/Drush/Commands/AZMetatagSetCommand.php
+++ b/modules/custom/az_seo/src/Drush/Commands/AZMetatagSetCommand.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\az_seo\Drush\Commands;
+
+use Consolidation\AnnotatedCommand\Input\StdinAwareInterface;
+use Consolidation\AnnotatedCommand\Input\StdinAwareTrait;
+use Consolidation\SiteAlias\SiteAliasManagerInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImportStorageTransformer;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Config\StorageManagerInterface;
+use Drush\Attributes as CLI;
+use Drush\Commands\AutowireTrait;
+use Drush\Commands\DrushCommands;
+use Drush\Exec\ExecTrait;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Yaml\Parser;
+
+/**
+ * Convenience command to alter global metatag defaults.
+ */
+final class AZMetatagSetCommand extends DrushCommands implements StdinAwareInterface {
+  use AutowireTrait;
+  use StdinAwareTrait;
+  use ExecTrait;
+
+  const SET = 'az-seo:tag';
+
+  /**
+   * Return the ConfigFactory service.
+   *
+   * @return \Drupal\Core\Config\ConfigFactoryInterface
+   *   The config factory.
+   */
+  public function getConfigFactory(): ConfigFactoryInterface {
+    return $this->configFactory;
+  }
+
+  public function __construct(
+    // @todo remove unnecessary services.
+    protected ConfigFactoryInterface $configFactory,
+    #[Autowire(service: 'config.storage')]
+    protected StorageInterface $configStorage,
+    protected SiteAliasManagerInterface $siteAliasManager,
+    protected StorageManagerInterface $configStorageExport,
+    protected ImportStorageTransformer $importStorageTransformer,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Save a global metatag default directly.
+   */
+  #[CLI\Command(name: self::SET, aliases: ['azm', 'azm-set'])]
+  #[CLI\Argument(name: 'tag', description: 'The tag to set.')]
+  #[CLI\Argument(name: 'value', description: 'The value to assign to the tag. Use <info>-</info> to read from stdin.')]
+  #[CLI\Option(name: 'input-format',
+    description: 'Format to parse the object. Recognized values: <info>string</info>, <info>yaml</info>. Since JSON is a subset of YAML, $value may be in JSON format.',
+    suggestedValues: ['string', 'json',
+    ])]
+  #[CLI\Usage(name: 'drush az-seo:tag schema_organization_name sitename', description: 'Sets a global metatag default of <info>sitename</info> for the <info>schema_organization_name</info> tag.')]
+  #[CLI\Usage(name: 'drush az-seo:tag schema_organization_parent_organization.@id https://quickstart.arizona.edu', description: 'Sets a global metatag default of <info>https://quickstart.arizona.edu</info> for the <info>@id</info> element of the <info>schema_organization_parent_organization</info> tag.')]
+  public function set($tag, $value, $options = ['input-format' => 'string']) {
+    $data = $value;
+
+    if (!isset($data)) {
+      throw new \Exception(dt('No tag value specified.'));
+    }
+
+    // Special flag indicating that the value has been passed via STDIN.
+    if ($data === '-') {
+      $data = $this->stdin()->contents();
+    }
+
+    // Special handling for null.
+    if (strtolower($data) === 'null') {
+      $data = NULL;
+    }
+
+    // Special handling for empty array.
+    if ($data == '[]') {
+      $data = [];
+    }
+
+    if ($options['input-format'] === 'yaml') {
+      $parser = new Parser();
+      $data = $parser->parse($data);
+    }
+
+    // @todo make class constant.
+    $config_name = 'metatag.metatag_defaults.global';
+    $config = $this->getConfigFactory()->getEditable($config_name);
+    // @todo determine special handling of parent organization
+    // Keep track if we need a specific child element of this tag.
+    $tag_key = NULL;
+    // Special handling for parent organization.
+    if (preg_match('/^schema_organization_parent_organization\.(.+)/', $tag, $matches)) {
+      $tag = 'schema_organization_parent_organization';
+      $tag_key = $matches[1];
+    }
+    // Check to see if tag already exists.
+    $tag = 'tags.' . $tag;
+    $existing_tag = $config->get($tag);
+    // Special case handling, unserialize organization.
+    if ($tag_key) {
+      // @todo more sanity checking.
+      $nested = unserialize($existing_tag, ['allowed_classes' => FALSE]);
+      if (is_array($nested)) {
+        // Set the requested nested array element.
+        $nested[$tag_key] = $data;
+      }
+      $data = $nested;
+    }
+    // Parent organization needs to be serialized for storage.
+    if ($tag === 'tags.schema_organization_parent_organization') {
+      $data = serialize($data);
+    }
+    $simulate = $this->getConfig()->simulate();
+
+    $confirmed = FALSE;
+    if ($config->isNew() && $this->io()->confirm(dt('!name config does not exist. Do you want to create a new config object?', ['!name' => $config_name]))) {
+      $confirmed = TRUE;
+    }
+    elseif (($existing_tag === NULL) && $this->io()->confirm(dt('Tag !tag does not exist. Do you want to create the tag?', ['!tag' => $tag]))) {
+      $confirmed = TRUE;
+    }
+    elseif ($this->io()->confirm(dt('Do you want to update the !tag tag in !name config?', [
+      '!tag' => $tag,
+      '!name' => $config_name,
+    ]))) {
+      $confirmed = TRUE;
+    }
+    if ($confirmed && !$simulate) {
+      return $config->set($tag, $data)->save();
+    }
+  }
+
+}


### PR DESCRIPTION
## Description
This PR provides a drush convenience command for setting metatag defaults:  `az-seo:tag`

This would be mostly unnecessary (and could be accomplished with `config:set`) aside for the fact that `schema_organization_parent_organization` is stored as serialized php. This drush command attempts to provide a `config:set-alike` interface for the serialized element.

### Release notes
```
Added `az-seo:tag` Drush command for setting metatag defaults.
```

## Related issues
#5669 

## How to test

- install site
- `drush az-seo:tag --help`
- `drush az-seo:tag schema_organization_name sitename`
- `drush az-seo:tag schema_organization_parent_organization.@id https://quickstart.arizona.edu`
- Verify the above changes are reflected in the global metatag defaults (`/admin/config/search/metatag`)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [x] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My change requires release notes.
