### PR TITLE
#5701: Update drupal/core-recommended to 10.6.11 for SA-CORE-2026-005, -006, -007, -008, and -009

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
         "drupal/config_split": "2.0.2",
         "drupal/config_sync": "3.0.0-alpha4",
         "drupal/config_update": "2.0.0-alpha4",
-        "drupal/core-recommended": "10.6.10",
+        "drupal/core-recommended": "10.6.11",
         "drupal/crop": "2.4.0",
         "drupal/date_ap_style": "2.1.2",
         "drupal/decorative_image_widget": "1.0.2",


### PR DESCRIPTION
## Description
Updates Drupal core to [10.6.11](https://www.drupal.org/project/drupal/releases/10.6.11) for:
- [Drupal core - Critical - PHP object injection - SA-CORE-2026-005](https://www.drupal.org/sa-core-2026-005)
- [Drupal core - Moderately critical - Gadget chain - SA-CORE-2026-006](https://www.drupal.org/sa-core-2026-006)
- [Drupal core - Less critical - Cache poisoning and open redirect - SA-CORE-2026-007](https://www.drupal.org/sa-core-2026-007)
- [Drupal core - Moderately critical - Server-side request forgery - SA-CORE-2026-008](https://www.drupal.org/sa-core-2026-008)
- [Drupal core - Moderately critical - Improper validation - SA-CORE-2026-009](https://www.drupal.org/sa-core-2026-009)

### Release notes

```
Updates Drupal core with fixes for a critical PHP object injection vulnerability ([SA-CORE-2026-005](https://www.drupal.org/sa-core-2026-005)) and four additional vulnerabilities ranging from less critical to moderately critical: [SA-CORE-2026-006](https://www.drupal.org/sa-core-2026-006), [SA-CORE-2026-007](https://www.drupal.org/sa-core-2026-007),
[SA-CORE-2026-008](https://www.drupal.org/sa-core-2026-008), and [SA-CORE-2026-009](https://www.drupal.org/sa-core-2026-009).  Also updates the guzzlehttp/psr7 dependency for a security fix. Note: See the description of [SA-CORE-2026-008](https://www.drupal.org/sa-core-2026-008) if your site has oEmbed discovery modifications.
```

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #5701

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [x] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
