### PR TITLE
Fixes #5716 az_text_media_paragraph_behavior does not check field group existence

### DIFF
--- a/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
+++ b/modules/custom/az_paragraphs/src/Plugin/paragraphs/Behavior/AZTextWithMediaParagraphBehavior.php
@@ -233,7 +233,9 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
     }
 
     // Set column classes.
-    $variables['elements']['#fieldgroups']['group_az_column']->format_settings['classes'] = implode(' ', $column_classes);
+    if (!empty($variables['elements']['#fieldgroups']['group_az_column'])) {
+      $variables['elements']['#fieldgroups']['group_az_column']->format_settings['classes'] = implode(' ', $column_classes);
+    }
 
     // Get content classes.
     $content_classes = [
@@ -301,10 +303,12 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
     }
 
     // Set content classes.
-    $variables['elements']['#fieldgroups']['group_az_content']->format_settings['classes'] = implode(' ', $content_classes);
+    if (!empty($variables['elements']['#fieldgroups']['group_az_content'])) {
+      $variables['elements']['#fieldgroups']['group_az_content']->format_settings['classes'] = implode(' ', $content_classes);
+    }
     // Set title element if a heading level other than h2 (the default) was
     // selected.
-    if ($config['title_level'] !== 'h2') {
+    if (($config['title_level'] !== 'h2') && (!empty($variables['elements']['#fieldgroups']['group_az_title']))) {
       $variables['elements']['#fieldgroups']['group_az_title']->format_settings['element'] = $config['title_level'];
     }
     // Get title classes.
@@ -317,7 +321,9 @@ class AZTextWithMediaParagraphBehavior extends AZDefaultParagraphsBehavior {
       $title_classes[] = 'text-blue';
     }
     // Set title classes.
-    $variables['elements']['#fieldgroups']['group_az_title']->format_settings['classes'] = implode(' ', $title_classes);
+    if (!empty($variables['elements']['#fieldgroups']['group_az_title'])) {
+      $variables['elements']['#fieldgroups']['group_az_title']->format_settings['classes'] = implode(' ', $title_classes);
+    }
   }
 
 }


### PR DESCRIPTION
## Description
The `az_text_media_paragraph_behavior` plugin does not check if specific field groups exist before using them. This can cause PHP errors on sites that have diverged from Quickstart's configuration.

This PR checks if the field group structures exist before using them. The null-safe operator cannot be used here since the variables are used in a write context.

## Related issues
#5716 

## How to test

- Create page using text on media paragraphs
- Verify content displays correctly
- Visit `/admin/structure/paragraphs_type/az_text_media/display`
- **Delete** one or more of the field groups `group_az_column`, `group_az_title`, or `group_az_content`
- View the page content you created again
- It may display unusually due to the missing field groups, but should not cause a whitescreen error

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [x] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
