### PR TITLE
Close #5741 Update config_ignore settings to allow content admins to edit news import settings.

### DIFF
--- a/config/optional/config_ignore.settings.yml
+++ b/config/optional/config_ignore.settings.yml
@@ -4,6 +4,7 @@ ignored_config_entities:
   - az_enterprise_attributes_import.settings
   - 'az_event_trellis.az_recurring_import_rule.*'
   - az_event_trellis.settings
+  - az_news_feeds.settings
   - az_publication.settings
   - 'block.block.*'
   - block_class.settings


### PR DESCRIPTION
Close #5741 