### PR TITLE
Prevent duplicate az-search class on search block when blue header AND AZ Navbar Fullscreen are enabled

### DIFF
--- a/themes/custom/az_barrio/az_barrio.theme
+++ b/themes/custom/az_barrio/az_barrio.theme
@@ -766,12 +766,15 @@ function az_barrio_preprocess_input__search_block_form__submit(array &$variables
  * Implements hook_preprocess_HOOK() for search block forms.
  *
  * Add az-search class to the desktop search block when AZ Header Blue is
- * enabled.
+ * enabled. Skipped when AZ Navbar Fullscreen is enabled, since the
+ * fullscreen navbar's own template wrapper already provides the az-search
+ * class; adding it again on the form would double up the az-search spacing.
  */
 function az_barrio_preprocess_form__search_block_form(array &$variables) {
   $theme_settings = \Drupal::service('Drupal\Core\Extension\ThemeSettingsProvider');
   $is_desktop_search_block = ($variables['attributes']['block'] ?? '') === 'block-az-barrio-search';
-  if ($is_desktop_search_block && $theme_settings->getSetting('az_header_blue')) {
+  if ($is_desktop_search_block && $theme_settings->getSetting('az_header_blue')
+    && !$theme_settings->getSetting('az_navbar_fullscreen')) {
     $variables['attributes']['class'][] = 'az-search';
   }
 }


### PR DESCRIPTION
See #5808, specifically [this comment](https://github.com/az-digital/az_quickstart/pull/5808#pullrequestreview-4790069232).

Fix duplicated `.az-search` class when both blue header and AZ Navbar Fullscreen are enabled at the same time.

### How to test
- Verify right spacing to nav toggle when only AZ Navbar Fullscreen is enabled, only blue header is enabled, and AZ Navbar Fullscreen AND blue header are enabled together.