### PR TITLE
Fixes #5864 Revert to usage of views_get_current_view in az_publication.

### DIFF
--- a/modules/custom/az_publication/az_publication.module
+++ b/modules/custom/az_publication/az_publication.module
@@ -187,6 +187,7 @@ function az_publication_node_view(array &$build, EntityInterface $entity, Entity
       if (function_exists('views_get_current_view')) {
         // @todo deprecated function to be removed in Drupal 13.
         // @todo this should be refactored to not use this API.
+        // @todo $entity->view does not contain complete argument information.
         // @see https://www.drupal.org/node/3572594
         // @phpstan-ignore-next-line
         $view = views_get_current_view();

--- a/modules/custom/az_publication/az_publication.module
+++ b/modules/custom/az_publication/az_publication.module
@@ -184,16 +184,24 @@ function az_publication_node_view(array &$build, EntityInterface $entity, Entity
       $repository = \Drupal::service('entity.repository');
       $style_context = $default_config->get('default_citation_style');
       // Attempt to find citation argument context.
-      if (!empty($entity->view)) {
-        $view = $entity->view;
-        if (!empty($view->argument)) {
-          foreach ($view->argument as $arg) {
-            // Only use the argument as style if it's a style argument.
-            if ($arg instanceof AZCitationStyleArgument) {
-              $citation_style_argument = $arg->getValue();
-              // If the argument exists, set our style to it.
-              if (!empty($citation_style_argument)) {
-                $style_context = $citation_style_argument;
+      if (function_exists('views_get_current_view')) {
+        // @todo deprecated function to be removed in Drupal 13.
+        // @todo this should be refactored to not use this API.
+        // @see https://www.drupal.org/node/3572594
+        // @phpstan-ignore-next-line
+        $view = views_get_current_view();
+        // Phpstan doesn't know this can be NULL.
+        // @phpstan-ignore-next-line
+        if (!empty($view)) {
+          if (!empty($view->argument)) {
+            foreach ($view->argument as $arg) {
+              // Only use the argument as style if it's a style argument.
+              if ($arg instanceof AZCitationStyleArgument) {
+                $citation_style_argument = $arg->getValue();
+                // If the argument exists, set our style to it.
+                if (!empty($citation_style_argument)) {
+                  $style_context = $citation_style_argument;
+                }
               }
             }
           }


### PR DESCRIPTION
## Description
This PR reverts a change that was made in the Drupal 11.4 changes made in #5679 to avoid relying on the deprecated function `views_get_current_view`. There is no direct alternative to this, but the [drupal change record](https://www.drupal.org/node/3572594) indicated that the view is partially available in `$entity->view`. It seems that the copy of the view objection available through this property isn't as complete. The copy of the argument object sometimes contains `all` when accessed this way.

For the time being, we are reverting this change and will investigate refactoring to not use this API prior to Drupal 13 when this function will be removed.

This PR adds documentation about the issue and phpstan hints to ignore the warnings.

## Related issues
#5864 

## How to test

- Log in as an admin
- enable `az_demo`
- Visit `/publications` and note the two Wilbur Wildcat publications (2023 and 2021).
- Visit `/person/wilbur-wildcat` and verify both publications are displayed.
- Once again, visit `/publications` and observe that the Wilbur Wildcat publications are displayed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
