### PR TITLE
Closes #5891: Upgrade Drupal core to 10.6.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "drupal/config_split": "2.0.2",
         "drupal/config_sync": "3.0.0-alpha4",
         "drupal/config_update": "2.0.0-alpha4",
-        "drupal/core-recommended": "10.6.14",
+        "drupal/core-recommended": "10.6.15",
         "drupal/crop": "2.4.0",
         "drupal/date_ap_style": "2.1.2",
         "drupal/decorative_image_widget": "1.0.2",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
https://www.drupal.org/project/drupal/releases/10.6.15

> ### Release notes
> This is a patch (bugfix) release of Drupal 10 and is ready for use on production sites. Learn more about the latest version of Drupal.
> 
> Drupal 10.6.x will receive security support until December 2026.
> 
> Drupal 10.5.x security support has ended. Sites on any Drupal version prior to 10.6.x should upgrade to a supported release as soon as possible.
> 
> #### All changes since 10.6.14
> 
> - [task: #3614340 Update to Twig 3.28](https://git.drupalcode.org/project/drupal/commit/dbee687bae7930b9883c87f0ec953466c9989eba)
> - [task: #3612448 Widen constraints in core-recommended for 11.3.x and 10.6.x](https://git.drupalcode.org/project/drupal/commit/d30e4429998e4fecaf680d7565e4a1df88f26e1e)
> - [task: #3579778 Removed modules should be included as a replace in composer.json](https://git.drupalcode.org/project/drupal/commit/56ced95aff797526b6612baafb14a12f6c8f00d0)
> - [Revert "task: #3579778 Removed modules should be included as a replace in composer.json"](https://git.drupalcode.org/project/drupal/commit/d5f902b2afd6f4edf8161a7f9ade3ed3634d0887)
> - [task: #3579778 Removed modules should be included as a replace in composer.json](https://git.drupalcode.org/project/drupal/commit/9a68ba60cb5e7179c0df447910b9f10a172aa890)
> - [fix: #3593390 Media Preview Endpoint Leaks Labels Of Non-Viewable Media By UUID](https://git.drupalcode.org/project/drupal/commit/c6cc68a2696b30fd49b9c1517a01bf0a1422c2d6)

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #5891

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->
https://pr5892-ik45p8ojx7bqscs4ajzi0jmh0zm6rpza.tugboatqa.com

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [x] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires release notes.
