### PR TITLE
Closes #5931: Update experimental AZ Navbar Fullscreen for Arizona Bootstrap v5.1.8

### DIFF
--- a/themes/custom/az_barrio/components/az-navbar-fullscreen/az-navbar-fullscreen.twig
+++ b/themes/custom/az_barrio/components/az-navbar-fullscreen/az-navbar-fullscreen.twig
@@ -90,6 +90,11 @@
                 </li>
               {% endfor %}
             </ul>
+            <div class="az-search ms-auto d-lg-none">
+              <div class="btn az-search-toggle invisible">
+                <span class="az-search-icon" aria-hidden="true"></span>
+              </div>
+            </div>
             <button class="navbar-toggler" type="button" data-bs-dismiss="modal" aria-label="Close site menu">
               <span class="navbar-toggler-icon" aria-hidden="true"></span>
             </button>
@@ -108,7 +113,7 @@
         <div class="navbar-az-fullscreen-modal-menu container-lg">
           <div class="row g-0">
             <div class="col d-none d-lg-flex position-relative" id="az-navbar-az-fullscreen-primary-accordion">
-              <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-12 col-lg-4">
+              <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-lg-4">
                 <!-- primary nav items -->
                 <nav class="nav navbar-az-fullscreen-nav-primary" aria-label="Main navigation sections">
                   {% for item in primary_items %}
@@ -131,7 +136,7 @@
                         </button>
                         <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-primary-submenu collapse{{ expanded ? ' show' }}" id="az-navbar-az-fullscreen-primary-{{ loop.index }}-content" data-bs-parent="#az-navbar-az-fullscreen-primary-accordion">
                           <div class="navbar-az-fullscreen-modal-menu-submenu-inner">
-                            <div class="col col-lg-6 navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-secondary">
+                            <div class="col-lg-6 navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-secondary">
                               <ul class="nav navbar-az-fullscreen-nav-secondary" id="az-navbar-az-fullscreen-{{ loop.index }}-secondary-nav" aria-label="{{ item.title }}">
                                 {% for child in item.below %}
                                   {% set end_of_trail = true %}
@@ -153,7 +158,7 @@
                                       </button>
                                       <div class="navbar-az-fullscreen-modal-menu-submenu navbar-az-fullscreen-modal-menu-secondary-submenu collapse{{ expanded ? ' show' }}" id="az-navbar-az-fullscreen-{{ loop.parent.loop.index }}-secondary-{{ loop.index }}-content" data-bs-parent="#az-navbar-az-fullscreen-{{ loop.parent.loop.index }}-secondary-nav">
                                         <div class="navbar-az-fullscreen-modal-menu-submenu-inner">
-                                          <div class="col navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-tertiary">
+                                          <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-tertiary">
                                             <ul class="nav navbar-az-fullscreen-nav-tertiary" aria-label="{{ child.title }} submenu">
                                             {% for grandchild in child.below %}
                                               <li class="nav-item">
@@ -189,29 +194,32 @@
                   </li>
                 {% endfor %}
               </ul>
-              <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-12 col-lg-4">
-                <nav class="nav navbar-az-fullscreen-nav-primary" aria-label="Main navigation sections">
-                  {% for item in primary_items %}
-                    {% set end_of_trail = true %}
-                    {% if item.below and item.in_active_trail %}
-                      {% for child in item.below %}
-                        {% if end_of_trail and child.in_active_trail %}
-                          {% set end_of_trail = false %}
-                        {% endif %}
-                      {% endfor %}
-                    {% endif %}
-                    <div class="nav-item">
-                      <a class="nav-link{{ item.in_active_trail and end_of_trail ? ' active' }}" href="{{ item.url }}">
-                        <span class="nav-link-text">{{ item.title }}</span>
-                      </a>
-                      {% if item.below %}
-                        <button class="btn nav-toggle nav-toggle-separated collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-{{ loop.index }}-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle {{ item.title }} submenu">
-                          <span class="nav-toggle-icon" aria-hidden="true"></span>
-                        </button>
+              <div class="navbar-az-fullscreen-nav-mobile-menu-container">
+                <div class="navbar-az-fullscreen-modal-menu-nav-col navbar-az-fullscreen-modal-menu-nav-col-primary col-lg-4">
+                  <div class="navbar-az-fullscreen-nav-mobile-menu-list-top"></div>
+                  <nav class="nav navbar-az-fullscreen-nav-primary" aria-label="Main navigation sections">
+                    {% for item in primary_items %}
+                      {% set end_of_trail = true %}
+                      {% if item.below and item.in_active_trail %}
+                        {% for child in item.below %}
+                          {% if end_of_trail and child.in_active_trail %}
+                            {% set end_of_trail = false %}
+                          {% endif %}
+                        {% endfor %}
                       {% endif %}
-                    </div>
-                  {% endfor %}
-                </nav>
+                      <div class="nav-item">
+                        <a class="nav-link{{ item.in_active_trail and end_of_trail ? ' active' }}" href="{{ item.url }}">
+                          <span class="nav-link-text">{{ item.title }}</span>
+                        </a>
+                        {% if item.below %}
+                          <button class="btn nav-toggle nav-toggle-separated collapsed" type="button" data-az-menu-element="#az-navbar-az-fullscreen-primary-{{ loop.index }}-content" aria-controls="navbar-az-fullscreen-nav-mobile-col" aria-label="Toggle {{ item.title }} submenu">
+                            <span class="nav-toggle-icon" aria-hidden="true"></span>
+                          </button>
+                        {% endif %}
+                      </div>
+                    {% endfor %}
+                  </nav>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail (include keywords close/fix/resolve) -->
Updates the AZ Navbar Fullscreen template to account for changes in Arizona Bootstrap v5.1.8:

- Adds an invisible `.az-search` element on mobile to maintain logo size at small screen widths (see [AZBS #2276](https://github.com/az-digital/arizona-bootstrap/pull/2276))
- Removes Bootstrap column classes for mobile and adds a container for initial mobile nav items (see [AZBS #2265](https://github.com/az-digital/arizona-bootstrap/pull/2265))

For reference, see the changes to `site/content/docs/5.1/examples/navbar-az-fullscreen/_index.html`: https://github.com/az-digital/arizona-bootstrap/compare/v5.1.7...v5.1.8. 

## Related issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 - #5931

## How to test
<!--- Please describe in detail how reviewers can test your changes -->
<!--- Include details of your testing environment and the tests you ran -->

1. Go to Arizona Barrio settings (`/admin/appearance/settings/az_barrio`), then go to Components -> Navbar Behaviour and check the "Enable AZ Navbar Fullscreen (experimental)" checkbox.
2. Go to Block Layout (`/admin/structure/block`) and in the Navigation Bar region, disable the "Main navigation" block.
3. Still in Block Layout, add a new "AZ Navbar Fullscreen Menu" block to the Navigation Bar region and configure the desired menus and search form blocks (`az_barrio_search` for the desktop navbar and `az_barrio_offcanvas_searchform` for the offcanvas modal). The footer headings have default values that are automatically set unless changed.
4. Clear cache.
5. Confirm the new appearance of AZ Navbar Fullscreen on desktop (see [AZBS #2261](https://github.com/az-digital/arizona-bootstrap/pull/2276)).
6. On mobile, confirm the new fade effect (or "scroll shadow") at the top of the list of menu items once you scroll them.
7. On mobile with screen width < 360px, confirm the navbar header elements are adjusted accordingly instead of wrapping to a new row.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

### Arizona Quickstart (install profile, custom modules, custom theme)
- **Patch release changes**
   - [ ] Bug fix
   - [ ] Accessibility, performance, or security improvement
   - [ ] Critical institutional link or brand change
   - [ ] Adding experimental module
   - [ ] Update experimental module
- **Minor release changes**
   - [ ] New feature
   - [ ] Breaking or visual change to existing behavior
   - [ ] Upgrade experimental module to stable
   - [ ] Enable existing module by default or database update
   - [ ] Non-critical brand change
   - [ ] New internal API or API improvement with backwards compatibility
   - [ ] Risky or disruptive cleanup to comply with coding standards
   - [ ] High-risk or disruptive change (requires upgrade path, risks regression, etc.)
- **Other or unknown**
   - [ ] Other or unknown

### Drupal core
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch level release (non-security bug-fix release)
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major or minor level update
- **Other or unknown**
   - [ ] Other or unknown

### Drupal contrib projects
- **Patch release changes**
   - [ ] Security update
   - [ ] Patch or minor level update
   - [ ] Add new module
   - [ ] Patch removal that's no longer necessary
- **Minor release changes**
   - [ ] Major level update
- **Other or unknown**
   - [ ] Other or unknown

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires release notes.
